### PR TITLE
Fix/references fullwidth tags

### DIFF
--- a/packages/client/src/components/Tag/Tag.stories.tsx
+++ b/packages/client/src/components/Tag/Tag.stories.tsx
@@ -24,7 +24,7 @@ export default {
     invertedLabel: false,
     short: false,
     fullWidth: false,
-    enableTooltip: false,
+    disableTooltip: true,
   },
   argTypes: {
     category: { options: entityIds, control: { type: "select" } },
@@ -66,5 +66,5 @@ export const TagWithVeryLongLabel = ({ ...args }) => {
 TagWithVeryLongLabel.args = {
   category: Entities["P"].id,
   label: "entity label entity label entity label",
-  enableTooltip: true,
+  disableTooltip: false,
 };

--- a/packages/client/src/components/Tag/Tag.tsx
+++ b/packages/client/src/components/Tag/Tag.tsx
@@ -94,6 +94,7 @@ export const Tag: React.FC<TagProps> = ({
     end: (item: DragItem | undefined, monitor: DragSourceMonitor) => {
       if (item && item.index !== index) updateOrderFn(item);
     },
+    canDrag: category !== "X",
   });
 
   useEffect(() => {
@@ -135,6 +136,7 @@ export const Tag: React.FC<TagProps> = ({
         <StyledTooltipSeparator>
           <StyledTagWrapper
             ref={ref}
+            isEmpty={category === "X"}
             status={status}
             ltype={ltype}
             borderStyle={borderStyle}
@@ -182,6 +184,7 @@ export const Tag: React.FC<TagProps> = ({
             <StyledTooltipSeparator>
               <StyledTagWrapper
                 ref={ref}
+                isEmpty={category === "X"}
                 borderStyle={borderStyle}
                 status={status}
                 ltype={ltype}

--- a/packages/client/src/components/Tag/Tag.tsx
+++ b/packages/client/src/components/Tag/Tag.tsx
@@ -28,7 +28,7 @@ interface TagProps {
   label?: string;
   tooltipDetail?: string;
   tooltipText?: string;
-  category: string;
+  category?: string;
   status?: string;
   ltype?: string;
   mode?: "selected" | "disabled" | "invalid" | false;
@@ -39,7 +39,7 @@ interface TagProps {
   fullWidth?: boolean;
   index?: number;
   moveFn?: (dragIndex: number, hoverIndex: number) => void;
-  enableTooltip?: boolean;
+  disableTooltip?: boolean;
   tooltipPosition?: PopupPosition | PopupPosition[];
   updateOrderFn?: (item: DragItem) => void;
   lvl?: number;
@@ -66,7 +66,7 @@ export const Tag: React.FC<TagProps> = ({
   index = -1,
   moveFn,
   tooltipPosition = "right top",
-  enableTooltip = true,
+  disableTooltip = false,
   updateOrderFn = () => {},
   statementsCount,
   isFavorited = false,
@@ -174,7 +174,7 @@ export const Tag: React.FC<TagProps> = ({
             label={label}
             detail={tooltipDetail}
             text={tooltipText}
-            disabled={!enableTooltip}
+            disabled={disableTooltip}
             position={tooltipPosition}
             tagTooltip
             itemsCount={statementsCount}

--- a/packages/client/src/components/Tag/TagStyles.tsx
+++ b/packages/client/src/components/Tag/TagStyles.tsx
@@ -1,4 +1,3 @@
-import { animated } from "react-spring";
 import styled from "styled-components";
 
 interface StyledTagWrapper {
@@ -6,6 +5,7 @@ interface StyledTagWrapper {
   borderStyle: "solid" | "dashed" | "dotted";
   status: string;
   ltype: string;
+  isEmpty?: boolean;
 }
 export const StyledTagWrapper = styled.div<StyledTagWrapper>`
   display: inline-flex;
@@ -16,7 +16,7 @@ export const StyledTagWrapper = styled.div<StyledTagWrapper>`
   border-radius: ${({ theme }) => theme.borderRadius["sm"]};
   margin-right: ${({ theme, hasMarginRight }) =>
     hasMarginRight && theme.space[1]};
-  cursor: move;
+  cursor: ${({ isEmpty }) => (isEmpty ? "default" : "move")};
   border-style: ${({ theme, ltype }) =>
     "solid solid solid " + theme.borderStyle[ltype]};
   color: ${({ theme }) => theme.color["black"]};

--- a/packages/client/src/components/index.tsx
+++ b/packages/client/src/components/index.tsx
@@ -2,31 +2,31 @@ import { Box } from "components/Box/Box";
 import { Button } from "components/Button/Button";
 import { ButtonGroup } from "components/ButtonGroup/ButtonGroup";
 import { Dropdown } from "components/Dropdown/Dropdown";
-import { Header } from "components/Header/Header";
 import { Footer } from "components/Footer/Footer";
+import { Header } from "components/Header/Header";
 import { Input } from "components/Input/Input";
-import { MultiInput } from "components/MultiInput/MultiInput";
 import { Loader } from "components/Loader/Loader";
-import { Panel } from "components/Panel/Panel";
-import { Suggester } from "components/Suggester/Suggester";
-import { Submit } from "components/Submit/Submit";
-import { Tag } from "components/Tag/Tag";
-import { TagGroup } from "components/TagGroup/TagGroup";
-import { Toast } from "components/Toast/Toast";
-import { Tooltip } from "components/Tooltip/Tooltip";
 import {
   Modal,
   ModalCard,
-  ModalHeader,
   ModalContent,
   ModalFooter,
+  ModalHeader,
   ModalInputForm,
   ModalInputLabel,
   ModalInputWrap,
 } from "components/Modal/Modal";
-import { PanelSeparator } from "./PanelSeparator/PanelSeparator";
-import { Checkbox } from "./Checkbox/Checkbox";
+import { MultiInput } from "components/MultiInput/MultiInput";
+import { Panel } from "components/Panel/Panel";
+import { Submit } from "components/Submit/Submit";
+import { Suggester } from "components/Suggester/Suggester";
+import { Tag } from "components/Tag/Tag";
+import { TagGroup } from "components/TagGroup/TagGroup";
+import { Toast } from "components/Toast/Toast";
+import { Tooltip } from "components/Tooltip/Tooltip";
 import { AttributeIcon } from "./AttributeIcon/AttributeIcon";
+import { Checkbox } from "./Checkbox/Checkbox";
+import { PanelSeparator } from "./PanelSeparator/PanelSeparator";
 
 export {
   AttributeIcon,

--- a/packages/client/src/pages/MainPage/containers/EmptyTag/EmptyTag.tsx
+++ b/packages/client/src/pages/MainPage/containers/EmptyTag/EmptyTag.tsx
@@ -1,0 +1,9 @@
+import { Tag } from "components";
+import React from "react";
+
+interface EmptyTag {
+  label: string;
+}
+export const EmptyTag: React.FC<EmptyTag> = ({ label }) => {
+  return <Tag propId={label} label={label} disableTooltip />;
+};

--- a/packages/client/src/pages/MainPage/containers/EntityBookmarkBox/EntityBookmarkFolderTable/EntityBookmarkFolderTable.tsx
+++ b/packages/client/src/pages/MainPage/containers/EntityBookmarkBox/EntityBookmarkFolderTable/EntityBookmarkFolderTable.tsx
@@ -39,6 +39,7 @@ export const EntityBookmarkFolderTable: React.FC<EntityBookmarkFolderTable> = ({
           return (
             <EntityTag
               actant={entity as IEntity}
+              tooltipPosition="left center"
               button={
                 <Button
                   key="d"

--- a/packages/client/src/pages/MainPage/containers/EntityDetailBox/EntityDetailBox.tsx
+++ b/packages/client/src/pages/MainPage/containers/EntityDetailBox/EntityDetailBox.tsx
@@ -131,7 +131,6 @@ export const EntityDetailBox: React.FC<EntityDetailBox> = ({}) => {
         queryClient.invalidateQueries(["entity"]);
         queryClient.invalidateQueries("statement");
 
-        console.log(variables);
         if (statementId === detailId) {
           queryClient.invalidateQueries("statement");
         }

--- a/packages/client/src/pages/MainPage/containers/EntityReferenceTable/EntityReferenceInputStyles.tsx
+++ b/packages/client/src/pages/MainPage/containers/EntityReferenceTable/EntityReferenceInputStyles.tsx
@@ -14,14 +14,15 @@ export const StyledGrid = styled.div`
 export const StyledGridCell = styled.div`
   margin: ${({ theme }) => theme.space[1]};
   display: inline-flex;
+  overflow: hidden;
   align-items: center;
 `;
 
 // references
 interface StyledReferencesList {}
 export const StyledReferencesList = styled(StyledGrid)<StyledReferencesList>`
-  grid-template-columns: auto auto auto;
-  /* width: 50rem; */
+  max-width: 100%;
+  overflow: hidden;
 `;
 
 interface StyledListHeaderColumn {}

--- a/packages/client/src/pages/MainPage/containers/EntityTag/EntityTag.tsx
+++ b/packages/client/src/pages/MainPage/containers/EntityTag/EntityTag.tsx
@@ -16,13 +16,12 @@ interface IEntityTag {
   index?: number;
   moveFn?: (dragIndex: number, hoverIndex: number) => void;
   isSelected?: boolean;
-  enableTooltip?: boolean;
+  disableTooltip?: boolean;
   tooltipPosition?: PopupPosition | PopupPosition[];
   updateOrderFn?: (item: DragItem) => void;
   lvl?: number;
   statementsCount?: number;
   isFavorited?: boolean;
-  disabled?: boolean;
 }
 
 export const EntityTag: React.FC<IEntityTag> = ({
@@ -36,13 +35,12 @@ export const EntityTag: React.FC<IEntityTag> = ({
   index,
   moveFn,
   isSelected,
-  enableTooltip = true,
+  disableTooltip = false,
   tooltipPosition,
   updateOrderFn,
   lvl,
   statementsCount,
   isFavorited,
-  disabled,
 }) => {
   const classId = actant.class;
 
@@ -62,7 +60,7 @@ export const EntityTag: React.FC<IEntityTag> = ({
       borderStyle="solid"
       invertedLabel={isSelected}
       index={index}
-      enableTooltip={enableTooltip}
+      disableTooltip={disableTooltip}
       tooltipPosition={tooltipPosition}
       updateOrderFn={updateOrderFn}
       parentId={parentId}

--- a/packages/client/src/pages/MainPage/containers/PropGroup/PropGroup.tsx
+++ b/packages/client/src/pages/MainPage/containers/PropGroup/PropGroup.tsx
@@ -62,8 +62,6 @@ export const PropGroup: React.FC<IPropGroup> = ({
     }
   );
 
-  console.log();
-
   const renderFirsLevelPropRow = useCallback(
     (
       prop1: IProp,

--- a/packages/client/src/pages/MainPage/containers/PropGroup/PropGroupRow/PropGroupRow.tsx
+++ b/packages/client/src/pages/MainPage/containers/PropGroup/PropGroupRow/PropGroupRow.tsx
@@ -145,7 +145,9 @@ export const PropGroupRow: React.FC<IPropGroupRow> = ({
           level={level}
           isTag={propTypeEntity ? true : false}
         >
-          <StyledFaGripVertical />
+          <div>
+            <StyledFaGripVertical />
+          </div>
           {propTypeEntity ? (
             <EntityTag
               actant={propTypeEntity}

--- a/packages/client/src/pages/MainPage/containers/StatementEditorBox/StatementEditorBox.tsx
+++ b/packages/client/src/pages/MainPage/containers/StatementEditorBox/StatementEditorBox.tsx
@@ -409,6 +409,7 @@ export const StatementEditorBox: React.FC = () => {
           queryClient.invalidateQueries(["entity"]);
         }
         queryClient.invalidateQueries(["statement"]);
+        queryClient.invalidateQueries(["territory"]);
       },
     }
   );

--- a/packages/client/src/pages/MainPage/containers/StatementsListBox/StatementListTable/StatementListRowExpanded/StatementListRowExpanded.tsx
+++ b/packages/client/src/pages/MainPage/containers/StatementsListBox/StatementListTable/StatementListRowExpanded/StatementListRowExpanded.tsx
@@ -17,6 +17,7 @@ import {
   StyledSubRow,
 } from "./StatementListRowExpandedStyles";
 import { StyledPropRow } from "./StatementListRowExpandedStyles";
+import { EmptyTag } from "pages/MainPage/containers";
 
 interface StatementListRowExpanded {
   row: Row;
@@ -29,26 +30,30 @@ export const StatementListRowExpanded: React.FC<StatementListRowExpanded> = ({
   entities,
 }) => {
   const renderReference = (
-    referenceId: string,
+    resourceId: string,
     valueId: string,
     key: number
   ) => {
     return (
       <React.Fragment key={key}>
         <StyledReferenceWrap key={key}>
-          {referenceId && (
+          {resourceId ? (
             <EntityTag
-              actant={entities[referenceId]}
+              actant={entities[resourceId]}
               tooltipPosition="bottom center"
               // fullWidth
             />
+          ) : (
+            <EmptyTag label="resource" />
           )}
-          {valueId && (
+          {valueId ? (
             <EntityTag
               actant={entities[valueId]}
               tooltipPosition="bottom center"
               // fullWidth
             />
+          ) : (
+            <EmptyTag label="value" />
           )}
         </StyledReferenceWrap>
       </React.Fragment>

--- a/packages/client/src/pages/MainPage/containers/StatementsListBox/StatementListTable/StatementListRowExpanded/StatementListRowExpanded.tsx
+++ b/packages/client/src/pages/MainPage/containers/StatementsListBox/StatementListTable/StatementListRowExpanded/StatementListRowExpanded.tsx
@@ -35,20 +35,22 @@ export const StatementListRowExpanded: React.FC<StatementListRowExpanded> = ({
   ) => {
     return (
       <React.Fragment key={key}>
-        {referenceId && (
-          <StyledReferenceWrap key={key}>
+        <StyledReferenceWrap key={key}>
+          {referenceId && (
             <EntityTag
               actant={entities[referenceId]}
               tooltipPosition="bottom center"
               // fullWidth
             />
+          )}
+          {valueId && (
             <EntityTag
               actant={entities[valueId]}
               tooltipPosition="bottom center"
               // fullWidth
             />
-          </StyledReferenceWrap>
-        )}
+          )}
+        </StyledReferenceWrap>
       </React.Fragment>
     );
   };

--- a/packages/client/src/pages/MainPage/containers/StatementsListBox/StatementListTable/StatementListRowExpanded/StatementListRowExpanded.tsx
+++ b/packages/client/src/pages/MainPage/containers/StatementsListBox/StatementListTable/StatementListRowExpanded/StatementListRowExpanded.tsx
@@ -210,11 +210,15 @@ export const StatementListRowExpanded: React.FC<StatementListRowExpanded> = ({
             ))}
           </StyledActantGroup>
           {references.map((reference, key) => (
-            <StyledPropRow level={1} key={key}>
-              <BsArrowReturnRight size="20" />
-              <span>&nbsp;&nbsp;(reference)&nbsp;&nbsp;</span>
-              {renderReference(reference.resource, reference.value, key)}
-            </StyledPropRow>
+            <React.Fragment key={key}>
+              {(reference.value || reference.resource) && (
+                <StyledPropRow level={1}>
+                  <BsArrowReturnRight size="20" />
+                  <span>&nbsp;&nbsp;(reference)&nbsp;&nbsp;</span>
+                  {renderReference(reference.resource, reference.value, key)}
+                </StyledPropRow>
+              )}
+            </React.Fragment>
           ))}
           {tagObjects.map((tag, key) => (
             <StyledPropRow level={1} key={key}>

--- a/packages/client/src/pages/MainPage/containers/StatementsListBox/StatementListTable/StatementListRowExpanded/StatementListRowExpanded.tsx
+++ b/packages/client/src/pages/MainPage/containers/StatementsListBox/StatementListTable/StatementListRowExpanded/StatementListRowExpanded.tsx
@@ -34,21 +34,24 @@ export const StatementListRowExpanded: React.FC<StatementListRowExpanded> = ({
     valueId: string,
     key: number
   ) => {
+    const resourceEntity: IEntity = entities[resourceId];
+    const valueEntity: IEntity = entities[valueId];
+
     return (
       <React.Fragment key={key}>
         <StyledReferenceWrap key={key}>
-          {resourceId ? (
+          {resourceEntity ? (
             <EntityTag
-              actant={entities[resourceId]}
+              actant={resourceEntity}
               tooltipPosition="bottom center"
               // fullWidth
             />
           ) : (
             <EmptyTag label="resource" />
           )}
-          {valueId ? (
+          {valueEntity ? (
             <EntityTag
-              actant={entities[valueId]}
+              actant={valueEntity}
               tooltipPosition="bottom center"
               // fullWidth
             />

--- a/packages/client/src/pages/MainPage/containers/StatementsListBox/StatementListTable/StatementListRowExpanded/StatementListRowExpandedPropGroup.tsx
+++ b/packages/client/src/pages/MainPage/containers/StatementsListBox/StatementListTable/StatementListRowExpanded/StatementListRowExpandedPropGroup.tsx
@@ -1,4 +1,5 @@
 import { IEntity, IProp } from "@shared/types";
+import { EmptyTag } from "pages/MainPage/containers";
 import React from "react";
 import { EntityTag } from "../../../EntityTag/EntityTag";
 import {
@@ -12,52 +13,47 @@ interface StatementListRowExpandedPropGroup {
   entities: { [key: string]: IEntity };
   renderChildrenPropRow?: (props: IProp[]) => React.ReactElement;
 }
-export const StatementListRowExpandedPropGroup: React.FC<StatementListRowExpandedPropGroup> =
-  ({ level, props, entities, renderChildrenPropRow }) => {
-    return (
-      <StyledPropGroup>
-        {props.map((prop, key) => {
-          const propTypeEntity: IEntity = entities[prop.type.id];
-          const propValueEntity: IEntity = entities[prop.value.id];
-          return (
-            <React.Fragment key={key}>
-              <StyledPropRow key={key} level={level}>
-                {propTypeEntity ? (
-                  <>
-                    <EntityTag
-                      actant={propTypeEntity}
-                      tooltipPosition="bottom center"
-                    />
-                    <span>&nbsp;</span>
-                  </>
-                ) : (
-                  <>
-                    <EntityTag
-                      actant={{ label: "type" }}
-                      tooltipPosition="bottom center"
-                    />
-                    <span>&nbsp;</span>
-                  </>
-                )}
-                {propValueEntity ? (
+export const StatementListRowExpandedPropGroup: React.FC<
+  StatementListRowExpandedPropGroup
+> = ({ level, props, entities, renderChildrenPropRow }) => {
+  return (
+    <StyledPropGroup>
+      {props.map((prop, key) => {
+        const propTypeEntity: IEntity = entities[prop.type.id];
+        const propValueEntity: IEntity = entities[prop.value.id];
+        return (
+          <React.Fragment key={key}>
+            <StyledPropRow key={key} level={level}>
+              {propTypeEntity ? (
+                <>
                   <EntityTag
-                    actant={propValueEntity}
+                    actant={propTypeEntity}
                     tooltipPosition="bottom center"
                   />
-                ) : (
-                  <EntityTag
-                    actant={{ label: "value" }}
-                    tooltipPosition="bottom center"
-                  />
-                )}
-              </StyledPropRow>
+                  <span>&nbsp;</span>
+                </>
+              ) : (
+                <>
+                  <EmptyTag label={"type"} />
+                  <span>&nbsp;</span>
+                </>
+              )}
+              {propValueEntity ? (
+                <EntityTag
+                  actant={propValueEntity}
+                  tooltipPosition="bottom center"
+                />
+              ) : (
+                <EmptyTag label={"value"} />
+              )}
+            </StyledPropRow>
 
-              <div key={`children-${key}`}>
-                {renderChildrenPropRow && renderChildrenPropRow(prop.children)}
-              </div>
-            </React.Fragment>
-          );
-        })}
-      </StyledPropGroup>
-    );
-  };
+            <div key={`children-${key}`}>
+              {renderChildrenPropRow && renderChildrenPropRow(prop.children)}
+            </div>
+          </React.Fragment>
+        );
+      })}
+    </StyledPropGroup>
+  );
+};

--- a/packages/client/src/pages/MainPage/containers/TerritoryTreeBox/TerritoryTreeNode/TerritoryTreeNode.tsx
+++ b/packages/client/src/pages/MainPage/containers/TerritoryTreeBox/TerritoryTreeNode/TerritoryTreeNode.tsx
@@ -278,7 +278,6 @@ export const TerritoryTreeNode: React.FC<TerritoryTreeNode> = ({
                     propId={propId}
                     index={index}
                     fullWidth
-                    enableTooltip
                     moveFn={moveFn}
                     updateOrderFn={moveTerritoryMutation.mutate}
                     statementsCount={statementsCount}

--- a/packages/client/src/pages/MainPage/containers/index.tsx
+++ b/packages/client/src/pages/MainPage/containers/index.tsx
@@ -1,23 +1,25 @@
 import { ActantSearchBox } from "./ActantSearchBox/ActantSearchBox";
-import { EntityDetailBox } from "./EntityDetailBox/EntityDetailBox";
-import { EntityTag } from "./EntityTag/EntityTag";
-import { EntitySuggester } from "./EntitySuggester/EntitySuggester";
 import { ActionModal } from "./ActionModal/ActionModal";
+import { EmptyTag } from "./EmptyTag/EmptyTag";
 import { EntityBookmarkBox } from "./EntityBookmarkBox/EntityBookmarkBox";
+import { EntityDetailBox } from "./EntityDetailBox/EntityDetailBox";
+import { EntitySuggester } from "./EntitySuggester/EntitySuggester";
+import { EntityTag } from "./EntityTag/EntityTag";
+import { LoginModal } from "./LoginModal/LoginModal";
 import { StatementEditorBox } from "./StatementEditorBox/StatementEditorBox";
 import { StatementListBox } from "./StatementsListBox/StatementListBox";
 import { TerritoryTreeBox } from "./TerritoryTreeBox/TerritoryTreeBox";
-import { LoginModal } from "./LoginModal/LoginModal";
-import { UserOptionsModal } from "./UserOptionsModal/UserOptionsModal";
-import { UserListModal } from "./UserListModal/UserListModal";
 import { CertaintyToggle } from "./toggles/CertaintyToggle";
 import { ElvlToggle } from "./toggles/ElvlToggle";
+import { UserListModal } from "./UserListModal/UserListModal";
+import { UserOptionsModal } from "./UserOptionsModal/UserOptionsModal";
 
 export {
   ActantSearchBox,
   EntityDetailBox,
   EntitySuggester,
   EntityTag,
+  EmptyTag,
   ActionModal,
   EntityBookmarkBox,
   StatementEditorBox,


### PR DESCRIPTION
Close #872 
Close #873 

- reference bug after add value or resource and refreshing list
- fix icon in editor props style when fullWidth tags
- bookmarks tooltip to left
- Empty tag component
- Empty tags for Value / Resource
- disabling DnD prop in Tag
- FIX fullwidth references editor grid
- FIX empty reference in expanded row
- reference updating expand row
- hide empty reference rows in expander