### PR TITLE
empty tag for unset props

### DIFF
--- a/packages/client/src/components/Tag/Tag.tsx
+++ b/packages/client/src/components/Tag/Tag.tsx
@@ -54,7 +54,7 @@ export const Tag: React.FC<TagProps> = ({
   label = "",
   tooltipDetail,
   tooltipText,
-  category = "T",
+  category = "X",
   status = "1",
   ltype = "1",
   mode = false,
@@ -197,7 +197,13 @@ export const Tag: React.FC<TagProps> = ({
                   fullWidth={fullWidth}
                   isFavorited={isFavorited}
                 >
-                  {label ? label : <StyledItalic>{"no label"}</StyledItalic>}
+                  {!label ? (
+                    <StyledItalic>{"no label"}</StyledItalic>
+                  ) : category === "X" ? (
+                    <StyledItalic>{label}</StyledItalic>
+                  ) : (
+                    label
+                  )}
                 </StyledLabel>
 
                 {button && renderButton()}

--- a/packages/client/src/pages/MainPage/containers/StatementsListBox/StatementListTable/StatementListRowExpanded/StatementListRowExpandedPropGroup.tsx
+++ b/packages/client/src/pages/MainPage/containers/StatementsListBox/StatementListTable/StatementListRowExpanded/StatementListRowExpandedPropGroup.tsx
@@ -12,45 +12,52 @@ interface StatementListRowExpandedPropGroup {
   entities: { [key: string]: IEntity };
   renderChildrenPropRow?: (props: IProp[]) => React.ReactElement;
 }
-export const StatementListRowExpandedPropGroup: React.FC<
-  StatementListRowExpandedPropGroup
-> = ({ level, props, entities, renderChildrenPropRow }) => {
-  return (
-    <StyledPropGroup>
-      {props.map((prop, key) => {
-        const propTypeEntity: IEntity = entities[prop.type.id];
-        const propValueEntity: IEntity = entities[prop.value.id];
-        return (
-
-          <React.Fragment key={key}>
-            <StyledPropRow key={key} level={level}>
-              {propTypeEntity ? (
-                <>
+export const StatementListRowExpandedPropGroup: React.FC<StatementListRowExpandedPropGroup> =
+  ({ level, props, entities, renderChildrenPropRow }) => {
+    return (
+      <StyledPropGroup>
+        {props.map((prop, key) => {
+          const propTypeEntity: IEntity = entities[prop.type.id];
+          const propValueEntity: IEntity = entities[prop.value.id];
+          return (
+            <React.Fragment key={key}>
+              <StyledPropRow key={key} level={level}>
+                {propTypeEntity ? (
+                  <>
+                    <EntityTag
+                      actant={propTypeEntity}
+                      tooltipPosition="bottom center"
+                    />
+                    <span>&nbsp;</span>
+                  </>
+                ) : (
+                  <>
+                    <EntityTag
+                      actant={{ label: "type" }}
+                      tooltipPosition="bottom center"
+                    />
+                    <span>&nbsp;</span>
+                  </>
+                )}
+                {propValueEntity ? (
                   <EntityTag
-                    actant={propTypeEntity}
+                    actant={propValueEntity}
                     tooltipPosition="bottom center"
                   />
-                  <span>&nbsp;</span>
-                </>
-              ) : (
-                <span>[type]&nbsp;</span>
-              )}
-              {propValueEntity ? (
-                <EntityTag
-                  actant={propValueEntity}
-                  tooltipPosition="bottom center"
-                />
-              ) : (
-                "[value]"
-              )}
-            </StyledPropRow>
+                ) : (
+                  <EntityTag
+                    actant={{ label: "value" }}
+                    tooltipPosition="bottom center"
+                  />
+                )}
+              </StyledPropRow>
 
-            <div key={`children-${key}`}>
-              {renderChildrenPropRow && renderChildrenPropRow(prop.children)}
-            </div>
-          </React.Fragment>
-        );
-      })}
-    </StyledPropGroup>
-  );
-};
+              <div key={`children-${key}`}>
+                {renderChildrenPropRow && renderChildrenPropRow(prop.children)}
+              </div>
+            </React.Fragment>
+          );
+        })}
+      </StyledPropGroup>
+    );
+  };

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -98,6 +98,11 @@ export const Entities: { [key: string]: IEntity } = {
     label: "Value",
     color: "entityV",
   },
+  X: {
+    id: "X",
+    label: "unset",
+    color: "white",
+  },
 };
 
 export type EntityKeys = keyof typeof Entities;


### PR DESCRIPTION
added X entity and made it a default, I didn't encounter any side effects. For empty type/value pairs in statement list expander, looks like this:
![empty-tag](https://user-images.githubusercontent.com/8287578/160200539-5c36a5ff-c106-4c74-bac1-e6fc43d033ab.png)

