### PR TITLE
refactor(batch reorder): move the reorder logic to BE

### DIFF
--- a/packages/client/src/api.tsx
+++ b/packages/client/src/api.tsx
@@ -1081,6 +1081,24 @@ class Api {
     }
   }
 
+  async statementsBatchReorder(
+    updates: { id: string; order: number }[],
+    options?: IApiOptions
+  ): Promise<AxiosResponse<IResponseGeneric>> {
+    try {
+      const response = await this.connection.put(
+        `/statements/batch-reorder`,
+        {
+          updates,
+        },
+        options
+      );
+      return response;
+    } catch (err) {
+      throw this.handleError(err);
+    }
+  }
+
   async statementsReferencesReplace(
     statementsIds: string[],
     references: IReference[],

--- a/packages/client/src/pages/Main/containers/StatementsListBox/StatementListBox.tsx
+++ b/packages/client/src/pages/Main/containers/StatementsListBox/StatementListBox.tsx
@@ -774,21 +774,20 @@ export const StatementListBox: React.FC = () => {
         }
       });
 
-      // Update each statement's order
-      const updates = finalOrder.map((statement, index) => {
-        const order = index * 100; // Use increments of 100 to leave room for future insertions
-        return api.entityUpdate(statement.id, {
-          data: {
-            ...statement.data,
-            territory: {
-              ...statement.data.territory,
-              order,
-            },
-          },
-        });
-      });
+      const currentOrderMap = new Map(
+        statements.map((statement) => [statement.id, statement.data.territory?.order])
+      );
 
-      await Promise.all(updates);
+      const updates = finalOrder
+        .map((statement, index) => ({
+          id: statement.id,
+          order: index + 1,
+        }))
+        .filter(({ id, order }) => currentOrderMap.get(id) !== order);
+
+      if (updates.length) {
+        await api.statementsBatchReorder(updates);
+      }
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["territory"] });

--- a/packages/server/src/modules/statements/index.ts
+++ b/packages/server/src/modules/statements/index.ts
@@ -23,7 +23,6 @@ import Entity from "@models/entity/entity";
 import Reference from "@models/entity/reference";
 import Relation from "@models/relation/relation";
 import { getRelationClass } from "@models/factory";
-import treeCache from "@service/treeCache";
 
 export default Router()
   /**
@@ -442,8 +441,6 @@ export default Router()
           )
           .run(request.db.connection);
       }
-
-      await treeCache.initialize();
 
       return {
         result: true,

--- a/packages/server/src/modules/statements/index.ts
+++ b/packages/server/src/modules/statements/index.ts
@@ -337,6 +337,102 @@ export default Router()
 
   /**
    * @openapi
+   * /statements/batch-reorder:
+   *   put:
+   *     description: Reorder N statements by setting exact territory order values
+   *     tags:
+   *       - entities
+   *     requestBody:
+   *       description: list of statement ids with target order
+   *       content:
+   *         application/json:
+   *           schema:
+   *             type: object
+   *             properties:
+   *               updates:
+   *                 type: array
+   *                 items:
+   *                   type: object
+   *                   properties:
+   *                     id:
+   *                       type: string
+   *                     order:
+   *                       type: number
+   *     responses:
+   *       200:
+   *         description: Returns generic response
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: "#/components/schemas/IResponseGeneric"
+   */
+  .put(
+    "/batch-reorder",
+    asyncRouteHandler<IResponseGeneric>(async (request: IRequest) => {
+      const updates = request.body?.updates as
+        | { id: string; order: number }[]
+        | undefined;
+
+      if (!updates || updates.constructor.name !== "Array" || !updates.length) {
+        throw new BadParams("updates are required");
+      }
+
+      if (
+        updates.some(
+          (item) =>
+            !item ||
+            typeof item.id !== "string" ||
+            item.id.length === 0 ||
+            typeof item.order !== "number" ||
+            Number.isNaN(item.order)
+        )
+      ) {
+        throw new BadParams("invalid updates payload");
+      }
+
+      const uniqueIds = Array.from(new Set(updates.map((item) => item.id)));
+      if (uniqueIds.length !== updates.length) {
+        throw new BadParams("duplicate statement ids are not allowed");
+      }
+
+      await request.db.lock();
+
+      const statements = await Entity.findEntitiesByIds(request.db.connection, uniqueIds);
+      const statementsCount = statements.reduce(
+        (acc, cur) => (cur.class === EntityEnums.Class.Statement ? acc + 1 : acc),
+        0
+      );
+      if (statementsCount !== uniqueIds.length) {
+        throw new StatementDoesNotExits("at least one statement not found", "");
+      }
+
+      const updatesMap = new Map(updates.map((item) => [item.id, item.order]));
+
+      for (const statementData of statements) {
+        const statement = new Statement(statementData as IStatement);
+        const nextOrder = updatesMap.get(statement.id);
+
+        if (nextOrder === undefined || statement.data.territory?.order === nextOrder) {
+          continue;
+        }
+
+        statement.data.territory = new StatementTerritory({
+          territoryId: statement.data.territory?.territoryId,
+          order: nextOrder,
+        });
+
+        await statement.update(request.db.connection, { data: statement.data });
+      }
+
+      return {
+        result: true,
+        message: `${updates.length} statements reordered`,
+      };
+    })
+  )
+
+  /**
+   * @openapi
    * /statements/references:
    *   put:
    *     description: Handles batch update for statements references according to replace flag

--- a/packages/server/src/modules/statements/index.ts
+++ b/packages/server/src/modules/statements/index.ts
@@ -1,4 +1,5 @@
 import { Router } from "express";
+import { r as rethink } from "rethinkdb-ts";
 import { findEntityById } from "@service/shorthands";
 import {
   BadParams,
@@ -22,6 +23,7 @@ import Entity from "@models/entity/entity";
 import Reference from "@models/entity/reference";
 import Relation from "@models/relation/relation";
 import { getRelationClass } from "@models/factory";
+import treeCache from "@service/treeCache";
 
 export default Router()
   /**
@@ -409,20 +411,28 @@ export default Router()
       const updatesMap = new Map(updates.map((item) => [item.id, item.order]));
 
       for (const statementData of statements) {
-        const statement = new Statement(statementData as IStatement);
-        const nextOrder = updatesMap.get(statement.id);
+        const nextOrder = updatesMap.get(statementData.id);
+        const currentTerritoryId = (statementData as IStatement).data.territory?.territoryId;
 
-        if (nextOrder === undefined || statement.data.territory?.order === nextOrder) {
+        if (
+          nextOrder === undefined ||
+          !currentTerritoryId ||
+          (statementData as IStatement).data.territory?.order === nextOrder
+        ) {
           continue;
         }
 
-        statement.data.territory = new StatementTerritory({
-          territoryId: statement.data.territory?.territoryId,
-          order: nextOrder,
-        });
-
-        await statement.update(request.db.connection, { data: statement.data });
+        await rethink
+          .table(Entity.table)
+          .get(statementData.id)
+          .update({
+            data: { territory: { territoryId: currentTerritoryId, order: nextOrder } },
+            updatedAt: new Date(),
+          })
+          .run(request.db.connection);
       }
+
+      await treeCache.initialize();
 
       return {
         result: true,

--- a/packages/server/src/modules/statements/index.ts
+++ b/packages/server/src/modules/statements/index.ts
@@ -1,5 +1,5 @@
 import { Router } from "express";
-import { r as rethink } from "rethinkdb-ts";
+import { r as rethink, RDatum } from "rethinkdb-ts";
 import { findEntityById } from "@service/shorthands";
 import {
   BadParams,
@@ -408,27 +408,38 @@ export default Router()
         throw new StatementDoesNotExits("at least one statement not found", "");
       }
 
-      const updatesMap = new Map(updates.map((item) => [item.id, item.order]));
+      const currentOrderById = new Map(
+        statements.map((s) => [s.id, (s as IStatement).data.territory?.order])
+      );
+      const territoryIdById = new Map(
+        statements.map((s) => [s.id, (s as IStatement).data.territory?.territoryId])
+      );
 
-      for (const statementData of statements) {
-        const nextOrder = updatesMap.get(statementData.id);
-        const currentTerritoryId = (statementData as IStatement).data.territory?.territoryId;
+      const updatesPayload = updates
+        .filter((u) => {
+          const tid = territoryIdById.get(u.id);
+          const current = currentOrderById.get(u.id);
+          return !!tid && current !== u.order;
+        })
+        .map((u) => ({
+          id: u.id,
+          territoryId: territoryIdById.get(u.id) as string,
+          order: u.order,
+        }));
 
-        if (
-          nextOrder === undefined ||
-          !currentTerritoryId ||
-          (statementData as IStatement).data.territory?.order === nextOrder
-        ) {
-          continue;
-        }
-
+      if (updatesPayload.length > 0) {
+        const now = new Date();
         await rethink
-          .table(Entity.table)
-          .get(statementData.id)
-          .update({
-            data: { territory: { territoryId: currentTerritoryId, order: nextOrder } },
-            updatedAt: new Date(),
-          })
+          .expr(updatesPayload)
+          .forEach((u: RDatum) =>
+            rethink
+              .table(Entity.table)
+              .get(u("id"))
+              .update({
+                data: { territory: { territoryId: u("territoryId"), order: u("order") } },
+                updatedAt: now,
+              })
+          )
           .run(request.db.connection);
       }
 

--- a/packages/server/src/modules/statements/statements.batch-reorder.test.ts
+++ b/packages/server/src/modules/statements/statements.batch-reorder.test.ts
@@ -119,7 +119,9 @@ describe("statements/batch-reorder", function () {
       expect(after3.data.territory.order).toBe(10);
     });
 
-    it("should handle reordering many statements in a single request", async () => {
+    it(
+      "should handle reordering many statements in a single request",
+      async () => {
       const N = 50;
       const stmts: Statement[] = [];
       for (let i = 0; i < N; i++) {
@@ -155,6 +157,8 @@ describe("statements/batch-reorder", function () {
         const after = await findEntityById(db, stmts[i].id);
         expect(after.data.territory.order).toBe(1000 + (N - 1 - i));
       }
-    });
+    },
+    30_000
+  );
   });
 });

--- a/packages/server/src/modules/statements/statements.batch-reorder.test.ts
+++ b/packages/server/src/modules/statements/statements.batch-reorder.test.ts
@@ -1,0 +1,85 @@
+import { createMockTree, testErroneousResponse } from "@modules/common.test";
+import { BadParams, StatementDoesNotExits } from "@shared/types/errors";
+import request from "supertest";
+import { supertestConfig } from "..";
+import { apiPath } from "@common/constants";
+import app from "../../Server";
+import { Db } from "@service/rethink";
+import { findEntityById } from "@service/shorthands";
+import Statement, { StatementTerritory } from "@models/statement/statement";
+import treeCache from "@service/treeCache";
+import { pool } from "@middlewares/db";
+
+describe("statements/batch-reorder", function () {
+  afterAll(async () => {
+    await pool.end();
+  });
+
+  describe("Empty/Invalid params", () => {
+    it("should return a BadParams error wrapped in IResponseGeneric for empty params", async () => {
+      await request(app)
+        .put(`${apiPath}/statements/batch-reorder`)
+        .set("authorization", "Bearer " + supertestConfig.token)
+        .expect(testErroneousResponse.bind(undefined, new BadParams("")));
+    });
+  });
+
+  describe("Provided params", () => {
+    const db = new Db();
+    const randSuffix = Math.random().toString();
+    let rootId = "";
+
+    beforeAll(async () => {
+      await db.initDb();
+      await createMockTree(db, randSuffix);
+      treeCache.db = db.connection;
+      treeCache.tree = await treeCache.createTree();
+      rootId = `root-${randSuffix}`;
+    });
+
+    afterAll(async () => {
+      await db.close();
+    });
+
+    it("should return StatementDoesNotExits for unknown statement id", async () => {
+      await request(app)
+        .put(`${apiPath}/statements/batch-reorder`)
+        .send({ updates: [{ id: "missing-id", order: 100 }] })
+        .set("authorization", "Bearer " + supertestConfig.token)
+        .expect(
+          testErroneousResponse.bind(undefined, new StatementDoesNotExits("", ""))
+        );
+    });
+
+    it("should update statement orders in one request", async () => {
+      const statement1 = new Statement({});
+      const statement2 = new Statement({});
+      statement1.data.territory = new StatementTerritory({
+        territoryId: rootId,
+        order: 100,
+      });
+      statement2.data.territory = new StatementTerritory({
+        territoryId: rootId,
+        order: 200,
+      });
+      await statement1.save(db.connection);
+      await statement2.save(db.connection);
+
+      await request(app)
+        .put(`${apiPath}/statements/batch-reorder`)
+        .send({
+          updates: [
+            { id: statement1.id, order: 200 },
+            { id: statement2.id, order: 100 },
+          ],
+        })
+        .set("authorization", "Bearer " + supertestConfig.token)
+        .expect((resp) => !!resp.body.result);
+
+      const statement1After = await findEntityById(db, statement1.id);
+      const statement2After = await findEntityById(db, statement2.id);
+      expect(statement1After.data.territory.order).toEqual(200);
+      expect(statement2After.data.territory.order).toEqual(100);
+    });
+  });
+});

--- a/packages/server/src/modules/statements/statements.batch-reorder.test.ts
+++ b/packages/server/src/modules/statements/statements.batch-reorder.test.ts
@@ -74,12 +74,87 @@ describe("statements/batch-reorder", function () {
           ],
         })
         .set("authorization", "Bearer " + supertestConfig.token)
-        .expect((resp) => !!resp.body.result);
+        .expect(200)
+        .expect((resp) => {
+          expect(resp.body.result).toBe(true);
+        });
 
       const statement1After = await findEntityById(db, statement1.id);
       const statement2After = await findEntityById(db, statement2.id);
       expect(statement1After.data.territory.order).toEqual(200);
       expect(statement2After.data.territory.order).toEqual(100);
+    });
+
+    it("should persist the exact order values requested, even when they collide with existing orders", async () => {
+      const s1 = new Statement({});
+      const s2 = new Statement({});
+      const s3 = new Statement({});
+      s1.data.territory = new StatementTerritory({ territoryId: rootId, order: 10 });
+      s2.data.territory = new StatementTerritory({ territoryId: rootId, order: 20 });
+      s3.data.territory = new StatementTerritory({ territoryId: rootId, order: 30 });
+      await s1.save(db.connection);
+      await s2.save(db.connection);
+      await s3.save(db.connection);
+
+      // Reverse the order: s1->30, s2->20, s3->10. Every target collides
+      // with an existing sibling — the legacy code path produced fractional
+      // orders here.
+      await request(app)
+        .put(`${apiPath}/statements/batch-reorder`)
+        .send({
+          updates: [
+            { id: s1.id, order: 30 },
+            { id: s2.id, order: 20 },
+            { id: s3.id, order: 10 },
+          ],
+        })
+        .set("authorization", "Bearer " + supertestConfig.token)
+        .expect(200);
+
+      const after1 = await findEntityById(db, s1.id);
+      const after2 = await findEntityById(db, s2.id);
+      const after3 = await findEntityById(db, s3.id);
+      expect(after1.data.territory.order).toBe(30);
+      expect(after2.data.territory.order).toBe(20);
+      expect(after3.data.territory.order).toBe(10);
+    });
+
+    it("should handle reordering many statements in a single request", async () => {
+      const N = 50;
+      const stmts: Statement[] = [];
+      for (let i = 0; i < N; i++) {
+        const s = new Statement({});
+        s.data.territory = new StatementTerritory({
+          territoryId: rootId,
+          order: 1000 + i, // far from other tests' values to avoid cross-test interference
+        });
+        await s.save(db.connection);
+        stmts.push(s);
+      }
+
+      // Reverse them
+      const updates = stmts.map((s, i) => ({
+        id: s.id,
+        order: 1000 + (N - 1 - i),
+      }));
+
+      const start = Date.now();
+      await request(app)
+        .put(`${apiPath}/statements/batch-reorder`)
+        .send({ updates })
+        .set("authorization", "Bearer " + supertestConfig.token)
+        .expect(200);
+      const elapsedMs = Date.now() - start;
+
+      // Generous bound — pre-fix this would balloon with `treeCache.initialize()`
+      // disabled in tests but is still fine. Mostly a regression guard against
+      // anyone reintroducing per-row sibling lookups.
+      expect(elapsedMs).toBeLessThan(5_000);
+
+      for (let i = 0; i < N; i++) {
+        const after = await findEntityById(db, stmts[i].id);
+        expect(after.data.territory.order).toBe(1000 + (N - 1 - i));
+      }
     });
   });
 });


### PR DESCRIPTION
There's auto order button in statement list to fix the order relevant to the order of the statements in document. It used to send api call for each statement, now it was moved to BE. The solution on client gets often timed out. This seems to still take quite a lot of the time so the only improvement is less api calls. Is there a way to optimize this?