### PR TITLE
suggester styling

### DIFF
--- a/packages/client/src/components/Input/Input.tsx
+++ b/packages/client/src/components/Input/Input.tsx
@@ -13,6 +13,7 @@ interface InputProps {
   label?: string;
   value?: string;
   inverted?: boolean;
+  suggester?: boolean;
   type?: "text" | "textarea" | "select";
   options?: IOption[];
   rows?: number;
@@ -29,6 +30,7 @@ interface InputProps {
 export const Input: React.FC<InputProps> = ({
   label = "",
   inverted = false,
+  suggester = false,
   value = "",
   type = "text",
   options = [],
@@ -75,6 +77,7 @@ export const Input: React.FC<InputProps> = ({
             }
           }}
           inverted={inverted}
+          suggester={suggester}
         />
       )}
       {type === "textarea" && (
@@ -103,6 +106,7 @@ export const Input: React.FC<InputProps> = ({
             }
           }}
           inverted={inverted}
+          suggester={suggester}
         />
       )}
       {type === "select" && options && (
@@ -120,6 +124,7 @@ export const Input: React.FC<InputProps> = ({
             }
           }}
           inverted={inverted}
+          suggester={suggester}
         >
           {options.map((option, oi) => (
             <option key={oi} value={option.value}>

--- a/packages/client/src/components/Input/InputStyles.tsx
+++ b/packages/client/src/components/Input/InputStyles.tsx
@@ -3,6 +3,7 @@ import { space1, space2 } from "Theme/constants";
 
 interface IValueStyle {
   inverted?: boolean;
+  suggester?: boolean;
   width?: number | "full";
   noBorder?: boolean;
 }
@@ -35,8 +36,8 @@ export const StyledInput = styled.input<IValueStyle>`
     inverted ? theme.color["primary"] : theme.color["white"]};
   border-width: ${({ theme, inverted }) =>
     inverted ? 0 : theme.borderWidth[1]};
-  border-color: ${({ inverted, theme }) =>
-    inverted ? theme.color["white"] : theme.color["gray"]["400"]};
+  border-color: ${({ suggester, theme }) =>
+    suggester ? theme.color["primary"] : theme.color["gray"]["400"]};
   font-size: ${({ theme }) => theme.fontSize["xs"]};
   padding: ${space1};
   width: ${({ width }) => getWidth(width)};
@@ -48,13 +49,11 @@ export const StyledInput = styled.input<IValueStyle>`
 export const StyledSelect = styled.select<IValueStyle>`
   height: ${({ theme }) => theme.space[10]};
   text-align: left;
-  color: ${({ inverted, theme }) =>
-    inverted ? theme.color["white"] : theme.color["primary"]};
   background-color: ${({ inverted, theme }) =>
-    inverted ? theme.color["primary"] : theme.color["white"]};
+    inverted ? theme.color["gray"][200] : theme.color["white"]};
   border-width: ${({ theme }) => theme.borderWidth[1]};
-  border-color: ${({ inverted, theme }) =>
-    inverted ? theme.color["gray"]["400"] : theme.color["gray"][400]};
+  border-color: ${({ suggester, theme }) =>
+    suggester ? theme.color["primary"] : theme.color["gray"][400]};
   font-size: ${({ theme }) => theme.fontSize["xs"]};
   font-weight: bold;
   width: ${({ width }) => getWidth(width)};

--- a/packages/client/src/components/Suggester/Suggester.tsx
+++ b/packages/client/src/components/Suggester/Suggester.tsx
@@ -16,6 +16,7 @@ import {
   StyledSuggestionLineActions,
   StyledSuggestionCancelButton,
   StyledRelativePosition,
+  StyledTypeBar,
 } from "./SuggesterStyles";
 
 export interface SuggestionI {
@@ -90,11 +91,13 @@ export const Suggester: React.FC<SuggesterProps> = ({
   return (
     <StyledSuggester marginTop={marginTop}>
       <StyledInputWrapper ref={dropRef} hasButton={allowCreate} isOver={isOver}>
+        <StyledTypeBar title={`entity${category}`}></StyledTypeBar>
         <Input
           type="select"
           value={category}
           options={categories}
           inverted
+          suggester
           onChangeFn={onChangeCategory}
         />
         <Input
@@ -102,6 +105,7 @@ export const Suggester: React.FC<SuggesterProps> = ({
           value={typed}
           onChangeFn={onType}
           placeholder={placeholder}
+          suggester
           changeOnType={true}
           width={inputWidth}
           onEnterPressFn={() => {

--- a/packages/client/src/components/Suggester/SuggesterStyles.tsx
+++ b/packages/client/src/components/Suggester/SuggesterStyles.tsx
@@ -61,6 +61,18 @@ export const StyledSuggestionCancelButton = styled.div`
   }
 `;
 
+interface StyledTypeBar {
+  title: string;
+}
+export const StyledTypeBar = styled.div`
+  position: absolute;
+  background-color: ${({ theme, title }) => theme.color[title]};
+  width: 3px;
+  left: 1px;
+  top: 1px;
+  bottom: 1px;
+`;
+
 export const StyledSuggestionLineIcons = styled.div``;
 
 export const StyledSuggestionLineTag = styled.div``;


### PR DESCRIPTION
Some style changes for suggester, colored stripe on the left corresponds with the selected entity, related to #408
![s1](https://user-images.githubusercontent.com/8287578/136862414-021b9e64-8b3a-43c9-81f9-b90aafdcd15f.png)
![s2](https://user-images.githubusercontent.com/8287578/136862416-df71f444-d635-4bb5-a569-59f800255442.png)
