### PR TITLE
fix(annotator): wrap full selection when adding outer anchor over existing tag

### DIFF
--- a/packages/annotator/src/lib/Annotator.ts
+++ b/packages/annotator/src/lib/Annotator.ts
@@ -1395,10 +1395,12 @@ export class Annotator {
       while ((match = openingRegex.exec(searchText)) !== null) {
         const absoluteStart = rangeStart + match.index;
         const absoluteEnd = rangeStart + match.index + match[0].length;
+        const rawName = match[1] || "";
+        const normalizedName = rawName.split(/\s+/)[0].toLowerCase();
         positions.push({
           start: absoluteStart,
           end: absoluteEnd,
-          name: match[1].toLowerCase(),
+          name: normalizedName,
           isOpen: true,
         });
       }

--- a/packages/annotator/src/lib/Annotator.ts
+++ b/packages/annotator/src/lib/Annotator.ts
@@ -1470,6 +1470,22 @@ export class Annotator {
         }
       }
 
+      const hasCompleteTagPairFullyContained = tagPositions.some((tag) => {
+        if (!tag.isOpen) return false;
+        const closingTag = tagPositions.find(
+          (t) => !t.isOpen && t.name === tag.name && t.start > tag.start
+        );
+        return (
+          closingTag != null &&
+          start <= tag.start &&
+          end >= closingTag.end
+        );
+      });
+
+      if (hasCompleteTagPairFullyContained) {
+        return [start, end];
+      }
+
       // Only contract if it's not a complete tag pair
       if (!isCompleteTagPair) {
         let contentStart = start;
@@ -1599,8 +1615,11 @@ export class Annotator {
         const closingTag = tagPositions.find(
           (t) => !t.isOpen && t.name === tag.name && t.start > tag.start
         );
-        if (closingTag && start === tag.start && end === closingTag.end) {
-          // Selection exactly matches a complete tag pair, no adjustment needed
+        if (
+          closingTag &&
+          start === tag.start &&
+          end >= closingTag.end
+        ) {
           return [start, end];
         }
       }

--- a/packages/annotator/src/lib/Annotator.ts
+++ b/packages/annotator/src/lib/Annotator.ts
@@ -975,7 +975,31 @@ export class Annotator {
       // after this we have envelope around neighboring tags
       indexEnd = this.skipTagsOnRight(indexEnd);
       // Sanitize envelope range by removing enveloping tags from both left and right sides
-      [indexStart, indexEnd] = this.sanitizeEnvelopeRange(indexStart, indexEnd);
+      const raw = this.text.value;
+      let minTagStart = raw.length;
+      let maxTagEnd = 0;
+      const openR = new RegExp(openingTagRegex.source, openingTagRegex.flags);
+      const closeR = new RegExp(closingTagRegex.source, closingTagRegex.flags);
+      let m: RegExpExecArray | null;
+      while ((m = openR.exec(raw)) !== null) {
+        minTagStart = Math.min(minTagStart, m.index);
+        maxTagEnd = Math.max(maxTagEnd, m.index + m[0].length);
+      }
+      while ((m = closeR.exec(raw)) !== null) {
+        minTagStart = Math.min(minTagStart, m.index);
+        maxTagEnd = Math.max(maxTagEnd, m.index + m[0].length);
+      }
+      const selectionEncompassesAllTags =
+        minTagStart <= maxTagEnd &&
+        indexStart <= minTagStart &&
+        indexEnd >= maxTagEnd;
+      if (selectionEncompassesAllTags) {
+        if (indexStart === 0) {
+          indexEnd = raw.length;
+        }
+      } else {
+        [indexStart, indexEnd] = this.sanitizeEnvelopeRange(indexStart, indexEnd);
+      }
 
       // could be '<tag>text .... text</tag> (closing tag always included if present)
       const selectedRawText = this.text.value.slice(indexStart, indexEnd);
@@ -1342,13 +1366,10 @@ export class Annotator {
     // Utility functions
     const clamp = (i: number): number => Math.max(0, Math.min(i, raw.length));
 
-    // Find tag positions only within the selection boundary
-    const findRelevantTagPositions = (): Array<{
-      start: number;
-      end: number;
-      name: string;
-      isOpen: boolean;
-    }> => {
+    const findAllTagPositionsInRange = (
+      rangeStart: number,
+      rangeEnd: number
+    ): Array<{ start: number; end: number; name: string; isOpen: boolean }> => {
       const positions: Array<{
         start: number;
         end: number;
@@ -1357,7 +1378,7 @@ export class Annotator {
       }> = [];
 
       // Search only within the selection range
-      const searchText = raw.slice(start, end);
+      const searchText = raw.slice(rangeStart, rangeEnd);
 
       // Use existing regexes to find all tags in the search range
       const openingRegex = new RegExp(
@@ -1372,9 +1393,8 @@ export class Annotator {
       // Find all opening tags
       let match;
       while ((match = openingRegex.exec(searchText)) !== null) {
-        const absoluteStart = start + match.index;
-        const absoluteEnd = start + match.index + match[0].length;
-
+        const absoluteStart = rangeStart + match.index;
+        const absoluteEnd = rangeStart + match.index + match[0].length;
         positions.push({
           start: absoluteStart,
           end: absoluteEnd,
@@ -1385,9 +1405,8 @@ export class Annotator {
 
       // Find all closing tags
       while ((match = closingRegex.exec(searchText)) !== null) {
-        const absoluteStart = start + match.index;
-        const absoluteEnd = start + match.index + match[0].length;
-
+        const absoluteStart = rangeStart + match.index;
+        const absoluteEnd = rangeStart + match.index + match[0].length;
         positions.push({
           start: absoluteStart,
           end: absoluteEnd,
@@ -1399,6 +1418,13 @@ export class Annotator {
       // Sort by position to maintain order
       return positions.sort((a, b) => a.start - b.start);
     };
+
+    const findRelevantTagPositions = (): Array<{
+      start: number;
+      end: number;
+      name: string;
+      isOpen: boolean;
+    }> => findAllTagPositionsInRange(start, end);
 
     // Normalize and clamp
     let start = clamp(indexStart);
@@ -1425,8 +1451,10 @@ export class Annotator {
 
     // If both boundaries are in text content, no adjustment needed
     if (isInsideText(start) && isInsideText(end)) {
-      // But if the selection extends beyond the actual content, we should still contract it
-      // Only apply this logic if the selection is not a complete tag pair
+      if (start === 0 && end === raw.length) {
+        return [start, end];
+      }
+
       let isCompleteTagPair = false;
 
       // Check if this is a complete tag pair

--- a/packages/annotator/src/sanitizeEnvelopeRange.test.ts
+++ b/packages/annotator/src/sanitizeEnvelopeRange.test.ts
@@ -57,6 +57,34 @@ describe('sanitizeEnvelopeRange', () => {
       expect(result).toEqual([0, 56]);
     });
 
+    test('should keep selection when range fully encompasses existing tag (e.g. 5-44 wraps <first>...</first>)', () => {
+      annotator = new Annotator(mockCanvas, 'ahoj ako sa mas <first> nejake meno </first> tu');
+
+      const result = sanitizeEnvelopeRange(5, 44);
+      expect(result).toEqual([5, 44]);
+    });
+
+    test('selection enveloping tag completely (space on left and right) should remain unchanged', () => {
+      annotator = new Annotator(mockCanvas, 'ahoj ako sa mas <first> nejake meno </first> tu');
+
+      const result = sanitizeEnvelopeRange(4, 46);
+      expect(result).toEqual([4, 46]);
+    });
+
+    test('selection enveloping tag with space only on left, end at end of closing tag should remain unchanged', () => {
+      annotator = new Annotator(mockCanvas, 'ahoj ako sa mas <first> nejake meno </first> test');
+
+      const result = sanitizeEnvelopeRange(5, 44);
+      expect(result).toEqual([5, 44]);
+    });
+
+    test('selection enveloping tag with space only on right, start at start of opening tag should remain unchanged', () => {
+      annotator = new Annotator(mockCanvas, 'ahoj ako sa mas <first> nejake meno </first> tu');
+
+      const result = sanitizeEnvelopeRange(16, 46);
+      expect(result).toEqual([16, 46]);
+    });
+
     test('should keep selection unchanged when selecting entire tag including tags', () => {
       // Text: "<p>test</p>", parsed: "test"
       // User selects entire tag including opening and closing tags (indices 0-11)

--- a/packages/annotator/src/sanitizeEnvelopeRange.test.ts
+++ b/packages/annotator/src/sanitizeEnvelopeRange.test.ts
@@ -50,6 +50,13 @@ describe('sanitizeEnvelopeRange', () => {
   });
 
   describe('Case 2: Selection equals parent tag', () => {
+    test('should keep full selection when selecting all text that contains an inner tag (wrap outer anchor)', () => {
+      annotator = new Annotator(mockCanvas, 'some text example <1> previously wrapped </1> more text ');
+
+      const result = sanitizeEnvelopeRange(0, 56);
+      expect(result).toEqual([0, 56]);
+    });
+
     test('should keep selection unchanged when selecting entire tag including tags', () => {
       // Text: "<p>test</p>", parsed: "test"
       // User selects entire tag including opening and closing tags (indices 0-11)
@@ -148,11 +155,10 @@ describe('sanitizeEnvelopeRange', () => {
     });
 
     test('should handle text with < symbols that are not tags', () => {
-      // Text contains < symbols in mathematical expressions and comparisons
       annotator = new Annotator(mockCanvas, 'Math: 5 < 10 and <p>real tag</p> with < symbol');
 
-      const result = sanitizeEnvelopeRange(0, 50); // entire text
-      expect(result).toEqual([20, 28]); // Should adjust to content of the real tag, ignoring < symbols in math
+      const result = sanitizeEnvelopeRange(0, 50);
+      expect(result).toEqual([0, 46]);
     });
   });
 

--- a/packages/annotator/src/sanitizeEnvelopeRange.test.ts
+++ b/packages/annotator/src/sanitizeEnvelopeRange.test.ts
@@ -78,6 +78,27 @@ describe('sanitizeEnvelopeRange', () => {
       expect(result).toEqual([5, 44]);
     });
 
+    test('selection enveloping tag with attribute on opening tag (space only on left) should remain unchanged', () => {
+      annotator = new Annotator(mockCanvas, 'ahoj ako sa mas <first elvl="1"> nejake meno </first> test');
+
+      const result = sanitizeEnvelopeRange(5, 53); // selected "ako....</first>"
+      expect(result).toEqual([5, 53]);
+    });
+
+    test('selection enveloping tag with attribute (space on left and right) should remain unchanged', () => {
+      annotator = new Annotator(mockCanvas, 'ahoj ako sa mas <first elvl="1"> nejake meno </first> tu');
+
+      const result = sanitizeEnvelopeRange(5, 56);
+      expect(result).toEqual([5, 56]);
+    });
+
+    test('selection enveloping tag with attribute (space only on right, start at opening tag) should remain unchanged', () => {
+      annotator = new Annotator(mockCanvas, 'ahoj ako sa mas <first elvl="1"> nejake meno </first> tu');
+
+      const result = sanitizeEnvelopeRange(16, 56);
+      expect(result).toEqual([16, 56]);
+    });
+
     test('selection enveloping tag with space only on right, start at start of opening tag should remain unchanged', () => {
       annotator = new Annotator(mockCanvas, 'ahoj ako sa mas <first> nejake meno </first> tu');
 


### PR DESCRIPTION


- In addAnchor, when selection encompasses all tags and starts at 0, use full document range so new anchor wraps entire text instead of nesting inside inner tag
- Skip sanitizeEnvelopeRange when selection encompasses all tags; only extend to raw.length when indexStart === 0 to avoid expanding selection when user selected only the inner tag
- In sanitizeEnvelopeRange, return [0, raw.length] unchanged when selection is full document to avoid contracting
- Add test for wrap-outer-anchor case; update test expectation for "text with < symbols" (full-document selection preserved)

Closes #2863 
Closes #2886