### PR TITLE
used-in details section redesign

### DIFF
--- a/packages/client/src/pages/MainPage/containers/EntityDetailBox/EntityDetailBox.tsx
+++ b/packages/client/src/pages/MainPage/containers/EntityDetailBox/EntityDetailBox.tsx
@@ -1067,32 +1067,35 @@ export const EntityDetailBox: React.FC<EntityDetailBox> = ({}) => {
             </StyledDetailSectionContent>
           </StyledDetailSection>
 
-          {/* usedId props */}
-          <EntityDetailBoxTable
-            title="Used in Meta Props"
-            entities={entity.entities}
-            useCases={entity.usedInMetaProps}
-            mode="Prop"
-            key="Prop"
-          />
+          <StyledDetailSection>
+            <StyledDetailSectionHeader>Used in:</StyledDetailSectionHeader>
+            {/* usedId props */}
+            <EntityDetailBoxTable
+              title="Meta Prop"
+              entities={entity.entities}
+              useCases={entity.usedInMetaProps}
+              mode="Prop"
+              key="Prop"
+            />
 
-          {/* usedId statements */}
-          <EntityDetailBoxTable
-            title="Used in Statement"
-            entities={entity.entities}
-            useCases={entity.usedInStatement}
-            mode="Statement"
-            key="Statement"
-          />
+            {/* usedId statements */}
+            <EntityDetailBoxTable
+              title="Statement"
+              entities={entity.entities}
+              useCases={entity.usedInStatement}
+              mode="Statement"
+              key="Statement"
+            />
 
-          {/* usedId statement props */}
-          <EntityDetailBoxTable
-            title="Used in Statement Props"
-            entities={entity.entities}
-            useCases={entity.usedInStatementProps}
-            mode="StatementProp"
-            key="StatementProp"
-          />
+            {/* usedId statement props */}
+            <EntityDetailBoxTable
+              title="Statement Prop"
+              entities={entity.entities}
+              useCases={entity.usedInStatementProps}
+              mode="StatementProp"
+              key="StatementProp"
+            />
+          </StyledDetailSection>
 
           {/* Audits */}
           <StyledDetailSection key="editor-section-audits">

--- a/packages/client/src/pages/MainPage/containers/EntityDetailBox/EntityDetailBoxStyles.tsx
+++ b/packages/client/src/pages/MainPage/containers/EntityDetailBox/EntityDetailBoxStyles.tsx
@@ -41,7 +41,6 @@ export const StyledTagWrap = styled.div`
 `;
 
 export const StyledDetailSectionHeader = styled.div`
-  font-weight: bold;
   font-size: ${({ theme }) => theme.fontSize.lg};
   margin-bottom: ${({ theme }) => theme.space["4"]};
   color: ${({ theme }) => theme.color["primary"]};
@@ -94,16 +93,29 @@ export const StyledDetailForm = styled.div`
   }
 `;
 
+export const StyledDetailSectionContentUsedInTitle = styled.div`
+  margin-top: ${({ theme }) => theme.space[2]};
+  color: ${({ theme }) => theme.color["info"]};
+`;
+
 export const StyledDetailSectionUsedTable = styled.div`
   display: grid;
   align-items: center;
   padding-left: ${({ theme }) => theme.space[0]};
-  grid-template-columns: auto auto auto auto;
-  width: fit-content;
+  width: 100%;
   grid-template-rows: auto;
   grid-auto-flow: row;
-  padding-top: ${({ theme }) => theme.space[6]};
-  padding-bottom: ${({ theme }) => theme.space[6]};
+  padding-top: ${({ theme }) => theme.space[2]};
+  padding-bottom: ${({ theme }) => theme.space[1]};
+`;
+
+export const StyledDetailSectionUsedTableRow = styled.div`
+  display: grid;
+  grid-template-columns: 10% auto 10% 8%;
+  width: 100%;
+  border-bottom: 1px solid ${({ theme }) => theme.color["gray"][400]};
+  padding-top: ${({ theme }) => theme.space[2]};
+  background: white;
 `;
 
 interface StyledDetailHeaderColumn {}
@@ -117,7 +129,7 @@ export const StyledDetailHeaderColumn = styled.div<StyledDetailHeaderColumn>`
 
 export const StyledDetailSectionUsedText = styled.div`
   font-size: ${({ theme }) => theme.fontSize["xs"]};
-  max-width: 20em;
+  max-width: 30em;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -130,6 +142,7 @@ interface StyledDetailSectionContent {}
 export const StyledDetailSectionContent = styled.div<StyledDetailSectionContent>`
   padding-left: ${({ theme, firstSection = false }) =>
     firstSection ? "" : theme.space[4]};
+  padding-top: ${({ theme }) => theme.space[4]};
 `;
 
 // usedIn section
@@ -141,8 +154,9 @@ export const StyledDetailSectionUsedPageManager = styled.div`
   font-size: ${({ theme }) => theme.fontSize["xs"]};
   display: inline-flex;
   align-items: center;
+  padding-bottom: ${({ theme }) => theme.space[3]};
   button {
-    margin: 0 ${({ theme }) => theme.space[2]};
+    margin: 0 ${({ theme }) => theme.space[1]};
   }
 `;
 
@@ -152,8 +166,6 @@ export const StyledDetailSectionUsedTableCell = styled.div<StyledDetailSectionMe
     lastSecondLevel ? theme.space[2] : theme.space[2]};
   align-items: center;
   padding: 0 5px;
-  border-right: ${({ theme, borderless }) =>
-    borderless ? "none" : "1px dashed black"};
 `;
 
 export const StyledDetailSectionMetaTable = styled.div`
@@ -189,6 +201,4 @@ export const StyledDetailSectionMetaTableCell = styled.div<StyledDetailSectionMe
     lastSecondLevel ? theme.space[2] : theme.space[2]};
   align-items: center;
   padding: 0 5px;
-  border-right: ${({ theme, borderless }) =>
-    borderless ? "none" : "1px dashed black"};
 `;

--- a/packages/client/src/pages/MainPage/containers/EntityDetailBox/EntityDetailBoxTable.tsx
+++ b/packages/client/src/pages/MainPage/containers/EntityDetailBox/EntityDetailBoxTable.tsx
@@ -1,20 +1,19 @@
 import { EntityClass } from "@shared/enums";
 import { IEntity } from "@shared/types";
-import { Button } from "components";
+import { Button, Tooltip } from "components";
 import { useSearchParams } from "hooks";
 import React, { useMemo, useState } from "react";
 import { FaEdit, FaStepBackward, FaStepForward } from "react-icons/fa";
 import { EntityTag } from "..";
 import {
-  StyledDetailHeaderColumn,
-  StyledDetailSection,
   StyledDetailSectionContentUsedIn,
-  StyledDetailSectionHeader,
+  StyledDetailSectionContentUsedInTitle,
   StyledDetailSectionMetaTableButtonGroup,
   StyledDetailSectionMetaTableCell,
   StyledDetailSectionUsedPageManager,
   StyledDetailSectionUsedTable,
   StyledDetailSectionUsedTableCell,
+  StyledDetailSectionUsedTableRow,
   StyledDetailSectionUsedText,
 } from "./EntityDetailBoxStyles";
 
@@ -42,20 +41,86 @@ export const EntityDetailBoxTable: React.FC<EntityDetailBoxTable> = ({
     useSearchParams();
 
   return (
-    <StyledDetailSection key={title}>
-      <StyledDetailSectionHeader>{title}:</StyledDetailSectionHeader>
+    <>
       <StyledDetailSectionContentUsedIn>
-        {`number of occurences ${useCases.length}`}
+        <StyledDetailSectionContentUsedInTitle>
+          <b>{`${useCases.length} `}</b>{" "}
+          {`${title}${useCases.length === 1 ? "" : "s"}`}
+        </StyledDetailSectionContentUsedInTitle>
       </StyledDetailSectionContentUsedIn>
       <StyledDetailSectionContentUsedIn>
-        <StyledDetailSectionUsedPageManager>
-          <StyledDetailSectionUsedTable>
+        <StyledDetailSectionUsedTable>
+          {useCases.map((useCase, ui) => {
+            const position = useCase.position;
+            const entityId =
+              mode === "Prop" ? useCase.entityId : useCase.statement?.id;
+            const entity = entityId ? entities[entityId] : false;
+
+            return entity ? (
+              <React.Fragment key={ui}>
+                <StyledDetailSectionUsedTableRow>
+                  <StyledDetailSectionUsedTableCell>
+                    <EntityTag
+                      key={entity.id}
+                      actant={entity}
+                      showOnly="entity"
+                      tooltipText={entity.label}
+                    />
+                  </StyledDetailSectionUsedTableCell>
+                  <StyledDetailSectionUsedTableCell>
+                    <StyledDetailSectionUsedText>
+                      {entity.class === EntityClass.Statement
+                        ? entity.data.text
+                        : ""}
+                    </StyledDetailSectionUsedText>
+                  </StyledDetailSectionUsedTableCell>
+                  <StyledDetailSectionUsedTableCell>
+                    <Tooltip label="position">
+                      <StyledDetailSectionUsedText
+                        style={{ cursor: "pointer" }}
+                      >
+                        {position}
+                      </StyledDetailSectionUsedText>
+                    </Tooltip>
+                  </StyledDetailSectionUsedTableCell>
+                  <StyledDetailSectionMetaTableCell borderless>
+                    <StyledDetailSectionMetaTableButtonGroup>
+                      {entity.data.territory?.id && (
+                        <React.Fragment>
+                          <Button
+                            key="e"
+                            icon={<FaEdit size={14} />}
+                            color="primary"
+                            inverted
+                            noBorder
+                            tooltip="edit statement"
+                            onClick={async () => {
+                              if (entity.data.territory) {
+                                setStatementId(entity.id);
+                                setTerritoryId(entity.data.territory.id);
+                              }
+                            }}
+                          />
+                        </React.Fragment>
+                      )}
+                    </StyledDetailSectionMetaTableButtonGroup>
+                  </StyledDetailSectionMetaTableCell>
+                </StyledDetailSectionUsedTableRow>
+              </React.Fragment>
+            ) : (
+              <div key={ui} />
+            );
+          })}
+        </StyledDetailSectionUsedTable>
+        {useCases.length > perPage && (
+          <StyledDetailSectionUsedPageManager>
             {`Page ${usedInPage + 1} / ${noPages}`}
             <Button
               key="previous"
               disabled={usedInPage === 0}
-              icon={<FaStepBackward size={14} />}
-              color="primary"
+              icon={<FaStepBackward size={12} />}
+              color="plain"
+              inverted
               tooltip="previous page"
               onClick={() => {
                 if (usedInPage !== 0) {
@@ -66,8 +131,9 @@ export const EntityDetailBoxTable: React.FC<EntityDetailBoxTable> = ({
             <Button
               key="next"
               disabled={usedInPage === noPages - 1}
-              icon={<FaStepForward size={14} />}
-              color="primary"
+              icon={<FaStepForward size={12} />}
+              color="plain"
+              inverted
               tooltip="next page"
               onClick={() => {
                 if (usedInPage !== noPages - 1) {
@@ -75,70 +141,9 @@ export const EntityDetailBoxTable: React.FC<EntityDetailBoxTable> = ({
                 }
               }}
             />
-          </StyledDetailSectionUsedTable>
-        </StyledDetailSectionUsedPageManager>
-        <StyledDetailSectionUsedTable>
-          <StyledDetailHeaderColumn></StyledDetailHeaderColumn>
-          <StyledDetailHeaderColumn>
-            {mode !== "Prop" ? "Text" : ""}
-          </StyledDetailHeaderColumn>
-          <StyledDetailHeaderColumn>Position</StyledDetailHeaderColumn>
-          <StyledDetailHeaderColumn></StyledDetailHeaderColumn>
-          {useCases.map((useCase, ui) => {
-            const position = useCase.position;
-            const entityId =
-              mode === "Prop" ? useCase.entityId : useCase.statement?.id;
-            const entity = entityId ? entities[entityId] : false;
-
-            return entity ? (
-              <React.Fragment key={ui}>
-                <StyledDetailSectionUsedTableCell>
-                  <EntityTag
-                    key={entity.id}
-                    actant={entity}
-                    showOnly="entity"
-                    tooltipText={entity.label}
-                  />
-                </StyledDetailSectionUsedTableCell>
-                <StyledDetailSectionUsedTableCell>
-                  <StyledDetailSectionUsedText>
-                    {entity.class === EntityClass.Statement
-                      ? entity.data.text
-                      : ""}
-                  </StyledDetailSectionUsedText>
-                </StyledDetailSectionUsedTableCell>
-                <StyledDetailSectionUsedTableCell>
-                  <StyledDetailSectionUsedText>
-                    {position}
-                  </StyledDetailSectionUsedText>
-                </StyledDetailSectionUsedTableCell>
-                <StyledDetailSectionMetaTableCell borderless>
-                  <StyledDetailSectionMetaTableButtonGroup>
-                    {entity.data.territory?.id && (
-                      <React.Fragment>
-                        <Button
-                          key="e"
-                          icon={<FaEdit size={14} />}
-                          color="plain"
-                          tooltip="edit statement"
-                          onClick={async () => {
-                            if (entity.data.territory) {
-                              setStatementId(entity.id);
-                              setTerritoryId(entity.data.territory.id);
-                            }
-                          }}
-                        />
-                      </React.Fragment>
-                    )}
-                  </StyledDetailSectionMetaTableButtonGroup>
-                </StyledDetailSectionMetaTableCell>
-              </React.Fragment>
-            ) : (
-              <div key={ui} />
-            );
-          })}
-        </StyledDetailSectionUsedTable>
+          </StyledDetailSectionUsedPageManager>
+        )}
       </StyledDetailSectionContentUsedIn>
-    </StyledDetailSection>
+    </>
   );
 };


### PR DESCRIPTION
closes #366 
closes #840 

Changes in used in sections:
- joined to one 'Used in' section
- title and item count joined together
- more table-like style
- pagination controls at the bottom and shown only when per page count is exceeded

![usedin1](https://user-images.githubusercontent.com/8287578/160294063-e4b5378b-8cd6-4733-8914-cbbb1f9ebc88.png)

![usedin2](https://user-images.githubusercontent.com/8287578/160294067-906da155-7691-4791-9eb9-0b2edd7ebed4.png)

