### PR TITLE
fix(annotator): fix simple overlapping issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,5 @@ database_data
 
 **/*.tar
 **/*.tar.gz
+
+.pnpm-store

--- a/packages/annotator/package.json
+++ b/packages/annotator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "annotator",
-  "version": "1.0.0",
+  "version": "1.1.2",
   "description": "",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/annotator/src/example.txt
+++ b/packages/annotator/src/example.txt
@@ -1,4 +1,4 @@
-<Tcad9c1fb-555b-45f1-92d5-a9a40adc2804>Richard Hegham
+<Tcad9c1fb-555b-45f1-92d5-a9a40adc2804 attr="111">Richard Hegham
 In primis videlicet Ricardus <a8b958fb-874b-49c4-a83f-b626e706f882>Hegham</a8b958fb-874b-49c4-a83f-b626e706f882> de eadem civitate palam et publice infamatur, accusatur et impetitur ac nominatur 
 quod ipse Ricardus fuit et sit verus hereticus pro eo et ex eo quod idem Ricardus infra civitatem Coventr’ predictam palam et publice predicavit, docuit, tenuit, asseruit et dogmatizavit 
 <3f4de0cf-3cc8-44ee-9ced-594a8446d29e>quod</3f4de0cf-3cc8-44ee-9ced-594a8446d29e> quilibet <ec44812e-d5e2-4699-b1da-7e777473d1cd>Christianus</ec44812e-d5e2-4699-b1da-7e777473d1cd> in articulo 

--- a/packages/annotator/src/lib/Annotator.ts
+++ b/packages/annotator/src/lib/Annotator.ts
@@ -10,9 +10,11 @@ import { EditMode, HighlightMode } from "./constants";
 
 // Updated regex to properly handle tags with attributes
 // Opening tags: <tagname attr="value"> or <tagname>
-const openingTagRegex = /<([a-zA-Z0-9\-_]+)(?:\s+[^>]*)?>/g;
+export const openingTagRegex = /<([a-zA-Z0-9\-_\s="']+)>/g;
 // Closing tags: </tagname>
-const closingTagRegex = /<\/([a-zA-Z0-9\-_]+)>/g;
+export const closingTagRegex = /<\/([a-zA-Z0-9\-_]+)>/g;
+// General tag removal regex
+export const tagRemovalRegex = /<\/?[^<>]+?>/g;
 
 // Occurrence holds exact position of a point in text
 export interface Occurrence {
@@ -765,6 +767,23 @@ export class Annotator {
     this.text.calculateLines();
   }
 
+  /**
+   * Adds an anchor tag around the currently selected text.
+   * 
+   * This function wraps the selected text with opening and closing XML-like tags.
+   * It handles text selection bounds, sanitizes the envelope range to avoid
+   * including unwanted neighboring tags, and updates the text content accordingly.
+   * 
+   * @param anchor - The tag name to wrap around the selected text (e.g., "person", "location")
+   * @param attributes - Optional attributes to add to the opening tag (e.g., {id: "123", type: "proper"})
+   * 
+   * @example
+   * // Wrap selected text with a person tag
+   * addAnchor("person");
+   * 
+   * // Wrap selected text with a location tag and attributes
+   * addAnchor("location", {id: "loc1", type: "city"});
+   */
   addAnchor(anchor: string, attributes?: Record<string, string>) {
     if (!this.cursor.isSelected()) {
       return;
@@ -1011,9 +1030,6 @@ export class Annotator {
     let newIndex = index;
     let currentIndex = index;
 
-    // Look for consecutive closing XML tags starting from the current index
-    const closingTagRegex = /<\/([^<>]+?)>/g;
-
     while (true) {
       closingTagRegex.lastIndex = currentIndex;
       const match = closingTagRegex.exec(text);
@@ -1034,46 +1050,6 @@ export class Annotator {
   }
 
   /**
-   * Include XML tags on the left side of the given index
-   * @param index The starting index
-   * @returns The new index including tags on the left
-   */
-  private includeTagsOnLeft(index: number): number {
-    const text = this.text.value;
-    let newIndex = index;
-
-    // Look for XML tags before the current index
-    const tagRegex = /<\/?[^<>]+?>/g;
-    let match;
-    let lastTagEnd = 0;
-
-    while ((match = tagRegex.exec(text)) !== null) {
-      if (match.index < index) {
-        // Keep track of the end position of the last tag before our index
-        lastTagEnd = match.index + match[0].length;
-      } else {
-        // We've reached tags at or after our index, stop
-        break;
-      }
-    }
-
-    // If we found tags before our index, start from the beginning of the first tag
-    if (lastTagEnd > 0) {
-      // Find the start of the first tag that ends before or at our index
-      tagRegex.lastIndex = 0;
-      while ((match = tagRegex.exec(text)) !== null) {
-        if (match.index + match[0].length <= index) {
-          newIndex = match.index;
-        } else {
-          break;
-        }
-      }
-    }
-
-    return newIndex;
-  }
-
-  /**
    * Prevent overlapping anchors by ensuring proper nesting
    * When a shorter span selection arrives at the end of another anchor, the shorter span should be within the longer span
    * When a longer span is selected, the anchors should encompass the shorter span
@@ -1086,7 +1062,7 @@ export class Annotator {
     indexEnd: number
   ): [number, number] {
     const text = this.text.value;
-
+  
     // Case 1: Check if selection starts at the beginning of an opening tag
     const currentSelection = text.slice(indexStart, indexEnd);
     
@@ -1099,7 +1075,6 @@ export class Annotator {
       indexStart = openingTagEnd;
     }
     
-
     // Case 2: Check if selection ends with a closing tag that was added by skipTagsOnRight
     const updatedSelection = text.slice(indexStart, indexEnd);
     if (updatedSelection.endsWith(">") && updatedSelection.includes("</")) {

--- a/packages/annotator/src/lib/Annotator.ts
+++ b/packages/annotator/src/lib/Annotator.ts
@@ -1071,9 +1071,22 @@ export class Annotator {
     openingTagRegex.lastIndex = 0; // Reset regex
     const openingMatch = openingTagRegex.exec(currentSelection);
     if (openingMatch && openingMatch.index === 0) {
-      // Selection starts with an opening tag, move start to after the tag
+      // Selection starts with an opening tag
       const openingTagEnd = indexStart + openingMatch[0].length;
-      indexStart = openingTagEnd;
+      const tagName = openingMatch[1].trim().split(/\s+/)[0];
+      
+      // Check if the selection contains the complete tag (opening + content + closing)
+      const selectionAfterOpening = text.slice(openingTagEnd, indexEnd);
+      const closingPattern = createOpeningTagRegex(tagName);
+      const closingMatch = closingTagRegex.exec(selectionAfterOpening);
+      
+      if (closingMatch) {
+        // Complete tag is within selection, keep the entire tag
+        // Don't modify indexStart - keep the opening tag
+      } else {
+        // Incomplete tag, move start to after the opening tag
+        indexStart = openingTagEnd;
+      }
     }
     
     // Case 2: Check if selection ends with closing tags that don't belong to content within the selection

--- a/packages/annotator/src/lib/Annotator.ts
+++ b/packages/annotator/src/lib/Annotator.ts
@@ -768,7 +768,7 @@ export class Annotator {
 
       // Check if indexStart position coincides with another tag in the segment
       const segmentPosition = this.text.getSegmentFromAbsTextIndex(indexStart);
-      if (segmentPosition) {  
+      if (segmentPosition) {
         const segment = this.text.segments[segmentPosition.segmentIndex];
         const startRawTextIndex = segmentPosition.rawTextIndex;
         const openingTagAtPosition = segment.openingTags.find(
@@ -786,7 +786,7 @@ export class Annotator {
             const existingTagContentSize =
               correspondingClosingTag.position - openingTagAtPosition.position;
             const newSelectionSize = indexEnd - indexStart;
-            console.log(existingTagContentSize, newSelectionSize)
+            console.log(existingTagContentSize, newSelectionSize);
             if (existingTagContentSize > newSelectionSize) {
               // Move start index to the right, making the new selection smaller
               indexStart += openingTagAtPosition.tag.length + 2;
@@ -952,22 +952,27 @@ export class Annotator {
   }
 
   onPasteText() {
-    window.navigator.clipboard.readText().then((clipText: string) => {
-      const area = this.cursor.getSelectedArea();
-      if (area) {
-        this.text.deleteRangeText(area[0], area[1]);
-        this.cursor.reset();
-        this.cursor.setPosition(
-          area[0].xLine,
-          area[0].yLine - this.viewport.lineStart
-        );
-      }
-      this.text.insertText(this.viewport, this.cursor, clipText);
-      this.cursor.move(clipText.length, 0);
-      this.cursor.fixOutOfBounds(this.viewport, this.text);
+    window.navigator.clipboard
+      .readText()
+      .then((clipText: string) => {
+        const area = this.cursor.getSelectedArea();
+        if (area) {
+          this.text.deleteRangeText(area[0], area[1]);
+          this.cursor.reset();
+          this.cursor.setPosition(
+            area[0].xLine,
+            area[0].yLine - this.viewport.lineStart
+          );
+        }
+        this.text.insertText(this.viewport, this.cursor, clipText);
+        this.cursor.move(clipText.length, 0);
+        this.cursor.fixOutOfBounds(this.viewport, this.text);
 
-      this.draw();
-    });
+        this.draw();
+      })
+      .catch((err) => {
+        console.error("Error reading clipboard", err);
+      });
   }
 
   onReplaceText(text: string) {

--- a/packages/annotator/src/lib/Annotator.ts
+++ b/packages/annotator/src/lib/Annotator.ts
@@ -5,6 +5,7 @@ import { Lines } from "./Lines";
 import Scroller from "./Scroller";
 import Text, { ITag, SegmentPosition } from "./Text";
 import Viewport from "./Viewport";
+import { Warnings } from "./warnings";
 import { EditMode, HighlightMode } from "./constants";
 
 // Occurrence holds exact position of a point in text
@@ -70,6 +71,7 @@ export class Annotator {
   scroller?: Scroller;
   lines?: Lines;
   keys: Keys;
+  warnings: Warnings;
 
   annotatedPosition: SegmentPosition | null = null;
 
@@ -131,6 +133,7 @@ export class Annotator {
     this.cursor = new Cursor(this.ratio, 0, 0);
 
     this.keys = new Keys(this);
+    this.warnings = new Warnings();
 
     this.bgColor = this.element.style.backgroundColor || "white";
     this.fontColor = this.element.style.color || "black";
@@ -245,6 +248,7 @@ export class Annotator {
 
         // update annotator
         // this.text.prepareSegments();
+        this.warnings.onTextChanged(this.text.value);
         this.draw();
       }
     }
@@ -298,6 +302,10 @@ export class Annotator {
 
   onTextChanged(cb: (text: string) => void): void {
     this.onTextChangeCb = cb;
+  }
+
+  onWarning(cb: (message: string) => void): void {
+    this.warnings.onWarning(cb);
   }
 
   /**
@@ -834,6 +842,7 @@ export class Annotator {
       this.text.prepareSegments();
       this.text.calculateLines();
       this.cursor.reset();
+      this.warnings.onTextChanged(this.text.value);
       this.draw();
     }
   }
@@ -860,6 +869,7 @@ export class Annotator {
     this.text.value = newText;
     this.text.prepareSegments();
     this.text.calculateLines();
+    this.warnings.onTextChanged(this.text.value);
 
     if (positionBeforeChange < this.text.noLines) {
       this.scrollToLine(positionBeforeChange);
@@ -968,6 +978,7 @@ export class Annotator {
         this.cursor.move(clipText.length, 0);
         this.cursor.fixOutOfBounds(this.viewport, this.text);
 
+        this.warnings.onTextChanged(this.text.value);
         this.draw();
       })
       .catch((err) => {
@@ -989,7 +1000,29 @@ export class Annotator {
     this.cursor.move(text.length, 0);
     this.cursor.fixOutOfBounds(this.viewport, this.text);
 
+    this.warnings.onTextChanged(this.text.value);
     this.draw();
+  }
+
+  /**
+   * Enable warnings system
+   */
+  enableWarnings(): void {
+    this.warnings.enable();
+  }
+
+  /**
+   * Disable warnings system
+   */
+  disableWarnings(): void {
+    this.warnings.disable();
+  }
+
+  /**
+   * Check if warnings are enabled
+   */
+  isWarningsEnabled(): boolean {
+    return this.warnings.isEnabled();
   }
 
   /**

--- a/packages/annotator/src/lib/Annotator.ts
+++ b/packages/annotator/src/lib/Annotator.ts
@@ -171,7 +171,7 @@ export class Annotator {
    * @param anchor
    */
   removeAnchorFromSelection(anchor: string) {
-    const [start, end] = this.cursor.getBounds();
+    const [start, end] = this.cursor.getAbsBounds();
 
     if (start && end) {
       this.text.getSegmentPosition(start.yLine, start.xLine) as SegmentPosition;
@@ -267,7 +267,7 @@ export class Annotator {
     const positionBeforeRel = this.viewport.lineStart / this.text.noLines;
 
     // FIXME try to update the cursor position based on the text that was selected before the resize
-    const [start, end] = this.cursor.getBounds();
+    const [start, end] = this.cursor.getAbsBounds();
     const selectedTextBefore =
       start && end ? this.text.getRangeText(start, end) : "";
 
@@ -618,7 +618,7 @@ export class Annotator {
 
     // if (this.onSelectTextCb && this.cursor.isSelected()) {
     if (this.onSelectTextCb) {
-      const [start, end] = this.cursor.getBounds();
+      const [start, end] = this.cursor.getAbsBounds();
       if (
         start &&
         end &&
@@ -756,17 +756,77 @@ export class Annotator {
       return;
     }
 
-    let [start, end] = this.cursor.getBounds();
+    // get bounds of the selection
+    let [start, end] = this.cursor.getAbsBounds();
     if (start && end) {
-      const indexPositionStart = this.text.getAbsTextIndex(start);
-      const indexPositionEnd = this.text.getAbsTextIndex(end);
-      const beforeText = this.text.value.slice(0, indexPositionStart);
-      const afterText = this.text.value.slice(indexPositionEnd);
-
-      const insideText = this.text.value.slice(
-        indexPositionStart,
-        indexPositionEnd
+      let indexStart = this.text.getAbsTextIndexFromPosition(
+        this.text.getSegmentPosition(start.yLine, start.xLine, true)
       );
+      let indexEnd = this.text.getAbsTextIndexFromPosition(
+        this.text.getSegmentPosition(end.yLine, end.xLine, true)
+      );
+
+      // Check if indexStart position coincides with another tag in the segment
+      const segmentPosition = this.text.getSegmentFromAbsTextIndex(indexStart);
+      if (segmentPosition) {  
+        const segment = this.text.segments[segmentPosition.segmentIndex];
+        const startRawTextIndex = segmentPosition.rawTextIndex;
+        const openingTagAtPosition = segment.openingTags.find(
+          (tag) => tag.position === startRawTextIndex
+        );
+        if (openingTagAtPosition) {
+          // Find the corresponding closing tag to calculate content size
+          const correspondingClosingTag = segment.closingTags.find(
+            (tag) =>
+              tag.tag === openingTagAtPosition.tag &&
+              tag.position > openingTagAtPosition.position
+          );
+
+          if (correspondingClosingTag) {
+            const existingTagContentSize =
+              correspondingClosingTag.position - openingTagAtPosition.position;
+            const newSelectionSize = indexEnd - indexStart;
+            console.log(existingTagContentSize, newSelectionSize)
+            if (existingTagContentSize > newSelectionSize) {
+              // Move start index to the right, making the new selection smaller
+              indexStart += openingTagAtPosition.tag.length + 2;
+            }
+          }
+        }
+      }
+
+      // Check if indexEnd position coincides with another tag in the segment
+      const endSegmentPosition = this.text.getSegmentFromAbsTextIndex(indexEnd);
+      if (endSegmentPosition) {
+        const endSegment = this.text.segments[endSegmentPosition.segmentIndex];
+        const endRawTextIndex = endSegmentPosition.rawTextIndex;
+        const closingTagAtEndPosition = endSegment.closingTags.find(
+          (tag) => tag.position === endRawTextIndex
+        );
+        if (closingTagAtEndPosition) {
+          // Find the corresponding opening tag to calculate content size
+          const correspondingOpeningTag = endSegment.openingTags.find(
+            (tag) =>
+              tag.tag === closingTagAtEndPosition.tag &&
+              tag.position < closingTagAtEndPosition.position
+          );
+          if (correspondingOpeningTag) {
+            const existingTagContentSize =
+              closingTagAtEndPosition.position -
+              correspondingOpeningTag.position;
+            const newSelectionSize = indexEnd - indexStart;
+
+            if (existingTagContentSize < newSelectionSize) {
+              // new selection is larger than existing selection, push indexEnd after the closing tag
+              indexEnd += closingTagAtEndPosition.tag.length + 3;
+            }
+          }
+        }
+      }
+
+      const beforeText = this.text.value.slice(0, indexStart);
+      const afterText = this.text.value.slice(indexEnd);
+      const insideText = this.text.value.slice(indexStart, indexEnd);
 
       this.text.value =
         beforeText + `<${anchor}>` + insideText + `</${anchor}>` + afterText;
@@ -864,7 +924,7 @@ export class Annotator {
 
     // Manually trigger onSelectText callback for search-based selections
     if (this.onSelectTextCb) {
-      const [start, end] = this.cursor.getBounds();
+      const [start, end] = this.cursor.getAbsBounds();
 
       if (start && end) {
         const startSegment = this.text.getSegmentPosition(

--- a/packages/annotator/src/lib/Annotator.ts
+++ b/packages/annotator/src/lib/Annotator.ts
@@ -1073,16 +1073,26 @@ export class Annotator {
     if (openingMatch && openingMatch.index === 0) {
       // Selection starts with an opening tag
       const openingTagEnd = indexStart + openingMatch[0].length;
-      const tagName = openingMatch[1].trim().split(/\s+/)[0];
       
       // Check if the selection contains the complete tag (opening + content + closing)
       const selectionAfterOpening = text.slice(openingTagEnd, indexEnd);
-      const closingPattern = createOpeningTagRegex(tagName);
+      closingTagRegex.lastIndex = 0; // Reset regex
       const closingMatch = closingTagRegex.exec(selectionAfterOpening);
       
       if (closingMatch) {
-        // Complete tag is within selection, keep the entire tag
-        // Don't modify indexStart - keep the opening tag
+        // Complete tag is within selection
+        const closingTagStart = openingTagEnd + closingMatch.index;
+        const closingTagEnd = closingTagStart + closingMatch[0].length;
+        
+        // If selection extends beyond the complete tag, keep the entire selection
+        // If selection is exactly the complete tag or smaller, keep the entire tag
+        if (indexEnd >= closingTagEnd) {
+          // Selection is larger than or equal to the complete tag - keep everything
+          // Don't modify indexStart - keep the opening tag
+        } else {
+          // Selection is smaller than the complete tag - keep the entire tag
+          indexEnd = closingTagEnd;
+        }
       } else {
         // Incomplete tag, move start to after the opening tag
         indexStart = openingTagEnd;

--- a/packages/annotator/src/lib/Annotator.ts
+++ b/packages/annotator/src/lib/Annotator.ts
@@ -15,6 +15,8 @@ export const openingTagRegex = /<([a-zA-Z0-9\-_\s="']+)>/g;
 export const closingTagRegex = /<\/([a-zA-Z0-9\-_]+)>/g;
 // General tag removal regex
 export const tagRemovalRegex = /<\/?[^<>]+?>/g;
+// Opening tag with specific name and optional attributes: <tagname attr="value"> or <tagname>
+export const createOpeningTagRegex = (tagName: string) => new RegExp(`<${tagName}(?:\\s+[^>]*)?>`, 'g');
 
 // Occurrence holds exact position of a point in text
 export interface Occurrence {
@@ -809,9 +811,9 @@ export class Annotator {
       // Move endIndex after tags on the right to avoid gathering additional non-XML tag characters
       // after this we have envelope around neighboring tags
       indexEnd = this.skipTagsOnRight(indexEnd);
-
       // Sanitize envelope range by removing enveloping tags from both left and right sides
       [indexStart, indexEnd] = this.sanitizeEnvelopeRange(indexStart, indexEnd);
+
       // could be '<tag>text .... text</tag> (closing tag always included if present)
       const selectedRawText = this.text.value.slice(indexStart, indexEnd);
       const beforeText = this.text.value.slice(0, indexStart);
@@ -1062,7 +1064,6 @@ export class Annotator {
     indexEnd: number
   ): [number, number] {
     const text = this.text.value;
-  
     // Case 1: Check if selection starts at the beginning of an opening tag
     const currentSelection = text.slice(indexStart, indexEnd);
     
@@ -1075,41 +1076,47 @@ export class Annotator {
       indexStart = openingTagEnd;
     }
     
-    // Case 2: Check if selection ends with a closing tag that was added by skipTagsOnRight
+    // Case 2: Check if selection ends with closing tags that don't belong to content within the selection
     const updatedSelection = text.slice(indexStart, indexEnd);
     if (updatedSelection.endsWith(">") && updatedSelection.includes("</")) {
-      // Find the last closing tag in the selection
-      let lastClosingTag = null;
+      // Find all closing tags in the selection
       let match;
       closingTagRegex.lastIndex = 0;
+      const closingTagsInSelection = [];
 
       while ((match = closingTagRegex.exec(updatedSelection)) !== null) {
-        lastClosingTag = {
+        closingTagsInSelection.push({
           tagName: match[1],
           start: indexStart + match.index,
           end: indexStart + match.index + match[0].length,
-        };
+        });
       }
 
-      if (lastClosingTag) {
-        // Check if this closing tag has a matching opening tag before the selection
-        const beforeSelection = text.slice(0, indexStart);
-        const openingTagName = lastClosingTag.tagName;
-        const openingPattern = new RegExp(`<${openingTagName}(?:\\s+[^>]*)?>`, 'g');
+      // Process closing tags from right to left (last to first)
+      for (let i = closingTagsInSelection.length - 1; i >= 0; i--) {
+        const closingTag = closingTagsInSelection[i];
+        const openingTagName = closingTag.tagName;
+        const openingPattern = createOpeningTagRegex(openingTagName);
         let openingMatch;
-        let lastOpeningTag = null;
+        let hasMatchingOpeningInSelection = false;
 
-        while ((openingMatch = openingPattern.exec(beforeSelection)) !== null) {
-          lastOpeningTag = {
-            start: openingMatch.index,
-            end: openingMatch.index + openingMatch[0].length,
-          };
+        // Check if there's a matching opening tag within the selection
+        while ((openingMatch = openingPattern.exec(updatedSelection)) !== null) {
+          const openingTagStart = indexStart + openingMatch.index;
+          const openingTagEnd = openingTagStart + openingMatch[0].length;
+          
+          // Only keep the closing tag if the opening tag is completely within the selection
+          // and the opening tag comes before the closing tag
+          if (openingTagStart >= indexStart && openingTagEnd <= closingTag.start && 
+              openingTagEnd <= indexEnd) {
+            hasMatchingOpeningInSelection = true;
+            break;
+          }
         }
 
-        if (lastOpeningTag && lastOpeningTag.end <= indexStart) {
-          // This closing tag belongs to an opening tag before the selection
-          // Remove the closing tag from the end
-          indexEnd = lastClosingTag.start;
+        // If no matching opening tag found within the selection, remove this closing tag
+        if (!hasMatchingOpeningInSelection) {
+          indexEnd = closingTag.start;
         }
       }
     }

--- a/packages/annotator/src/lib/Annotator.ts
+++ b/packages/annotator/src/lib/Annotator.ts
@@ -3,7 +3,7 @@ import Highlighter, { IAbsCoordinates, CursorStyle } from "./Highlighter";
 import Keys from "./Keys";
 import { Lines } from "./Lines";
 import Scroller from "./Scroller";
-import Text, { ITag, SegmentPosition } from "./Text";
+import Text, { Tag, SegmentPosition } from "./Text";
 import Viewport from "./Viewport";
 import { Warnings } from "./warnings";
 import { EditMode, HighlightMode } from "./constants";
@@ -485,7 +485,7 @@ export class Annotator {
     // find still opened until current window
     for (let i = 0; i <= start.segmentIndex; i++) {
       const segment = this.text.segments[i];
-      let openingTags, closingTags: ITag[];
+      let openingTags, closingTags: Tag[];
       if (i === start.segmentIndex) {
         [openingTags, closingTags] = segment.getTagsBeforePosition(
           start.rawTextIndex
@@ -505,7 +505,7 @@ export class Annotator {
     // use everything that is between start and end
     for (let i = start.segmentIndex; i < end.segmentIndex; i++) {
       const segment = this.text.segments[i];
-      let openingTags, closingTags: ITag[];
+      let openingTags, closingTags: Tag[];
       if (i === start.segmentIndex) {
         [openingTags, closingTags] = segment.getTagsAfterPosition(
           start.rawTextIndex
@@ -523,7 +523,7 @@ export class Annotator {
 
     // process end segment
     const endSegment = this.text.segments[end.segmentIndex];
-    let opened, closed: ITag[];
+    let opened, closed: Tag[];
     if (start.segmentIndex !== end.segmentIndex) {
       // if end segment != start segment - use everything up to end position
       [opened, closed] = endSegment.getTagsBeforePosition(end.rawTextIndex);
@@ -759,10 +759,17 @@ export class Annotator {
     this.text.calculateLines();
   }
 
-  addAnchor(anchor: string) {
+  addAnchor(anchor: string, attributes?: Record<string, string>) {
     if (!this.cursor.isSelected()) {
       return;
     }
+
+    // Construct the Tag at the start
+    const openTag = new Tag(0, anchor, false);
+    if (attributes) {
+      openTag.attributes = attributes;
+    }
+    const closeTag = new Tag(0, anchor, true);
 
     // get bounds of the selection
     let [start, end] = this.cursor.getAbsBounds();
@@ -794,10 +801,9 @@ export class Annotator {
             const existingTagContentSize =
               correspondingClosingTag.position - openingTagAtPosition.position;
             const newSelectionSize = indexEnd - indexStart;
-            console.log(existingTagContentSize, newSelectionSize);
             if (existingTagContentSize > newSelectionSize) {
               // Move start index to the right, making the new selection smaller
-              indexStart += openingTagAtPosition.tag.length + 2;
+              indexStart += openingTagAtPosition.getTag().length;
             }
           }
         }
@@ -826,7 +832,7 @@ export class Annotator {
 
             if (existingTagContentSize < newSelectionSize) {
               // new selection is larger than existing selection, push indexEnd after the closing tag
-              indexEnd += closingTagAtEndPosition.tag.length + 3;
+              indexEnd += closingTagAtEndPosition.getTag().length;
             }
           }
         }
@@ -837,7 +843,7 @@ export class Annotator {
       const insideText = this.text.value.slice(indexStart, indexEnd);
 
       this.text.value =
-        beforeText + `<${anchor}>` + insideText + `</${anchor}>` + afterText;
+        beforeText + openTag.getTag() + insideText + closeTag.getTag() + afterText;
 
       this.text.prepareSegments();
       this.text.calculateLines();

--- a/packages/annotator/src/lib/Annotator.ts
+++ b/packages/annotator/src/lib/Annotator.ts
@@ -8,6 +8,12 @@ import Viewport from "./Viewport";
 import { Warnings } from "./warnings";
 import { EditMode, HighlightMode } from "./constants";
 
+// Updated regex to properly handle tags with attributes
+// Opening tags: <tagname attr="value"> or <tagname>
+const openingTagRegex = /<([a-zA-Z0-9\-_]+)(?:\s+[^>]*)?>/g;
+// Closing tags: </tagname>
+const closingTagRegex = /<\/([a-zA-Z0-9\-_]+)>/g;
+
 // Occurrence holds exact position of a point in text
 export interface Occurrence {
   segmentIndex: number;
@@ -781,69 +787,23 @@ export class Annotator {
         this.text.getSegmentPosition(end.yLine, end.xLine, true)
       );
 
-      // Check if indexStart position coincides with another tag in the segment
-      const segmentPosition = this.text.getSegmentFromAbsTextIndex(indexStart);
-      if (segmentPosition) {
-        const segment = this.text.segments[segmentPosition.segmentIndex];
-        const startRawTextIndex = segmentPosition.rawTextIndex;
-        const openingTagAtPosition = segment.openingTags.find(
-          (tag) => tag.position === startRawTextIndex
-        );
-        if (openingTagAtPosition) {
-          // Find the corresponding closing tag to calculate content size
-          const correspondingClosingTag = segment.closingTags.find(
-            (tag) =>
-              tag.tag === openingTagAtPosition.tag &&
-              tag.position > openingTagAtPosition.position
-          );
+      // Move endIndex after tags on the right to avoid gathering additional non-XML tag characters
+      // after this we have envelope around neighboring tags
+      indexEnd = this.skipTagsOnRight(indexEnd);
 
-          if (correspondingClosingTag) {
-            const existingTagContentSize =
-              correspondingClosingTag.position - openingTagAtPosition.position;
-            const newSelectionSize = indexEnd - indexStart;
-            if (existingTagContentSize > newSelectionSize) {
-              // Move start index to the right, making the new selection smaller
-              indexStart += openingTagAtPosition.getTag().length;
-            }
-          }
-        }
-      }
-
-      // Check if indexEnd position coincides with another tag in the segment
-      const endSegmentPosition = this.text.getSegmentFromAbsTextIndex(indexEnd);
-      if (endSegmentPosition) {
-        const endSegment = this.text.segments[endSegmentPosition.segmentIndex];
-        const endRawTextIndex = endSegmentPosition.rawTextIndex;
-        const closingTagAtEndPosition = endSegment.closingTags.find(
-          (tag) => tag.position === endRawTextIndex
-        );
-        if (closingTagAtEndPosition) {
-          // Find the corresponding opening tag to calculate content size
-          const correspondingOpeningTag = endSegment.openingTags.find(
-            (tag) =>
-              tag.tag === closingTagAtEndPosition.tag &&
-              tag.position < closingTagAtEndPosition.position
-          );
-          if (correspondingOpeningTag) {
-            const existingTagContentSize =
-              closingTagAtEndPosition.position -
-              correspondingOpeningTag.position;
-            const newSelectionSize = indexEnd - indexStart;
-
-            if (existingTagContentSize < newSelectionSize) {
-              // new selection is larger than existing selection, push indexEnd after the closing tag
-              indexEnd += closingTagAtEndPosition.getTag().length;
-            }
-          }
-        }
-      }
-
+      // Sanitize envelope range by removing enveloping tags from both left and right sides
+      [indexStart, indexEnd] = this.sanitizeEnvelopeRange(indexStart, indexEnd);
+      // could be '<tag>text .... text</tag> (closing tag always included if present)
+      const selectedRawText = this.text.value.slice(indexStart, indexEnd);
       const beforeText = this.text.value.slice(0, indexStart);
       const afterText = this.text.value.slice(indexEnd);
-      const insideText = this.text.value.slice(indexStart, indexEnd);
 
       this.text.value =
-        beforeText + openTag.getTag() + insideText + closeTag.getTag() + afterText;
+        beforeText +
+        openTag.getTag() +
+        selectedRawText +
+        closeTag.getTag() +
+        afterText;
 
       this.text.prepareSegments();
       this.text.calculateLines();
@@ -1038,4 +998,148 @@ export class Annotator {
     this.cursor.reset();
     this.draw();
   }
+
+  /**
+   * Skip closing XML tags on the right side of the given index to avoid gathering additional non-XML tag characters
+   * Only moves over closing tags when the selection ends exactly at the tag boundary, not when followed by normal text
+   * Includes all consecutive closing tags
+   * @param index The starting index
+   * @returns The new index after skipping consecutive closing tags on the right
+   */
+  private skipTagsOnRight(index: number): number {
+    const text = this.text.value;
+    let newIndex = index;
+    let currentIndex = index;
+
+    // Look for consecutive closing XML tags starting from the current index
+    const closingTagRegex = /<\/([^<>]+?)>/g;
+
+    while (true) {
+      closingTagRegex.lastIndex = currentIndex;
+      const match = closingTagRegex.exec(text);
+
+      // If we find a closing tag that starts exactly at our current position
+      if (match && match.index === currentIndex) {
+        // Move the index to the end of this closing tag
+        newIndex = match.index + match[0].length;
+        currentIndex = newIndex;
+        // Continue looking for more consecutive closing tags
+      } else {
+        // No more consecutive closing tags, stop
+        break;
+      }
+    }
+
+    return newIndex;
+  }
+
+  /**
+   * Include XML tags on the left side of the given index
+   * @param index The starting index
+   * @returns The new index including tags on the left
+   */
+  private includeTagsOnLeft(index: number): number {
+    const text = this.text.value;
+    let newIndex = index;
+
+    // Look for XML tags before the current index
+    const tagRegex = /<\/?[^<>]+?>/g;
+    let match;
+    let lastTagEnd = 0;
+
+    while ((match = tagRegex.exec(text)) !== null) {
+      if (match.index < index) {
+        // Keep track of the end position of the last tag before our index
+        lastTagEnd = match.index + match[0].length;
+      } else {
+        // We've reached tags at or after our index, stop
+        break;
+      }
+    }
+
+    // If we found tags before our index, start from the beginning of the first tag
+    if (lastTagEnd > 0) {
+      // Find the start of the first tag that ends before or at our index
+      tagRegex.lastIndex = 0;
+      while ((match = tagRegex.exec(text)) !== null) {
+        if (match.index + match[0].length <= index) {
+          newIndex = match.index;
+        } else {
+          break;
+        }
+      }
+    }
+
+    return newIndex;
+  }
+
+  /**
+   * Prevent overlapping anchors by ensuring proper nesting
+   * When a shorter span selection arrives at the end of another anchor, the shorter span should be within the longer span
+   * When a longer span is selected, the anchors should encompass the shorter span
+   * @param indexStart The current start index
+   * @param indexEnd The current end index
+   * @returns The new [indexStart, indexEnd] after preventing overlaps
+   */
+  private sanitizeEnvelopeRange(
+    indexStart: number,
+    indexEnd: number
+  ): [number, number] {
+    const text = this.text.value;
+
+    // Case 1: Check if selection starts at the beginning of an opening tag
+    const currentSelection = text.slice(indexStart, indexEnd);
+    
+    // Check if the selection itself starts with an opening tag
+    openingTagRegex.lastIndex = 0; // Reset regex
+    const openingMatch = openingTagRegex.exec(currentSelection);
+    if (openingMatch && openingMatch.index === 0) {
+      // Selection starts with an opening tag, move start to after the tag
+      const openingTagEnd = indexStart + openingMatch[0].length;
+      indexStart = openingTagEnd;
+    }
+    
+
+    // Case 2: Check if selection ends with a closing tag that was added by skipTagsOnRight
+    const updatedSelection = text.slice(indexStart, indexEnd);
+    if (updatedSelection.endsWith(">") && updatedSelection.includes("</")) {
+      // Find the last closing tag in the selection
+      let lastClosingTag = null;
+      let match;
+      closingTagRegex.lastIndex = 0;
+
+      while ((match = closingTagRegex.exec(updatedSelection)) !== null) {
+        lastClosingTag = {
+          tagName: match[1],
+          start: indexStart + match.index,
+          end: indexStart + match.index + match[0].length,
+        };
+      }
+
+      if (lastClosingTag) {
+        // Check if this closing tag has a matching opening tag before the selection
+        const beforeSelection = text.slice(0, indexStart);
+        const openingTagName = lastClosingTag.tagName;
+        const openingPattern = new RegExp(`<${openingTagName}(?:\\s+[^>]*)?>`, 'g');
+        let openingMatch;
+        let lastOpeningTag = null;
+
+        while ((openingMatch = openingPattern.exec(beforeSelection)) !== null) {
+          lastOpeningTag = {
+            start: openingMatch.index,
+            end: openingMatch.index + openingMatch[0].length,
+          };
+        }
+
+        if (lastOpeningTag && lastOpeningTag.end <= indexStart) {
+          // This closing tag belongs to an opening tag before the selection
+          // Remove the closing tag from the end
+          indexEnd = lastClosingTag.start;
+        }
+      }
+    }
+
+    return [indexStart, indexEnd];
+  }
+
 }

--- a/packages/annotator/src/lib/Cursor.ts
+++ b/packages/annotator/src/lib/Cursor.ts
@@ -107,7 +107,7 @@ export default class Cursor
    * @returns
    */
   getSelectedArea(): [IAbsCoordinates, IAbsCoordinates] | null {
-    const selected = this.getBounds();
+    const selected = this.getAbsBounds();
     if (
       selected[0] === undefined ||
       selected[1] === undefined ||
@@ -121,10 +121,10 @@ export default class Cursor
   }
 
   /**
-   * getSelected is getter for absolute selected coordinates
+   * getAbsBounds is getter for absolute selected coordinates start->end
    * @returns
    */
-  getBounds(): [IAbsCoordinates | undefined, IAbsCoordinates | undefined] {
+  getAbsBounds(): [IAbsCoordinates | undefined, IAbsCoordinates | undefined] {
     if (!this.selectStart || !this.selectEnd) {
       return [undefined, undefined];
     }
@@ -237,7 +237,7 @@ export default class Cursor
       return;
     }
 
-    let [hStart, hEnd] = this.getBounds();
+    let [hStart, hEnd] = this.getAbsBounds();
 
     const rowsToDraw: { rowI: number; start: number; end: number }[] = [];
 

--- a/packages/annotator/src/lib/Highlighter.ts
+++ b/packages/annotator/src/lib/Highlighter.ts
@@ -68,7 +68,7 @@ export default class Highlighter {
    * getSelected is getter for absolute selected coordinates
    * @returns
    */
-  getBounds(): [IAbsCoordinates | undefined, IAbsCoordinates | undefined] {
+  getAbsBounds(): [IAbsCoordinates | undefined, IAbsCoordinates | undefined] {
     if (!this.selectStart || !this.selectEnd) {
       return [undefined, undefined];
     }
@@ -149,7 +149,7 @@ export default class Highlighter {
   ) {
     const { charsAtLine } = drawingOptions;
 
-    let [hStart, hEnd] = this.getBounds();
+    let [hStart, hEnd] = this.getAbsBounds();
     if (hStart && hEnd) {
       if (hStart.yLine > hEnd.yLine) {
         [hStart, hEnd] = [hEnd, hStart];

--- a/packages/annotator/src/lib/Text.ts
+++ b/packages/annotator/src/lib/Text.ts
@@ -2,10 +2,63 @@ import Viewport from "./Viewport";
 import { IAbsCoordinates, IRelativeCoordinates } from "./Highlighter";
 import { EditMode } from "./constants";
 
-export interface ITag {
+export class Tag {
   position: number;
   tag: string;
   closing?: boolean;
+  attributes: Record<string, string>;
+
+  constructor(position: number, tag: string, closing?: boolean) {
+    this.position = position;
+    this.tag = tag;
+    this.closing = closing;
+    this.attributes = this.parseAttributes(tag);
+  }
+
+  private parseAttributes(tagString: string): Record<string, string> {
+    const attributes: Record<string, string> = {};
+    
+    // Split the tag string to separate tag name from attributes
+    const parts = tagString.trim().split(/\s+/);
+    
+    // If there are no attributes, return empty object
+    if (parts.length === 1) {
+      return attributes;
+    }
+    
+    // Parse attributes from the remaining parts
+    for (let i = 1; i < parts.length; i++) {
+      const part = parts[i];
+      const equalIndex = part.indexOf('=');
+      
+      if (equalIndex > 0) {
+        const key = part.substring(0, equalIndex);
+        let value = part.substring(equalIndex + 1);
+        
+        // Remove quotes if present
+        if ((value.startsWith('"') && value.endsWith('"')) || 
+            (value.startsWith("'") && value.endsWith("'"))) {
+          value = value.slice(1, -1);
+        }
+        
+        attributes[key] = value;
+      }
+    }
+    
+    return attributes;
+  }
+
+  getTag(): string {
+    if (this.closing) {
+      return `</${this.tag}>`;
+    }
+    let openTag = `<${this.tag}`;
+    for (const [key, value] of Object.entries(this.attributes)) {
+      openTag += ` ${key}="${value}"`;
+    }
+    openTag += '>';
+    return openTag;
+  }
 }
 
 export class Segment {
@@ -13,8 +66,8 @@ export class Segment {
   lineEnd: number = -1; // incl.
   raw: string;
   parsed: string = "";
-  openingTags: ITag[] = [];
-  closingTags: ITag[] = [];
+  openingTags: Tag[] = [];
+  closingTags: Tag[] = [];
   lines: string[] = [];
 
   constructor(text: string) {
@@ -31,19 +84,12 @@ export class Segment {
     // Find opening tags
     let match;
     while ((match = openingTagsRegex.exec(this.raw)) !== null) {
-      this.openingTags.push({
-        position: match.index,
-        tag: match[1],
-      });
+      this.openingTags.push(new Tag(match.index, match[1]));
     }
 
     // Find closing tags
     while ((match = closingTagsRegex.exec(this.raw)) !== null) {
-      this.closingTags.push({
-        position: match.index,
-        tag: match[1],
-        closing: true,
-      });
+      this.closingTags.push(new Tag(match.index, match[1], true));
     }
 
     // Remove tags from the text
@@ -55,9 +101,9 @@ export class Segment {
    * @param rawIndex
    * @returns
    */
-  getTagsBeforePosition(rawIndex: number): [ITag[], ITag[]] {
-    const openedTags: ITag[] = [];
-    const closedTags: ITag[] = [];
+  getTagsBeforePosition(rawIndex: number): [Tag[], Tag[]] {
+    const openedTags: Tag[] = [];
+    const closedTags: Tag[] = [];
     for (const tag of this.openingTags) {
       if (tag.position < rawIndex) {
         openedTags.push(tag);
@@ -76,9 +122,9 @@ export class Segment {
    * @param rawIndex
    * @returns
    */
-  getTagsAfterPosition(rawIndex: number): [ITag[], ITag[]] {
-    const openedTags: ITag[] = [];
-    const closedTags: ITag[] = [];
+  getTagsAfterPosition(rawIndex: number): [Tag[], Tag[]] {
+    const openedTags: Tag[] = [];
+    const closedTags: Tag[] = [];
     for (const tag of this.openingTags) {
       if (tag.position > rawIndex) {
         openedTags.push(tag);
@@ -100,9 +146,9 @@ export class Segment {
   getTagsInPosition(
     startRawIndex: number,
     endRawIndex: number
-  ): [ITag[], ITag[]] {
-    const openedTags: ITag[] = [];
-    const closedTags: ITag[] = [];
+  ): [Tag[], Tag[]] {
+    const openedTags: Tag[] = [];
+    const closedTags: Tag[] = [];
     for (const tag of this.openingTags) {
       if (tag.position < endRawIndex && tag.position > startRawIndex) {
         openedTags.push(tag);
@@ -116,7 +162,7 @@ export class Segment {
     return [openedTags, closedTags];
   }
 
-  findTagParsedPosition(tag: ITag): { x: number; y: number } {
+  findTagParsedPosition(tag: Tag): { x: number; y: number } {
     // find abs position right after the <tag> in segment's text
     let parsedTextOpenPosition = this.openingTags
       .filter((t) => t.position < tag.position)
@@ -851,8 +897,8 @@ class Text {
   }
 
   getTagPosition(tag: string, index: number = 0): IAbsCoordinates[] {
-    let openingTagMatch: { tag: ITag; segment: Segment } | null = null;
-    let closingTagMatch: { tag: ITag; segment: Segment } | null = null;
+    let openingTagMatch: { tag: Tag; segment: Segment } | null = null;
+    let closingTagMatch: { tag: Tag; segment: Segment } | null = null;
 
     let openingTagIndex = 0;
     let closingTagIndex = 0;

--- a/packages/annotator/src/lib/Text.ts
+++ b/packages/annotator/src/lib/Text.ts
@@ -322,10 +322,7 @@ class Text {
    * @returns
    */
   getAbsTextIndex(absCoords: IAbsCoordinates): number {
-    const pos = this.getSegmentPosition(
-      absCoords.yLine,
-      absCoords.xLine,
-    );
+    const pos = this.getSegmentPosition(absCoords.yLine, absCoords.xLine);
     if (!pos) {
       return -1;
     }
@@ -350,6 +347,117 @@ class Text {
   }
 
   /**
+   * getSegmentFromAbsTextIndex returns segment position from absolute text index
+   * @param absTextIndex
+   * @returns
+   */
+  getSegmentFromAbsTextIndex(absTextIndex: number): SegmentPosition | null {
+    if (absTextIndex < 0 || this.segments.length === 0) {
+      return null;
+    }
+
+    let currentIndex = 0;
+
+    // Find which segment contains this absolute text index
+    for (
+      let segmentIndex = 0;
+      segmentIndex < this.segments.length;
+      segmentIndex++
+    ) {
+      const segment = this.segments[segmentIndex];
+      const segmentLength = segment.raw.length;
+
+      // Check if the index falls within this segment
+      if (absTextIndex < currentIndex + segmentLength) {
+        const rawTextIndex = absTextIndex - currentIndex;
+
+        // Calculate parsed text index by accounting for tags
+        let parsedTextIndex = rawTextIndex;
+        if (this.mode !== EditMode.RAW) {
+          const tags = segment.openingTags
+            .concat(segment.closingTags)
+            .sort((a, b) => a.position - b.position);
+
+          for (const tag of tags) {
+            if (tag.position <= rawTextIndex) {
+              parsedTextIndex -= tag.tag.length + (tag.closing ? 3 : 2);
+            }
+          }
+        }
+
+        // Find line index and character position within the line
+        let lineIndex = 0;
+        let charInLineIndex = parsedTextIndex;
+        let remainingChars = parsedTextIndex;
+
+        for (let i = 0; i < segment.lines.length; i++) {
+          const lineLength = segment.lines[i].length;
+          if (remainingChars < lineLength) {
+            lineIndex = i;
+            charInLineIndex = remainingChars;
+            break;
+          }
+          remainingChars -= lineLength;
+          lineIndex = i + 1;
+        }
+
+        // Ensure we don't exceed bounds
+        if (lineIndex >= segment.lines.length) {
+          lineIndex = segment.lines.length - 1;
+          charInLineIndex = segment.lines[lineIndex]?.length || 0;
+        }
+
+        return {
+          segmentIndex,
+          lineIndex,
+          charInLineIndex,
+          parsedTextIndex: Math.max(0, parsedTextIndex),
+          rawTextIndex,
+        };
+      }
+
+      // Move to next segment (add 1 for newline character between segments)
+      currentIndex += segmentLength + 1;
+
+      // Handle case where index points to the newline between segments
+      if (
+        absTextIndex === currentIndex - 1 &&
+        segmentIndex < this.segments.length - 1
+      ) {
+        // Return end of current segment
+        const lastLineIndex = segment.lines.length - 1;
+        const lastLineLength = segment.lines[lastLineIndex]?.length || 0;
+
+        return {
+          segmentIndex,
+          lineIndex: lastLineIndex,
+          charInLineIndex: lastLineLength,
+          parsedTextIndex: segment.parsed.length,
+          rawTextIndex: segment.raw.length,
+        };
+      }
+    }
+
+    // If index is beyond the text, return the last position
+    if (absTextIndex >= currentIndex - 1) {
+      const lastSegmentIndex = this.segments.length - 1;
+      const lastSegment = this.segments[lastSegmentIndex];
+      const lastLineIndex = lastSegment.lines.length - 1;
+      const lastLineLength = lastSegment.lines[lastLineIndex]?.length || 0;
+
+      return {
+        segmentIndex: lastSegmentIndex,
+        lineIndex: lastLineIndex,
+        charInLineIndex: lastLineLength,
+        parsedTextIndex: lastSegment.parsed.length,
+        rawTextIndex: lastSegment.raw.length,
+      };
+    }
+
+    return null;
+  }
+
+  /**
    * getLineFromPosition returns line from segment position
    * @param segment
    * @returns
@@ -367,6 +475,7 @@ class Text {
   getSegmentPosition(
     absLineIndex: number,
     charInLineIndex: number = 0,
+    ignoreLastClosingTag: boolean = false
   ): SegmentPosition | null {
     // sanitize bounds
     if (absLineIndex < 0) {
@@ -403,7 +512,12 @@ class Text {
         .concat(segment.closingTags)
         .sort((a, b) => a.position - b.position);
       for (const tag of tags) {
-        if (tag.position <= rawTextIndex) {
+        // condition which ignores tags on same position as current rawTextIndex
+        if (
+          ignoreLastClosingTag
+            ? tag.position < rawTextIndex
+            : tag.position <= rawTextIndex
+        ) {
           rawTextIndex += tag.tag.length + (tag.closing ? 3 : 2);
         }
       }

--- a/packages/annotator/src/lib/Text.ts
+++ b/packages/annotator/src/lib/Text.ts
@@ -7,12 +7,14 @@ export class Tag {
   tag: string;
   closing?: boolean;
   attributes: Record<string, string>;
+  relativeParsedPosition: number;
 
-  constructor(position: number, tag: string, closing?: boolean) {
+  constructor(position: number, tag: string, closing?: boolean, segment?: Segment) {
     this.position = position;
     this.tag = tag;
     this.closing = closing;
     this.attributes = this.parseAttributes(tag);
+    this.relativeParsedPosition = this.calculateRelativeParsedPosition(segment);
   }
 
   private parseAttributes(tagString: string): Record<string, string> {
@@ -46,6 +48,31 @@ export class Tag {
     }
     
     return attributes;
+  }
+
+  private calculateRelativeParsedPosition(segment?: Segment): number {
+    if (!segment) {
+      return 0;
+    }
+
+    // Calculate the parsed position by subtracting the length of all tags that come before this tag
+    let parsedPosition = this.position;
+    
+    // Subtract length of all opening tags before this position
+    for (const tag of segment.openingTags) {
+      if (tag.position < this.position) {
+        parsedPosition -= tag.tag.length + 2; // +2 for < and >
+      }
+    }
+    
+    // Subtract length of all closing tags before this position
+    for (const tag of segment.closingTags) {
+      if (tag.position < this.position) {
+        parsedPosition -= tag.tag.length + 3; // +3 for </ and >
+      }
+    }
+    
+    return parsedPosition;
   }
 
   getTag(): string {
@@ -84,12 +111,12 @@ export class Segment {
     // Find opening tags
     let match;
     while ((match = openingTagsRegex.exec(this.raw)) !== null) {
-      this.openingTags.push(new Tag(match.index, match[1]));
+      this.openingTags.push(new Tag(match.index, match[1], false, this));
     }
 
     // Find closing tags
     while ((match = closingTagsRegex.exec(this.raw)) !== null) {
-      this.closingTags.push(new Tag(match.index, match[1], true));
+      this.closingTags.push(new Tag(match.index, match[1], true, this));
     }
 
     // Remove tags from the text

--- a/packages/annotator/src/lib/Text.ts
+++ b/packages/annotator/src/lib/Text.ts
@@ -1,7 +1,12 @@
 import Viewport from "./Viewport";
 import { IAbsCoordinates, IRelativeCoordinates } from "./Highlighter";
 import { EditMode } from "./constants";
+import { closingTagRegex, openingTagRegex, tagRemovalRegex } from "./Annotator";
 
+/**
+ * Represents an XML-like tag within a text segment.
+ * Tags can be opening or closing tags and may contain attributes.
+ */
 export class Tag {
   position: number;
   tag: string;
@@ -9,6 +14,14 @@ export class Tag {
   attributes: Record<string, string>;
   relativeParsedPosition: number;
 
+  /**
+   * Creates a new Tag instance.
+   * 
+   * @param position - The absolute position of the tag in the raw text
+   * @param tag - The tag name (e.g., "person", "location")
+   * @param closing - Whether this is a closing tag (default: false)
+   * @param segment - Optional segment reference for calculating relative position
+   */
   constructor(position: number, tag: string, closing?: boolean, segment?: Segment) {
     this.position = position;
     this.tag = tag;
@@ -17,6 +30,15 @@ export class Tag {
     this.relativeParsedPosition = this.calculateRelativeParsedPosition(segment);
   }
 
+  /**
+   * Parses attributes from a tag string.
+   * 
+   * Extracts key-value pairs from tag strings like "person id='123' type='proper'".
+   * Handles both single and double quotes around attribute values.
+   * 
+   * @param tagString - The tag string to parse attributes from
+   * @returns Object containing parsed attributes
+   */
   private parseAttributes(tagString: string): Record<string, string> {
     const attributes: Record<string, string> = {};
     
@@ -50,6 +72,16 @@ export class Tag {
     return attributes;
   }
 
+  /**
+   * Calculates the position of this tag in the parsed (tag-free) text.
+   * 
+   * This method accounts for the length of all tags that appear before this tag
+   * in the raw text, providing the position where this tag would appear in
+   * the clean, parsed text without any XML-like tags.
+   * 
+   * @param segment - The segment containing this tag
+   * @returns The relative position in parsed text
+   */
   private calculateRelativeParsedPosition(segment?: Segment): number {
     if (!segment) {
       return 0;
@@ -75,6 +107,14 @@ export class Tag {
     return parsedPosition;
   }
 
+  /**
+   * Generates the complete tag string for this tag.
+   * 
+   * For closing tags, returns the closing tag format (e.g., "</person>").
+   * For opening tags, includes all attributes in the format (e.g., '<person id="123" type="proper">').
+   * 
+   * @returns The complete tag string
+   */
   getTag(): string {
     if (this.closing) {
       return `</${this.tag}>`;
@@ -88,6 +128,10 @@ export class Tag {
   }
 }
 
+/**
+ * Represents a segment of text that can contain XML-like tags.
+ * A segment is a portion of text that gets processed and displayed as lines.
+ */
 export class Segment {
   lineStart: number = -1; // incl.
   lineEnd: number = -1; // incl.
@@ -97,36 +141,51 @@ export class Segment {
   closingTags: Tag[] = [];
   lines: string[] = [];
 
+  /**
+   * Creates a new Segment from raw text.
+   * 
+   * @param text - The raw text content for this segment
+   */
   constructor(text: string) {
     this.raw = text;
     this.parseText();
   }
 
+  /**
+   * Parses the raw text to extract tags and create clean parsed text.
+   * 
+   * This method identifies opening and closing tags using regex patterns,
+   * creates Tag objects for each found tag, and generates a clean parsed
+   * version of the text with all tags removed.
+   */
   parseText() {
     this.openingTags = [];
     this.closingTags = [];
-    const openingTagsRegex = /<([^<>\/]+?)>/g;
-    const closingTagsRegex = /<\/([^<>]+?)>/g;
+
+    // Create new regex instances to avoid global flag state issues
+    const openingRegex = new RegExp(openingTagRegex.source, openingTagRegex.flags);
+    const closingRegex = new RegExp(closingTagRegex.source, closingTagRegex.flags);
 
     // Find opening tags
     let match;
-    while ((match = openingTagsRegex.exec(this.raw)) !== null) {
+    while ((match = openingRegex.exec(this.raw)) !== null) {
       this.openingTags.push(new Tag(match.index, match[1], false, this));
     }
 
     // Find closing tags
-    while ((match = closingTagsRegex.exec(this.raw)) !== null) {
+    while ((match = closingRegex.exec(this.raw)) !== null) {
       this.closingTags.push(new Tag(match.index, match[1], true, this));
     }
 
     // Remove tags from the text
-    this.parsed = this.raw.replace(/<\/?[^<>]+?>/g, "");
+    this.parsed = this.raw.replace(tagRemovalRegex, "");
   }
 
   /**
-   * Returns list of opening/closing tags in this segment before raw index
-   * @param rawIndex
-   * @returns
+   * Returns all opening and closing tags that appear before a given position.
+   * 
+   * @param rawIndex - The raw text index to check before
+   * @returns Tuple containing [openingTags, closingTags] that appear before the index
    */
   getTagsBeforePosition(rawIndex: number): [Tag[], Tag[]] {
     const openedTags: Tag[] = [];
@@ -145,9 +204,10 @@ export class Segment {
   }
 
   /**
-   * Returns list of opening/closing tags in this segment after raw index
-   * @param rawIndex
-   * @returns
+   * Returns all opening and closing tags that appear after a given position.
+   * 
+   * @param rawIndex - The raw text index to check after
+   * @returns Tuple containing [openingTags, closingTags] that appear after the index
    */
   getTagsAfterPosition(rawIndex: number): [Tag[], Tag[]] {
     const openedTags: Tag[] = [];
@@ -166,9 +226,11 @@ export class Segment {
   }
 
   /**
-   * Returns list of opening/closing tags in this segment between start/end raw indexes
-   * @param pos
-   * @returns
+   * Returns all opening and closing tags that appear within a given range.
+   * 
+   * @param startRawIndex - The start of the range (exclusive)
+   * @param endRawIndex - The end of the range (exclusive)
+   * @returns Tuple containing [openingTags, closingTags] within the range
    */
   getTagsInPosition(
     startRawIndex: number,
@@ -189,6 +251,15 @@ export class Segment {
     return [openedTags, closedTags];
   }
 
+  /**
+   * Finds the parsed position (line and character) of a tag in the clean text.
+   * 
+   * This method calculates where a tag would appear in the parsed (tag-free) text
+   * by accounting for the length of all preceding tags and converting to 2D coordinates.
+   * 
+   * @param tag - The tag to find the position for
+   * @returns Object with x (character) and y (line) coordinates in parsed text
+   */
   findTagParsedPosition(tag: Tag): { x: number; y: number } {
     // find abs position right after the <tag> in segment's text
     let parsedTextOpenPosition = this.openingTags
@@ -226,7 +297,11 @@ export interface SegmentPosition {
 }
 
 /**
- * Text provides more abstract control over the provided raw text
+ * Text provides more abstract control over the provided raw text.
+ * 
+ * This class manages text content by breaking it into segments, handling
+ * different edit modes (RAW, HIGHLIGHT, SEMI), and providing methods for
+ * text manipulation, line calculation, and position tracking.
  */
 class Text {
   mode: EditMode = EditMode.RAW;
@@ -235,6 +310,13 @@ class Text {
   value: string;
   charsAtLine: number;
   noLines: number;
+  
+  /**
+   * Creates a new Text instance from raw text content.
+   * 
+   * @param value - The raw text content
+   * @param charsAtLine - Maximum characters per line for text wrapping
+   */
   constructor(value: string, charsAtLine: number) {
     this.value = value;
     this.segments = [];
@@ -267,11 +349,22 @@ class Text {
     return segment.lines[relativeLineIndex] || "";
   }
 
+  /**
+   * Updates the maximum characters per line and recalculates line breaks.
+   * 
+   * @param charsAtLine - New maximum characters per line
+   */
   updateCharsAtLine(charsAtLine: number) {
     this.charsAtLine = charsAtLine;
     this.calculateLines();
   }
 
+  /**
+   * Splits the raw text into segments based on newline characters.
+   * 
+   * Each segment represents a line of text and gets parsed for tags.
+   * This method is called when the text content changes.
+   */
   prepareSegments() {
     const segmentsArray = this.value.split("\n");
     const segments: Segment[] = [];
@@ -284,14 +377,25 @@ class Text {
     this.segments = segments;
   }
 
+  /**
+   * Reconstructs the raw text value from all segments.
+   * 
+   * This method joins all segment raw content with newlines and
+   * triggers a recalculation of line breaks.
+   */
   assignValueFromSegments(): void {
     this.value = this.segments.map((s) => s.raw).join("\n");
     this.calculateLines();
   }
 
   /**
-   * calculateLines processes the raw text by splitting it into lines
-   * TODO provide more optimized approach so this method does not have to recalculate everyting after writing single characted
+   * Calculates line breaks and organizes text into displayable lines.
+   * 
+   * This method processes each segment, applies text wrapping based on
+   * charsAtLine, handles different edit modes (RAW/HIGHLIGHT/SEMI), and
+   * updates line numbering for all segments.
+   * 
+   * TODO: Optimize to avoid full recalculation after single character changes
    */
   calculateLines(): void {
     const time1 = performance.now();
@@ -360,10 +464,11 @@ class Text {
   }
 
   /**
-   * cursorToIndex calculates index position of the text from cursor position
-   * @param viewport
-   * @param cursor
-   * @returns
+   * Converts cursor position to segment position.
+   * 
+   * @param viewport - The current viewport information
+   * @param cursor - The relative cursor coordinates
+   * @returns Segment position or null if invalid
    */
   cursorToIndex(
     viewport: Viewport,
@@ -377,6 +482,13 @@ class Text {
     return pos;
   }
 
+  /**
+   * Gets the current line content at the cursor position.
+   * 
+   * @param viewport - The current viewport information
+   * @param cursor - The relative cursor coordinates
+   * @returns The line content or null if invalid position
+   */
   getCurrentLine(
     viewport: Viewport,
     cursor: IRelativeCoordinates
@@ -390,9 +502,10 @@ class Text {
   }
 
   /**
-   * getAbsTextIndex returns absolute text index from absolute coordinates
-   * @param absCoords
-   * @returns
+   * Converts absolute coordinates to absolute text index.
+   * 
+   * @param absCoords - The absolute coordinates (line, character)
+   * @returns The absolute text index or -1 if invalid
    */
   getAbsTextIndex(absCoords: IAbsCoordinates): number {
     const pos = this.getSegmentPosition(absCoords.yLine, absCoords.xLine);
@@ -404,9 +517,10 @@ class Text {
   }
 
   /**
-   * getAbsTextIndexFromPosition returns absolute text index from segment position
-   * @param segment
-   * @returns
+   * Converts segment position to absolute text index.
+   * 
+   * @param segment - The segment position
+   * @returns The absolute text index or -1 if invalid
    */
   getAbsTextIndexFromPosition(segment: SegmentPosition | null): number {
     if (!segment) {
@@ -420,9 +534,13 @@ class Text {
   }
 
   /**
-   * getSegmentFromAbsTextIndex returns segment position from absolute text index
-   * @param absTextIndex
-   * @returns
+   * Converts absolute text index to segment position.
+   * 
+   * This method finds which segment contains the given text index and
+   * calculates the corresponding line and character positions within that segment.
+   * 
+   * @param absTextIndex - The absolute text index
+   * @returns Segment position or null if invalid
    */
   getSegmentFromAbsTextIndex(absTextIndex: number): SegmentPosition | null {
     if (absTextIndex < 0 || this.segments.length === 0) {
@@ -531,19 +649,25 @@ class Text {
   }
 
   /**
-   * getLineFromPosition returns line from segment position
-   * @param segment
-   * @returns
+   * Gets the line content from a segment position.
+   * 
+   * @param segment - The segment position
+   * @returns The line content or empty string if invalid
    */
   getLineFromPosition(segment: SegmentPosition): string {
     return this.segments[segment.segmentIndex].lines[segment.lineIndex] || "";
   }
 
   /**
-   * getSegmentPosition returns segment position from absolute line index
-   * @param absLineIndex
-   * @param charInLineIndex
-   * @returns
+   * Converts absolute line index to segment position.
+   * 
+   * This method finds the segment containing the given line and calculates
+   * the corresponding positions, accounting for different edit modes and tags.
+   * 
+   * @param absLineIndex - The absolute line index
+   * @param charInLineIndex - Character position within the line (default: 0)
+   * @param ignoreLastClosingTag - Whether to ignore the last closing tag (default: false)
+   * @returns Segment position or null if invalid
    */
   getSegmentPosition(
     absLineIndex: number,
@@ -606,8 +730,9 @@ class Text {
   }
 
   /**
-   * getLastSegmentPosition returns last segment position
-   * @returns
+   * Gets the position of the last segment.
+   * 
+   * @returns The last segment position or null if no segments exist
    */
   getLastSegmentPosition(): SegmentPosition | null {
     if (this.segments.length === 0) {
@@ -662,9 +787,10 @@ class Text {
   }
 
   /**
-   * getViewportText returns visible text to be rendered by Viewport
-   * @param viewport
-   * @returns
+   * Gets the text content visible in the current viewport.
+   * 
+   * @param viewport - The viewport information containing line range
+   * @returns Array of lines visible in the viewport
    */
   getViewportText(viewport: Viewport): string[] {
     const posStart = this.getSegmentPosition(viewport.lineStart);
@@ -694,10 +820,11 @@ class Text {
   }
 
   /**
-   * findWordOffsets returns word offsets from text and index
-   * @param text
-   * @param index
-   * @returns
+   * Finds word boundaries around a given text index.
+   * 
+   * @param text - The text to search in
+   * @param index - The character index within the text
+   * @returns Tuple of [startOffset, endOffset] relative to the word boundaries
    */
   findWordOffsets(text: string, index: number): [number, number] {
     const wordRegex = /[^\s,.]+/g; // Match any sequence of characters that are not whitespace, comma, or dot
@@ -732,9 +859,11 @@ class Text {
   }
 
   /**
-   * getCursorWord returns current word under active cursor
-   * @param cursor
-   * @returns
+   * Gets word boundaries for the word under the cursor.
+   * 
+   * @param viewport - The current viewport information
+   * @param cursor - The relative cursor coordinates
+   * @returns Tuple of [startOffset, endOffset] for the word under cursor
    */
   getCursorWordOffsets(
     viewport: Viewport,
@@ -757,10 +886,11 @@ class Text {
   }
 
   /**
-   * insertText adds text to cursor position
-   * @param viewport
-   * @param cursorPosition
-   * @param textToInsert
+   * Inserts text at the cursor position.
+   * 
+   * @param viewport - The current viewport information
+   * @param cursorPosition - The relative cursor coordinates
+   * @param textToInsert - The text to insert
    */
   insertText(
     viewport: Viewport,
@@ -798,10 +928,10 @@ class Text {
   }
 
   /**
-   * adds newline character on current cursor position, creating new segment in the process
-   * @param viewport
-   * @param cursorPosition
-   * @returns
+   * Inserts a newline character at the cursor position, creating a new segment.
+   * 
+   * @param viewport - The current viewport information
+   * @param cursorPosition - The relative cursor coordinates
    */
   insertNewline(
     viewport: Viewport,
@@ -827,6 +957,11 @@ class Text {
     this.calculateLines();
   }
 
+  /**
+   * Deletes a segment at the specified index.
+   * 
+   * @param index - The index of the segment to delete
+   */
   deleteSegment(index: number) {
     this.segments = this.segments
       .slice(0, index)
@@ -834,11 +969,13 @@ class Text {
   }
 
   /**
-   * deleteText removes one char from text at cursor's position
-   * For more characters, see deleteRangeText as that method is slighly slower that this
-   * @param viewport
-   * @param cursorPosition
-   * @param forwardChar
+   * Deletes a single character at the cursor position.
+   * 
+   * For deleting multiple characters, use deleteRangeText as it's more efficient.
+   * 
+   * @param viewport - The current viewport information
+   * @param cursorPosition - The relative cursor coordinates
+   * @param forwardChar - Whether to delete forward (default: backward)
    */
   deleteTextChar(
     viewport: Viewport,
@@ -877,10 +1014,11 @@ class Text {
   }
 
   /**
-   * getRangeText returns text delimited by provided absolute range
-   * @param start
-   * @param end
-   * @returns
+   * Gets text content within the specified absolute coordinate range.
+   * 
+   * @param start - The start coordinates of the range
+   * @param end - The end coordinates of the range
+   * @returns The text content within the range
    */
   getRangeText(start: IAbsCoordinates, end: IAbsCoordinates): string {
     // swap in case start is after end
@@ -904,6 +1042,12 @@ class Text {
     return rangeLines.join("\n");
   }
 
+  /**
+   * Deletes text within the specified absolute coordinate range.
+   * 
+   * @param start - The start coordinates of the range to delete
+   * @param end - The end coordinates of the range to delete
+   */
   deleteRangeText(start: IAbsCoordinates, end: IAbsCoordinates): void {
     // swap in case start is after end
     if (
@@ -923,6 +1067,13 @@ class Text {
     this.calculateLines();
   }
 
+  /**
+   * Finds the position of a specific tag occurrence.
+   * 
+   * @param tag - The tag name to search for
+   * @param index - The occurrence index (0-based, default: 0)
+   * @returns Array containing start and end coordinates of the tag, or empty array if not found
+   */
   getTagPosition(tag: string, index: number = 0): IAbsCoordinates[] {
     let openingTagMatch: { tag: Tag; segment: Segment } | null = null;
     let closingTagMatch: { tag: Tag; segment: Segment } | null = null;

--- a/packages/annotator/src/lib/index.ts
+++ b/packages/annotator/src/lib/index.ts
@@ -3,6 +3,7 @@ export * from "./Highlighter";
 export * from "./Viewport";
 export * from "./Text";
 export * from "./Annotator";
+export * from "./warnings";
 
 import { LoremIpsum } from "lorem-ipsum";
 

--- a/packages/annotator/src/lib/warnings.ts
+++ b/packages/annotator/src/lib/warnings.ts
@@ -1,0 +1,73 @@
+/**
+ * Warnings system for the Annotator
+ * Handles warning messages and notifications for various annotator operations
+ */
+export class Warnings {
+  private enabled: boolean = true;
+  private onWarningCb?: (message: string) => void;
+
+  constructor(enabled: boolean = true) {
+    this.enabled = enabled;
+  }
+
+  /**
+   * Enable warnings system
+   */
+  enable(): void {
+    this.enabled = true;
+  }
+
+  /**
+   * Disable warnings system
+   */
+  disable(): void {
+    this.enabled = false;
+  }
+
+  /**
+   * Check if warnings are enabled
+   */
+  isEnabled(): boolean {
+    return this.enabled;
+  }
+
+  /**
+   * Set callback for warning events
+   */
+  onWarning(cb: (message: string) => void): void {
+    this.onWarningCb = cb;
+  }
+
+  /**
+   * Trigger a warning
+   */
+  warn(message: string): void {
+    if (!this.enabled || !this.onWarningCb) {
+      return;
+    }
+    
+    this.onWarningCb(message);
+  }
+
+  /**
+   * Called when text changes in the annotator
+   * Performs various checks on the text content
+   */
+  onTextChanged(text: string): void {
+    if (!this.enabled) {
+      return;
+    }
+
+    this.checkOverlappingXmlTags(text);
+  }
+
+  /**
+   * Internal method to check for overlapping XML tag issues
+   * TODO: Implement logic to detect overlapping XML tags
+   */
+  private checkOverlappingXmlTags(text: string): void {
+    // TODO: Implement overlapping XML tag detection logic
+    // This method should analyze the text for XML tag overlapping issues
+    // and call this.warn() with appropriate warning messages
+  }
+}


### PR DESCRIPTION
simple overlapping issues should be fixed:

```
dolor
<test2><test1>sit</test1>
a</test2>met
```
instead of
```
dolor
<test1><test2>sit</test1>
a</test2>met
```
etc