### PR TITLE
736 audits get many

### DIFF
--- a/packages/client/src/api.tsx
+++ b/packages/client/src/api.tsx
@@ -542,6 +542,22 @@ class Api {
   }
 
   /**
+   * Audits for statements in territory
+   */
+  async auditsForStatements(
+    territoryId: string
+  ): Promise<AxiosResponse<IResponseAudit[]>> {
+    try {
+      const response = await this.connection.get(
+        `/audits?forTerritory=${territoryId}`
+      );
+      return response;
+    } catch (err: any | AxiosError) {
+      throw { ...err.response.data };
+    }
+  }
+
+  /**
    * Statement
    * Editor container
    */

--- a/packages/client/src/pages/MainPage/containers/StatementsListBox/StatementListBox.tsx
+++ b/packages/client/src/pages/MainPage/containers/StatementsListBox/StatementListBox.tsx
@@ -2,6 +2,7 @@ import { Order, UserRole, UserRoleMode } from "@shared/enums";
 import {
   IAction,
   IEntity,
+  IResponseAudit,
   IResponseStatement,
   IStatement,
 } from "@shared/types";
@@ -39,7 +40,7 @@ import {
 } from "./StatementLitBoxStyles";
 
 const initialData: {
-  statements: IResponseStatement[];
+  statements: (IResponseStatement & { audit?: IResponseAudit })[];
   entities: { [key: string]: IEntity };
   right: UserRoleMode;
 } = {
@@ -61,6 +62,18 @@ export const StatementListBox: React.FC = () => {
     ["territory", "statement-list", territoryId],
     async () => {
       const res = await api.territoryGet(territoryId);
+      return res.data;
+    },
+    {
+      enabled: !!territoryId && api.isLoggedIn(),
+      retry: 2,
+    }
+  );
+
+  const { data: audits, isFetching: isFetchingAudits } = useQuery(
+    ["territory", "statement-list", "audits", territoryId],
+    async () => {
+      const res = await api.auditsForStatements(territoryId);
       return res.data;
     },
     {
@@ -587,11 +600,14 @@ export const StatementListBox: React.FC = () => {
         />
       )}
 
-      {statements && (
+      {statements && audits && (
         <StyledTableWrapper id="Statements-box-table">
           <StatementListTable
             moveEndRow={moveEndRow}
-            data={statements}
+            data={statements.map((st) => ({
+              ...st,
+              audit: audits.find((a) => a.entity === st.id),
+            }))}
             columns={columns}
             handleRowClick={(rowId: string) => {
               setStatementId(rowId);
@@ -625,6 +641,7 @@ export const StatementListBox: React.FC = () => {
       <Loader
         show={
           isFetching ||
+          isFetchingAudits ||
           removeStatementMutation.isLoading ||
           duplicateStatementMutation.isLoading ||
           addStatementAtTheEndMutation.isLoading ||

--- a/packages/client/src/pages/MainPage/containers/StatementsListBox/StatementListTable/StatementListRow.tsx
+++ b/packages/client/src/pages/MainPage/containers/StatementsListBox/StatementListTable/StatementListRow.tsx
@@ -1,5 +1,4 @@
 import { IEntity } from "@shared/types";
-import api from "api";
 import { useSearchParams } from "hooks";
 import React, { useMemo, useRef } from "react";
 import {
@@ -9,7 +8,6 @@ import {
   useDrop,
 } from "react-dnd";
 import { FaGripVertical } from "react-icons/fa";
-import { useQuery } from "react-query";
 import { Cell, ColumnInstance } from "react-table";
 import { DragItem, ItemTypes } from "types";
 import { dndHoverFn } from "utils";
@@ -41,20 +39,7 @@ export const StatementListRow: React.FC<StatementListRow> = ({
   entities,
 }) => {
   const { statementId } = useSearchParams();
-
-  const {
-    status: statusAudit,
-    data: audit,
-    error: auditError,
-    isFetching: isFetchingAudit,
-  } = useQuery(
-    ["audit", row.values.id],
-    async () => {
-      const res = await api.auditGet(row.values.id);
-      return res.data;
-    },
-    { enabled: row && !!row.values.id, retry: 2 }
-  );
+  const audit = row.original.audit;
 
   const lastEditdateText = useMemo(() => {
     if (audit && audit.last && audit.last[0] && audit.last[0].date) {

--- a/packages/database/scripts/import.ts
+++ b/packages/database/scripts/import.ts
@@ -109,6 +109,7 @@ const datasets: Record<string, TableSchema[]> = {
           return audit;
         });
       },
+      indexes: [(table: RTable) => table.indexCreate(DbIndex.AuditEntityId)],
     },
   ],
   empty: [
@@ -201,6 +202,7 @@ const datasets: Record<string, TableSchema[]> = {
           return audit;
         });
       },
+      indexes: [(table: RTable) => table.indexCreate(DbIndex.AuditEntityId)],
     },
   ],
   allparsed: [
@@ -293,6 +295,7 @@ const datasets: Record<string, TableSchema[]> = {
           return audit;
         });
       },
+      indexes: [(table: RTable) => table.indexCreate(DbIndex.AuditEntityId)],
     },
   ],
 };

--- a/packages/server/src/models/audit/response.ts
+++ b/packages/server/src/models/audit/response.ts
@@ -1,6 +1,7 @@
 import { r as rethink, Connection } from "rethinkdb-ts";
 import { IAudit, IResponseAudit } from "@shared/types";
 import Audit from "./audit";
+import { DbIndex } from "@shared/enums";
 
 export class ResponseAudit implements IResponseAudit {
   entity: string;
@@ -15,7 +16,7 @@ export class ResponseAudit implements IResponseAudit {
   async getLastNForEntity(dbConn: Connection, n: number = 5): Promise<void> {
     const result = await rethink
       .table(Audit.table)
-      .filter({ entityId: this.entity })
+      .getAll(this.entity, { index: DbIndex.AuditEntityId })
       .orderBy(rethink.desc("date"))
       .limit(n)
       .run(dbConn);
@@ -31,7 +32,7 @@ export class ResponseAudit implements IResponseAudit {
   async getFirstForEntity(db: Connection): Promise<void> {
     const result = await rethink
       .table(Audit.table)
-      .filter({ entityId: this.entity })
+      .getAll(this.entity, { index: DbIndex.AuditEntityId })
       .orderBy(rethink.asc("date"))
       .limit(1)
       .run(db);

--- a/packages/server/src/modules/audits/index.ts
+++ b/packages/server/src/modules/audits/index.ts
@@ -2,34 +2,63 @@ import { asyncRouteHandler } from "../index";
 import { Router, Request } from "express";
 import { findEntityById } from "@service/shorthands";
 import { BadParams, EntityDoesNotExits } from "@shared/types/errors";
-import { IResponseAudit } from "@shared/types";
+import { IResponseAudit, IStatement } from "@shared/types";
 import { ResponseAudit } from "@models/audit/response";
+import Statement from "@models/statement/statement";
 
-export default Router().get(
-  "/get/:entityId?",
-  asyncRouteHandler<IResponseAudit>(async (request: Request) => {
-    const entityId = request.params.entityId;
+export default Router()
+  .get(
+    "/get/:entityId?",
+    asyncRouteHandler<IResponseAudit>(async (request: Request) => {
+      const entityId = request.params.entityId;
 
-    if (!entityId) {
-      throw new BadParams("entityId has to be set");
-    }
+      if (!entityId) {
+        throw new BadParams("entityId has to be set");
+      }
 
-    // entityId must be already in the db
-    const existingEntity = await findEntityById(request.db, entityId);
+      // entityId must be already in the db
+      const existingEntity = await findEntityById(request.db, entityId);
 
-    if (!existingEntity) {
-      throw new EntityDoesNotExits(
-        `entity with id ${entityId} does not exist`,
-        entityId
-      );
-    }
+      if (!existingEntity) {
+        throw new EntityDoesNotExits(
+          `entity with id ${entityId} does not exist`,
+          entityId
+        );
+      }
 
-    const response = new ResponseAudit(entityId);
-    await response.getLastNForEntity(request.db.connection);
-    if (response.last.length) {
-      await response.getFirstForEntity(request.db.connection);
-    }
+      const response = new ResponseAudit(entityId);
+      await response.getLastNForEntity(request.db.connection);
+      if (response.last.length) {
+        await response.getFirstForEntity(request.db.connection);
+      }
 
-    return response;
-  })
-);
+      return response;
+    })
+  )
+  .get(
+    "/",
+    asyncRouteHandler<IResponseAudit[]>(async (request: Request) => {
+      const territoryId = (request.query.forTerritory as string) || "";
+      if (!territoryId) {
+        throw new BadParams("forTerritory has to be set");
+      }
+
+      const statements: IStatement[] =
+        await Statement.findStatementsInTerritory(
+          request.db.connection,
+          territoryId
+        );
+
+      const out: IResponseAudit[] = [];
+      for (const statementData of statements) {
+        const response = new ResponseAudit(statementData.id);
+        await response.getLastNForEntity(request.db.connection);
+        if (response.last.length) {
+          await response.getFirstForEntity(request.db.connection);
+        }
+        out.push(response);
+      }
+
+      return out;
+    })
+  );

--- a/packages/server/src/modules/audits/index.ts
+++ b/packages/server/src/modules/audits/index.ts
@@ -26,7 +26,9 @@ export default Router().get(
 
     const response = new ResponseAudit(entityId);
     await response.getLastNForEntity(request.db.connection);
-    await response.getFirstForEntity(request.db.connection);
+    if (response.last.length) {
+      await response.getFirstForEntity(request.db.connection);
+    }
 
     return response;
   })

--- a/packages/shared/enums/index.ts
+++ b/packages/shared/enums/index.ts
@@ -192,4 +192,5 @@ export enum DbIndex {
   Class = "class",
   StatementTerritory = "statement_territory",
   StatementEntities = "statement_entities",
+  AuditEntityId = "entityId",
 }


### PR DESCRIPTION
close #736 

db import needed.
Speed for tested call with 30 statements (15 with audit logs) took around 300ms on localhost (1 call instead of 30 calls).
