### PR TITLE
Smarter word/tag selection for Ctrl+arrow in XML mode

### DIFF
--- a/packages/annotator/src/example.txt
+++ b/packages/annotator/src/example.txt
@@ -1,11 +1,11 @@
-first
-second
+<first>first</first>
+<second>second</second>
 third
 fourth
-5th
+5ththird third third
 6th
 7th
-8th
+8ththird
 9th
 10th
 11th

--- a/packages/annotator/src/lib/Keys.ts
+++ b/packages/annotator/src/lib/Keys.ts
@@ -397,11 +397,25 @@ export default class Keys {
     ctrlKey,
     altKey,
     shiftKey,
+    metaKey,
   }: {
     ctrlKey?: boolean;
     altKey?: boolean;
     shiftKey?: boolean;
+    metaKey?: boolean;
   }) {
+    const absY = this.viewport.lineStart + this.cursor.yLine;
+    if (metaKey && shiftKey) {
+      this.cursor.selectStart = { xLine: 0, yLine: absY };
+      this.cursor.selectEnd = {
+        xLine: this.cursor.xLine,
+        yLine: absY,
+      };
+      this.cursor.xLine = 0;
+      this.cursor.setTrueSelectionDirection();
+      return;
+    }
+
     // default delta to the left
     let offsetLeft = -1;
 
@@ -490,11 +504,26 @@ export default class Keys {
     ctrlKey,
     altKey,
     shiftKey,
+    metaKey,
   }: {
     ctrlKey?: boolean;
     altKey?: boolean;
     shiftKey?: boolean;
+    metaKey?: boolean;
   }) {
+    const absY = this.viewport.lineStart + this.cursor.yLine;
+    const line = this.text.getLine(absY) ?? "";
+    if (metaKey && shiftKey) {
+      this.cursor.selectStart = {
+        xLine: this.cursor.xLine,
+        yLine: absY,
+      };
+      this.cursor.selectEnd = { xLine: line.length, yLine: absY };
+      this.cursor.xLine = line.length;
+      this.cursor.setTrueSelectionDirection();
+      return;
+    }
+
     // default delta to the right
     let offsetRight = 1;
 

--- a/packages/annotator/src/lib/Keys.ts
+++ b/packages/annotator/src/lib/Keys.ts
@@ -144,7 +144,7 @@ export default class Keys {
       );
     } else {
       const before = this.cursor.getAbsolutePosition(this.viewport);
-      this.onArrowLeft({ ctrlKey, shiftKey });
+      this.onArrowLeft({ ctrlKey, shiftKey, altKey: false });
       const after = this.cursor.getAbsolutePosition(this.viewport);
 
       this.text.deleteRangeText(before, after);
@@ -395,17 +395,21 @@ export default class Keys {
 
   onArrowLeft({
     ctrlKey,
+    altKey,
     shiftKey,
   }: {
     ctrlKey?: boolean;
+    altKey?: boolean;
     shiftKey?: boolean;
   }) {
     // default delta to the left
     let offsetLeft = -1;
 
+    ctrlKey = ctrlKey || altKey;
     const originalXLine = this.cursor.xLine;
 
     if (ctrlKey) {
+      console.log("ctrlKey", ctrlKey);
       // ctrl key used - find last word to the left
       offsetLeft = 0;
       while (!offsetLeft) {
@@ -422,6 +426,8 @@ export default class Keys {
               Math.floor(this.annotator.width / this.annotator.charWidth) - 1;
           }
         }
+        console.log("offsetLeft", offsetLeft);
+
       }
     }
 
@@ -482,18 +488,20 @@ export default class Keys {
 
   onArrowRight({
     ctrlKey,
+    altKey,
     shiftKey,
   }: {
     ctrlKey?: boolean;
+    altKey?: boolean;
     shiftKey?: boolean;
   }) {
     // default delta to the right
     let offsetRight = 1;
 
+    ctrlKey = ctrlKey || altKey;
     const originalXLine = this.cursor.xLine;
 
     if (ctrlKey) {
-      // ctrl key used - find next word to the right
       offsetRight = 0;
       while (!offsetRight) {
         [, offsetRight] = this.text.getCursorWordOffsets(
@@ -509,12 +517,6 @@ export default class Keys {
             this.cursor.xLine = 0;
             this.cursor.yLine++;
           }
-        } else if (
-          offsetRight + this.cursor.xLine >
-          Math.floor(this.annotator.width / this.annotator.charWidth)
-        ) {
-          this.cursor.xLine = 0;
-          this.cursor.yLine++;
         }
 
         if (this.cursor.yLine > this.viewport.noLines) {
@@ -524,22 +526,55 @@ export default class Keys {
       }
     }
 
-    this.cursor.move(offsetRight, 0);
+    if (ctrlKey && offsetRight !== 0) {
+      const pos = this.text.cursorToIndex(this.viewport, this.cursor);
+      if (pos) {
+        if (this.text.mode === EditMode.RAW) {
+          const abs = this.text.getAbsTextIndexFromPosition(pos) + offsetRight;
+          const target = this.text.getSegmentFromAbsTextIndex(abs);
+          if (target) {
+            const coords = this.text.positionToCursor(this.viewport, target);
+            if (coords) {
+              this.cursor.xLine = coords.xLine;
+              this.cursor.yLine = coords.yLine;
+            }
+          }
+        } else {
+          const seg = this.text.segments[pos.segmentIndex];
+          const targetParsed = Math.max(
+            0,
+            Math.min(
+              pos.parsedTextIndex + offsetRight,
+              seg?.parsed?.length ?? 0
+            )
+          );
+          const lineChar = this.text.getLineAndCharFromSegmentParsedIndex(
+            pos.segmentIndex,
+            targetParsed
+          );
+          if (seg && lineChar) {
+            this.cursor.xLine = lineChar.charInLineIndex;
+            this.cursor.yLine =
+              seg.lineStart + lineChar.lineIndex - this.viewport.lineStart;
+          }
+        }
+      }
+    } else if (!ctrlKey) {
+      this.cursor.move(offsetRight, 0);
 
-    // check if we are at the end of the line -> move to next line
-    const line = this.text.getCurrentLine(this.viewport, this.cursor) || "";
-    let backupXLine = this.cursor.xLine;
-    let backupYLine = this.cursor.yLine;
+      const line = this.text.getCurrentLine(this.viewport, this.cursor) || "";
+      let backupXLine = this.cursor.xLine;
+      let backupYLine = this.cursor.yLine;
 
-    if (line.length < this.cursor.xLine) {
-      this.cursor.xLine = 0;
-      this.cursor.yLine++;
-    }
+      if (line.length < this.cursor.xLine) {
+        this.cursor.xLine = 0;
+        this.cursor.yLine++;
+      }
 
-    // revert if end of the document reached
-    if (!this.text.cursorToIndex(this.viewport, this.cursor)) {
-      this.cursor.xLine = backupXLine - 1;
-      this.cursor.yLine = backupYLine;
+      if (!this.text.cursorToIndex(this.viewport, this.cursor)) {
+        this.cursor.xLine = backupXLine - 1;
+        this.cursor.yLine = backupYLine;
+      }
     }
 
     if (shiftKey) {

--- a/packages/annotator/src/lib/Keys.ts
+++ b/packages/annotator/src/lib/Keys.ts
@@ -281,7 +281,19 @@ export default class Keys {
     const originalXLine = this.cursor.xLine;
     const originalAbsYline = this.viewport.lineStart + this.cursor.yLine;
 
-    if (metaKey && !shiftKey) {
+    if (metaKey && shiftKey) {
+      // Cmd + Shift + Up: select from current position to very start of text
+      this.cursor.selectStart = { xLine: 0, yLine: 0 };
+      this.cursor.selectEnd = {
+        xLine: originalXLine,
+        yLine: originalAbsYline,
+      };
+      this.viewport.scrollTo(0, this.text.noLines);
+      this.cursor.yLine = 0;
+      this.cursor.xLine = 0;
+      this.cursor.setTrueSelectionDirection();
+      return;
+    } else if (metaKey && !shiftKey) {
       // Cmd + Up: jump to very start of text (first line, col 0)
       this.viewport.scrollTo(0, this.text.noLines);
       this.cursor.yLine = 0;
@@ -359,7 +371,24 @@ export default class Keys {
     const originalXLine = this.cursor.xLine;
     const originalAbsYline = this.viewport.lineStart + this.cursor.yLine;
 
-    if (metaKey && !shiftKey) {
+    if (metaKey && shiftKey) {
+      // Cmd + Shift + Down: select from current position to end of entire text
+      const lastLineIndex = this.text.noLines > 0 ? this.text.noLines - 1 : 0;
+      const lineText = this.text.getLine(lastLineIndex) ?? "";
+      this.cursor.selectStart = {
+        xLine: originalXLine,
+        yLine: originalAbsYline,
+      };
+      this.cursor.selectEnd = {
+        xLine: lineText.length,
+        yLine: lastLineIndex,
+      };
+      this.viewport.scrollTo(this.text.noLines, this.text.noLines);
+      this.cursor.yLine = lastLineIndex - this.viewport.lineStart;
+      this.cursor.xLine = lineText.length;
+      this.cursor.setTrueSelectionDirection();
+      return;
+    } else if (metaKey && !shiftKey) {
       // Cmd + Down: jump to end of entire text
       const lastLineIndex = this.text.noLines > 0 ? this.text.noLines - 1 : 0;
       const lineText = this.text.getLine(lastLineIndex) ?? "";

--- a/packages/annotator/src/lib/Keys.ts
+++ b/packages/annotator/src/lib/Keys.ts
@@ -414,6 +414,13 @@ export default class Keys {
       this.cursor.xLine = 0;
       this.cursor.setTrueSelectionDirection();
       return;
+    } else if (metaKey && !shiftKey) {
+      // Cmd + Left: move caret to start of line, clear selection
+      this.cursor.xLine = 0;
+      this.cursor.selectStart = undefined;
+      this.cursor.selectEnd = undefined;
+      this.cursor.setTrueSelectionDirection();
+      return;
     }
 
     // default delta to the left
@@ -520,6 +527,13 @@ export default class Keys {
       };
       this.cursor.selectEnd = { xLine: line.length, yLine: absY };
       this.cursor.xLine = line.length;
+      this.cursor.setTrueSelectionDirection();
+      return;
+    } else if (metaKey && !shiftKey) {
+      // Cmd + Right: move caret to end of line, clear selection
+      this.cursor.xLine = line.length;
+      this.cursor.selectStart = undefined;
+      this.cursor.selectEnd = undefined;
       this.cursor.setTrueSelectionDirection();
       return;
     }

--- a/packages/annotator/src/lib/Keys.ts
+++ b/packages/annotator/src/lib/Keys.ts
@@ -269,9 +269,28 @@ export default class Keys {
     }
   }
 
-  onArrowUp({ ctrlKey, shiftKey }: { ctrlKey?: boolean; shiftKey?: boolean }) {
+  onArrowUp({
+    ctrlKey,
+    shiftKey,
+    metaKey,
+  }: {
+    ctrlKey?: boolean;
+    shiftKey?: boolean;
+    metaKey?: boolean;
+  }) {
     const originalXLine = this.cursor.xLine;
     const originalAbsYline = this.viewport.lineStart + this.cursor.yLine;
+
+    if (metaKey && !shiftKey) {
+      // Cmd + Up: jump to very start of text (first line, col 0)
+      this.viewport.scrollTo(0, this.text.noLines);
+      this.cursor.yLine = 0;
+      this.cursor.xLine = 0;
+      this.cursor.selectStart = undefined;
+      this.cursor.selectEnd = undefined;
+      this.cursor.setTrueSelectionDirection();
+      return;
+    }
 
     if (this.cursor.yLine <= 0) {
       // scroll up if going outside of the viewport
@@ -331,12 +350,27 @@ export default class Keys {
   onArrowDown({
     ctrlKey,
     shiftKey,
+    metaKey,
   }: {
     ctrlKey?: boolean;
     shiftKey?: boolean;
+    metaKey?: boolean;
   }) {
     const originalXLine = this.cursor.xLine;
     const originalAbsYline = this.viewport.lineStart + this.cursor.yLine;
+
+    if (metaKey && !shiftKey) {
+      // Cmd + Down: jump to end of entire text
+      const lastLineIndex = this.text.noLines > 0 ? this.text.noLines - 1 : 0;
+      const lineText = this.text.getLine(lastLineIndex) ?? "";
+      this.viewport.scrollTo(this.text.noLines, this.text.noLines);
+      this.cursor.yLine = lastLineIndex - this.viewport.lineStart;
+      this.cursor.xLine = lineText.length;
+      this.cursor.selectStart = undefined;
+      this.cursor.selectEnd = undefined;
+      this.cursor.setTrueSelectionDirection();
+      return;
+    }
 
     this.cursor.move(0, 1);
 

--- a/packages/annotator/src/lib/Text.ts
+++ b/packages/annotator/src/lib/Text.ts
@@ -625,6 +625,41 @@ class Text {
     return this.segments[segment.segmentIndex].lines[segment.lineIndex] || "";
   }
 
+  getLineAndCharFromSegmentParsedIndex(
+    segmentIndex: number,
+    parsedIndex: number
+  ): { lineIndex: number; charInLineIndex: number } | null {
+    const segment = this.segments[segmentIndex];
+    if (!segment) return null;
+    const parsed = Math.max(0, Math.min(parsedIndex, segment.parsed.length));
+    let remaining = parsed;
+    for (let i = 0; i < segment.lines.length; i++) {
+      const lineLen = segment.lines[i].length;
+      if (remaining < lineLen) {
+        return { lineIndex: i, charInLineIndex: remaining };
+      }
+      remaining -= lineLen;
+    }
+    const last = segment.lines.length - 1;
+    return {
+      lineIndex: last,
+      charInLineIndex: segment.lines[last]?.length ?? 0,
+    };
+  }
+
+  positionToCursor(
+    viewport: Viewport,
+    pos: SegmentPosition
+  ): { xLine: number; yLine: number } | null {
+    const segment = this.segments[pos.segmentIndex];
+    if (!segment) return null;
+    const absLine = segment.lineStart + pos.lineIndex;
+    return {
+      xLine: pos.charInLineIndex,
+      yLine: absLine - viewport.lineStart,
+    };
+  }
+
   /**
    * Converts absolute line index to segment position.
    * 
@@ -786,24 +821,66 @@ class Text {
     return out;
   }
 
-  /**
-   * Finds word boundaries around a given text index.
-   * 
-   * @param text - The text to search in
-   * @param index - The character index within the text
-   * @returns Tuple of [startOffset, endOffset] relative to the word boundaries
-   */
-  findWordOffsets(text: string, index: number): [number, number] {
-    const wordRegex = /[^\s,.]+/g; // Match any sequence of characters that are not whitespace, comma, or dot
+  findWordOffsetsInXml(text: string, index: number): [number, number] {
+    let i = index - 1;
+    while (i >= 0 && text[i] !== "<" && text[i] !== ">") {
+      i--;
+    }
+    const leftBound = i < 0 ? ">" : text[i];
+    const tagStart = i;
+    if (leftBound === "<") {
+      const close = text.indexOf(">", tagStart);
+      if (close !== -1) {
+        if (index <= close) {
+          return [-(index - tagStart), close - index];
+        }
+      }
+    }
+    const contentRegex = /[^\s,.<>]+/g;
     let match;
+    const matches: { start: number; end: number }[] = [];
+    while ((match = contentRegex.exec(text)) !== null) {
+      matches.push({ start: match.index, end: match.index + match[0].length });
+    }
+    for (const { start, end } of matches) {
+      if (index >= start && index < end) {
+        return [-(index - start), end - index];
+      }
+      if (index === end && text[index] === "<") {
+        const close = text.indexOf(">", index);
+        if (close !== -1) {
+          return [-(index - start), close - index + 1];
+        }
+        return [-(index - start), 0];
+      }
+      if (index === start - 1 && text[index] === ">") {
+        const nextAngle = text.indexOf("<", index + 1);
+        if (nextAngle !== -1) {
+          return [0, nextAngle - index];
+        }
+        return [0, end - index];
+      }
+    }
+    if (index < text.length && text[index] === "<") {
+      const close = text.indexOf(">", index);
+      if (close !== -1) {
+        return [0, close - index + 1];
+      }
+      return [-1, 1];
+    }
+    if (index < text.length && text[index] === ">") {
+      return [-1, 1];
+    }
+    return [0, 0];
+  }
 
-    // Find all matches of words in the text
+  findWordOffsets(text: string, index: number): [number, number] {
+    const wordRegex = /[^\s,.]+/g;
+    let match;
     const matches = [];
     while ((match = wordRegex.exec(text)) !== null) {
       matches.push({ start: match.index, end: match.index + match[0].length });
     }
-
-    // Find the word containing the given index
     let wordIndices;
     for (let i = 0; i < matches.length; i++) {
       const { start, end } = matches[i];
@@ -812,16 +889,11 @@ class Text {
         break;
       }
     }
-
-    // If no word contains the given index, return default offsets
     if (!wordIndices) {
       return [0, 0];
     }
-
-    // Calculate offsets relative to the word's start and end indices
     const startOffset = index - wordIndices.start;
     const endOffset = wordIndices.end - index;
-
     return [-startOffset, endOffset];
   }
 
@@ -847,9 +919,9 @@ class Text {
     if (this.mode === EditMode.RAW) {
       text = this.segments[position.segmentIndex].raw;
       textIndex = position.rawTextIndex;
+      return this.findWordOffsetsInXml(text, textIndex);
     }
-
-    return this.findWordOffsets(text, textIndex);
+    return this.findWordOffsetsInXml(text, textIndex);
   }
 
   /**


### PR DESCRIPTION
should handle both mac+win keysstokes

Closes #2821 

Also add other metaKey + arrow shortcuts for mac - jump to end / start of the line and jump to end / start of the document