### PR TITLE
Fix search in empty territories

### DIFF
--- a/packages/server/src/models/entity/response-search.ts
+++ b/packages/server/src/models/entity/response-search.ts
@@ -239,15 +239,14 @@ export class SearchQuery {
       }
 
       const assocEntityIds = await this.getStatementObjectIdsForTerritories(territoryIds);
-      
+
       if (!req.entityIds) {
         req.entityIds = [];
       }
       req.entityIds = req.entityIds.concat(assocEntityIds);
+    }
 
-      // TODO check this
-      this.whereEntityIds(req.entityIds);
-    } else if (req.entityIds?.length) {
+    if (req.entityIds) {
       this.whereEntityIds(req.entityIds);
     }
 
@@ -270,6 +269,8 @@ export class SearchQuery {
     if (req.label) {
       this.whereLabel(req.label);
     }
+
+    console.log(this.query.toString());
   }
 
   /**

--- a/packages/server/src/models/entity/response-search.ts
+++ b/packages/server/src/models/entity/response-search.ts
@@ -239,13 +239,15 @@ export class SearchQuery {
       }
 
       const assocEntityIds = await this.getStatementObjectIdsForTerritories(territoryIds);
+      
       if (!req.entityIds) {
         req.entityIds = [];
       }
       req.entityIds = req.entityIds.concat(assocEntityIds);
-    }
 
-    if (req.entityIds?.length) {
+      // TODO check this
+      this.whereEntityIds(req.entityIds);
+    } else if (req.entityIds?.length) {
       this.whereEntityIds(req.entityIds);
     }
 

--- a/packages/shared/types/request-search.ts
+++ b/packages/shared/types/request-search.ts
@@ -37,7 +37,7 @@ export class RequestSearch {
       (requestData as any).relatedEntityId ||
       false;
 
-    this.entityIds = requestData.entityIds || [];
+    this.entityIds = requestData.entityIds;
 
     if (requestData.excluded) {
       if (requestData.excluded.constructor.name === "String") {


### PR DESCRIPTION
@jancimertel plz review this and do a merge after. 
The original implementation ignores empty territories because of `req.entityIds?.length`
After this fix, it is fully working for me. 

https://github.com/DISSINET/InkVisitor/issues/1507