### PR TITLE
Breadcrumb

### DIFF
--- a/packages/client/src/pages/MainPage/containers/StatementEditorBox/StatementEditorBox.tsx
+++ b/packages/client/src/pages/MainPage/containers/StatementEditorBox/StatementEditorBox.tsx
@@ -25,7 +25,7 @@ import {
   IStatementReference,
   IResponseStatement,
 } from "@shared/types";
-import { Button, Input, Loader, MultiInput } from "components";
+import { Button, ButtonGroup, Input, Loader, MultiInput } from "components";
 import { ActantSuggester } from "./../";
 
 import {
@@ -51,10 +51,18 @@ import { StatementEditorActantTable } from "./StatementEditorActantTable/Stateme
 import { StatementEditorActionTable } from "./StatementEditorActionTable/StatementEditorActionTable";
 import { AttributesEditor } from "../AttributesEditor/AttributesEditor";
 import { ColumnInstance } from "react-table";
+import { useAppSelector } from "redux/hooks";
 import { useSearchParams } from "hooks";
 import { AttributeButtonGroup } from "../AttributeButtonGroup/AttributeButtonGroup";
 import { UserRoleMode } from "@shared/enums";
 import { StyledSubRow } from "./StatementEditorActionTable/StatementEditorActionTableStyles";
+import {
+  StyledHeader,
+  StyledHeaderBreadcrumbRow,
+  StyledTitle,
+} from "../StatementsListBox/StatementListHeader/StatementListHeaderStyles";
+import { StatementListBreadcrumbItem } from "../StatementsListBox/StatementListHeader/StatementListBreadcrumbItem/StatementListBreadcrumbItem";
+
 
 const classesActants = ["A", "T", "R", "P", "G", "O", "C", "L", "V", "E"];
 const classesPropType = ["C"];
@@ -118,6 +126,8 @@ export const StatementEditorBox: React.FC = () => {
     }
   );
 
+  //TODO recurse to get all parents
+  const territoryPath = territoryData && Array(territoryData["data"]["parent"]["id"])
   const userCanEdit: boolean = useMemo(() => {
     return (
       !!statement &&
@@ -668,14 +678,20 @@ export const StatementEditorBox: React.FC = () => {
       {statement ? (
         <div style={{ marginBottom: "4rem" }} key={statement.id}>
           <StyledEditorPreSection>
-            {/* breadcrumb */}
-
             {territoryData && (
               <StyledGrid>
                 <StyledGridCell>
-                  <StyledListHeaderColumn>
-                    Statement territory
-                  </StyledListHeaderColumn>
+                <ButtonGroup noMargin>
+                  {territoryPath &&
+                    territoryPath.map((territory: string, key: number) => {
+                      return (
+                        <React.Fragment key={key}>
+                          <StatementListBreadcrumbItem territoryId={territory} />
+                        </React.Fragment>
+                      );
+                    })}
+                    {"/"}
+                </ButtonGroup>
                 </StyledGridCell>
                 <StyledGridCell>
                   <ActantTag actant={territoryData} fullWidth />

--- a/packages/client/src/pages/MainPage/containers/StatementEditorBox/StatementEditorBoxStyles.tsx
+++ b/packages/client/src/pages/MainPage/containers/StatementEditorBox/StatementEditorBoxStyles.tsx
@@ -19,7 +19,9 @@ export const StyledGridCell = styled.div`
 // Editor Section
 interface StyledEditorPreSection {}
 export const StyledEditorPreSection = styled.div<StyledEditorPreSection>`
-  padding: ${({ theme }) => theme.space[6]};
+  padding: ${({ theme }) => theme.space[3]};
+  color: ${({ theme }) => theme.color["info"]};
+
 `;
 interface StyledEditorSection {
   firstSection?: boolean;

--- a/packages/client/src/pages/MainPage/containers/StatementsListBox/StatementListHeader/StatementListBreadcrumbItem/StatementListBreadcrumbItem.tsx
+++ b/packages/client/src/pages/MainPage/containers/StatementsListBox/StatementListHeader/StatementListBreadcrumbItem/StatementListBreadcrumbItem.tsx
@@ -32,10 +32,12 @@ export const StatementListBreadcrumbItem: React.FC<StatementListBreadcrumbItem> 
     <>
       {territoryId !== rootTerritoryId && (
         <StyledItemBox>
+          {"/"}
           <Button
             label={data ? data.label : territoryId}
             color="info"
             inverted
+            noBorder
             onClick={() => {
               dispatch(setTreeInitialized(false));
               setTerritoryId(territoryId);

--- a/packages/client/src/pages/MainPage/containers/StatementsListBox/StatementListHeader/StatementListBreadcrumbItem/StatementListBreadcrumbItemStyles.tsx
+++ b/packages/client/src/pages/MainPage/containers/StatementsListBox/StatementListHeader/StatementListBreadcrumbItem/StatementListBreadcrumbItemStyles.tsx
@@ -2,6 +2,8 @@ import styled from "styled-components";
 
 export const StyledItemBox = styled.div`
   position: relative;
+  display: flex;
+  color: ${({ theme }) => theme.color["info"]};
   margin-bottom: ${({ theme }) => theme.space[2]};
-  margin-right: ${({ theme }) => theme.space[2]};
+  margin-right: ${({ theme }) => theme.space[1]};
 `;


### PR DESCRIPTION
- just immediate parent shown (yet)
- breadcrumb styling
- statement territory shown as part of breadcrumb
![bread](https://user-images.githubusercontent.com/8287578/141376215-46dbf254-d969-4465-8f94-0aae4e48d02e.png)

