### PR TITLE
2885 move annotation span with button

### DIFF
--- a/packages/annotator/src/lib/Annotator.ts
+++ b/packages/annotator/src/lib/Annotator.ts
@@ -1872,47 +1872,83 @@ export class Annotator {
       return false;
     }
 
+    const findTagEndFrom = (startIndex: number): number => {
+      const end = rawText.indexOf(">", startIndex);
+      return end;
+    };
+
+    const findTagStartFrom = (endIndex: number): number => {
+      const start = rawText.lastIndexOf("<", endIndex);
+      return start;
+    };
+
+    const findNextVisibleChar = (fromIndex: number, maxExclusive: number): number => {
+      let i = fromIndex;
+      while (i < maxExclusive) {
+        const ch = rawText[i];
+        if (ch === "<") {
+          const tagEnd = findTagEndFrom(i);
+          if (tagEnd === -1) return -1;
+          i = tagEnd + 1;
+          continue;
+        }
+        return i;
+      }
+      return -1;
+    };
+
+    const findPrevVisibleChar = (fromIndex: number, minInclusive: number): number => {
+      let i = fromIndex;
+      while (i >= minInclusive) {
+        const ch = rawText[i];
+        if (ch === ">") {
+          const tagStart = findTagStartFrom(i);
+          if (tagStart === -1) return -1;
+          i = tagStart - 1;
+          continue;
+        }
+        return i;
+      }
+      return -1;
+    };
+
     let nextRaw = rawText;
 
     if (boundary === "start" && direction === "right") {
-      const charIndex = openAbs + openLen;
-      if (charIndex >= closeAbs || charIndex >= rawText.length) return false;
-      const movedChar = rawText[charIndex];
-      if (movedChar === "<") return false;
+      const charIndex = findNextVisibleChar(openAbs + openLen, closeAbs);
+      if (charIndex === -1) return false;
+      const movedBlock = rawText.slice(openAbs + openLen, charIndex + 1);
       nextRaw =
         rawText.slice(0, openAbs) +
-        movedChar +
+        movedBlock +
         openTagString +
         rawText.slice(charIndex + 1);
     } else if (boundary === "start" && direction === "left") {
-      const charIndex = openAbs - 1;
-      if (charIndex < 0) return false;
-      const movedChar = rawText[charIndex];
-      if (movedChar === ">") return false;
+      const charIndex = findPrevVisibleChar(openAbs - 1, 0);
+      if (charIndex === -1) return false;
+      const movedBlock = rawText.slice(charIndex, openAbs);
       nextRaw =
         rawText.slice(0, charIndex) +
         openTagString +
-        movedChar +
+        movedBlock +
         rawText.slice(openAbs + openLen);
     } else if (boundary === "end" && direction === "right") {
-      const charIndex = closeAbs + closeLen;
-      if (charIndex >= rawText.length) return false;
-      const movedChar = rawText[charIndex];
-      if (movedChar === "<") return false;
+      const charIndex = findNextVisibleChar(closeAbs + closeLen, rawText.length);
+      if (charIndex === -1) return false;
+      const movedBlock = rawText.slice(closeAbs + closeLen, charIndex + 1);
       nextRaw =
         rawText.slice(0, closeAbs) +
-        movedChar +
+        movedBlock +
         closeTagString +
         rawText.slice(charIndex + 1);
     } else {
-      const charIndex = closeAbs - 1;
-      if (charIndex < openAbs + openLen || charIndex < 0) return false;
-      const movedChar = rawText[charIndex];
-      if (movedChar === ">") return false;
+      const charIndex = findPrevVisibleChar(closeAbs - 1, openAbs + openLen);
+      if (charIndex === -1) return false;
+      const movedBlock = rawText.slice(charIndex, closeAbs);
       nextRaw =
         rawText.slice(0, charIndex) +
         closeTagString +
-        movedChar +
+        movedBlock +
         rawText.slice(closeAbs + closeLen);
     }
 

--- a/packages/annotator/src/lib/Annotator.ts
+++ b/packages/annotator/src/lib/Annotator.ts
@@ -1809,6 +1809,126 @@ export class Annotator {
   }
 
   /**
+   * Moves one anchor boundary by one character.
+   * Uses a safe tag/character swap to preserve markup validity.
+   */
+  nudgeAnchorBoundary(
+    anchorTag: Tag,
+    boundary: "start" | "end",
+    direction: "left" | "right"
+  ): boolean {
+    if (anchorTag.closing) {
+      throw new Error("nudgeAnchorBoundary only accepts opening tags");
+    }
+
+    const anchorName = anchorTag.getTagName();
+    const anchorSegIdx = anchorTag.segmentIndex;
+    const anchorPos = anchorTag.position;
+    const openSegment = this.text.segments[anchorSegIdx];
+    if (!openSegment) {
+      return false;
+    }
+
+    const openTag = openSegment.openingTags.find(
+      (tag) => tag.getTagName() === anchorName && tag.position === anchorPos
+    );
+    if (!openTag) {
+      return false;
+    }
+
+    let closeTag: Tag | undefined;
+    let closeSegIdx = -1;
+    for (let i = anchorSegIdx; i < this.text.segments.length; i++) {
+      const seg = this.text.segments[i];
+      const candidates =
+        i === anchorSegIdx
+          ? seg.closingTags.filter((t) => t.position > anchorPos)
+          : seg.closingTags;
+      closeTag = candidates.find((tag) => tag.getTagName() === anchorName);
+      if (closeTag) {
+        closeSegIdx = i;
+        break;
+      }
+    }
+
+    if (!closeTag || closeSegIdx === -1) {
+      return false;
+    }
+
+    const rawText = this.text.value;
+    const openTagString = openTag.getTag();
+    const closeTagString = closeTag.getTag();
+    const openLen = openTagString.length;
+    const closeLen = closeTagString.length;
+    const openAbs = openTag.getAbsoluteTagPosition(this.text.segments);
+    const closeAbs = closeTag.getAbsoluteTagPosition(this.text.segments);
+
+    if (
+      openAbs < 0 ||
+      closeAbs < 0 ||
+      openAbs + openLen > rawText.length ||
+      closeAbs + closeLen > rawText.length
+    ) {
+      return false;
+    }
+
+    let nextRaw = rawText;
+
+    if (boundary === "start" && direction === "right") {
+      const charIndex = openAbs + openLen;
+      if (charIndex >= closeAbs || charIndex >= rawText.length) return false;
+      const movedChar = rawText[charIndex];
+      if (movedChar === "<") return false;
+      nextRaw =
+        rawText.slice(0, openAbs) +
+        movedChar +
+        openTagString +
+        rawText.slice(charIndex + 1);
+    } else if (boundary === "start" && direction === "left") {
+      const charIndex = openAbs - 1;
+      if (charIndex < 0) return false;
+      const movedChar = rawText[charIndex];
+      if (movedChar === ">") return false;
+      nextRaw =
+        rawText.slice(0, charIndex) +
+        openTagString +
+        movedChar +
+        rawText.slice(openAbs + openLen);
+    } else if (boundary === "end" && direction === "right") {
+      const charIndex = closeAbs + closeLen;
+      if (charIndex >= rawText.length) return false;
+      const movedChar = rawText[charIndex];
+      if (movedChar === "<") return false;
+      nextRaw =
+        rawText.slice(0, closeAbs) +
+        movedChar +
+        closeTagString +
+        rawText.slice(charIndex + 1);
+    } else {
+      const charIndex = closeAbs - 1;
+      if (charIndex < openAbs + openLen || charIndex < 0) return false;
+      const movedChar = rawText[charIndex];
+      if (movedChar === ">") return false;
+      nextRaw =
+        rawText.slice(0, charIndex) +
+        closeTagString +
+        movedChar +
+        rawText.slice(closeAbs + closeLen);
+    }
+
+    if (nextRaw === rawText) {
+      return false;
+    }
+
+    this.text.value = nextRaw;
+    this.text.prepareSegments();
+    this.text.calculateLines();
+    this.warnings.onTextChanged(this.text.value);
+    this.draw();
+    return true;
+  }
+
+  /**
    * Scrolls the viewport to the anchor and moves the caret to the first character
    * inside the anchor (after the opening tag in raw text).
    * Uses {@link Text.getSegmentFromAbsTextIndex} so line/column match RAW/XML and

--- a/packages/client/src/components/advanced/Annotator/Annotator.tsx
+++ b/packages/client/src/components/advanced/Annotator/Annotator.tsx
@@ -898,6 +898,18 @@ export const TextAnnotator = ({
     handleSaveNewContent(true, true);
   };
 
+  const onNudgeAnchorSpan = (
+    anchor: Tag,
+    boundary: "start" | "end",
+    direction: "left" | "right"
+  ): boolean => {
+    return Boolean(annotator?.nudgeAnchorBoundary(anchor, boundary, direction));
+  };
+
+  const onCommitAnchorSpanEdits = () => {
+    handleSaveNewContent(true, true);
+  };
+
   const isMenuDisplayed = useMemo<boolean>(() => {
     return (
       annotatorMode === EditMode.HIGHLIGHT &&
@@ -1104,6 +1116,8 @@ export const TextAnnotator = ({
                       onCreateStatement={onCreateStatement}
                       onRemoveAnchor={onRemoveAnchor}
                       onUpdateAnchor={onUpdateAnchor}
+                      onNudgeAnchorSpan={onNudgeAnchorSpan}
+                      onCommitAnchorSpanEdits={onCommitAnchorSpanEdits}
                       isTextInsideThisT={selectedAnchors.some(
                         (anchor) => anchor.getTagName() === thisTerritoryEntityId
                       )}

--- a/packages/client/src/components/advanced/Annotator/AnnotatorMenu.tsx
+++ b/packages/client/src/components/advanced/Annotator/AnnotatorMenu.tsx
@@ -72,6 +72,12 @@ interface TextAnnotatorMenuProps {
   onEscapePressed: () => void;
   disableCreate?: boolean;
   onUpdateAnchor?: (anchor: Tag, elvl: EntityEnums.Elvl) => void;
+  onNudgeAnchorSpan?: (
+    anchor: Tag,
+    boundary: "start" | "end",
+    direction: "left" | "right"
+  ) => boolean;
+  onCommitAnchorSpanEdits?: () => void;
 
   isLoading: boolean;
 
@@ -89,6 +95,8 @@ export const TextAnnotatorMenu = ({
   onCreateActiveTAnchor = undefined,
   onRemoveAnchor = undefined,
   onUpdateAnchor = undefined,
+  onNudgeAnchorSpan = undefined,
+  onCommitAnchorSpanEdits = undefined,
   canCreateActiveTAnchor,
   hasParentT,
   isTextInsideThisT,
@@ -141,10 +149,16 @@ export const TextAnnotatorMenu = ({
 
   const resolvedAnchors = useMemo((): AnnotatorAnchorListItem[] => {
     const out: AnnotatorAnchorListItem[] = [];
+    let occurrence = 0;
     for (const anchor of anchors) {
       const anchorTagName = anchor.getTagName();
       if (entities[anchorTagName]) {
-        out.push({ anchor, anchorTagName });
+        out.push({
+          anchor,
+          anchorTagName,
+          stableKey: `${anchorTagName}:${occurrence}`,
+        });
+        occurrence += 1;
       }
     }
     return out;
@@ -156,8 +170,17 @@ export const TextAnnotatorMenu = ({
       entities,
       onRemoveAnchor,
       onUpdateAnchor,
+      onNudgeAnchorSpan,
+      onCommitAnchorSpanEdits,
     }),
-    [resolvedAnchors, entities, onRemoveAnchor, onUpdateAnchor]
+    [
+      resolvedAnchors,
+      entities,
+      onRemoveAnchor,
+      onUpdateAnchor,
+      onNudgeAnchorSpan,
+      onCommitAnchorSpanEdits,
+    ]
   );
 
   return (

--- a/packages/client/src/components/advanced/Annotator/AnnotatorMenu.tsx
+++ b/packages/client/src/components/advanced/Annotator/AnnotatorMenu.tsx
@@ -135,6 +135,9 @@ export const TextAnnotatorMenu = ({
   const [territoryElvl, setTerritoryElvl] = useState<EntityEnums.Elvl>(
     EntityEnums.Elvl.Textual
   );
+  const [editingAnchorKey, setEditingAnchorKey] = useState<string | null>(null);
+  const [hasPendingSpanEditChanges, setHasPendingSpanEditChanges] =
+    useState<boolean>(false);
 
   const someAnchorsWithoutElvl = useMemo(
     () =>
@@ -149,16 +152,17 @@ export const TextAnnotatorMenu = ({
 
   const resolvedAnchors = useMemo((): AnnotatorAnchorListItem[] => {
     const out: AnnotatorAnchorListItem[] = [];
-    let occurrence = 0;
+    const occurrenceByTagName = new Map<string, number>();
     for (const anchor of anchors) {
       const anchorTagName = anchor.getTagName();
       if (entities[anchorTagName]) {
+        const occurrenceForTag = occurrenceByTagName.get(anchorTagName) ?? 0;
         out.push({
           anchor,
           anchorTagName,
-          stableKey: `${anchorTagName}:${occurrence}`,
+          stableKey: `${anchorTagName}:${occurrenceForTag}`,
         });
-        occurrence += 1;
+        occurrenceByTagName.set(anchorTagName, occurrenceForTag + 1);
       }
     }
     return out;
@@ -172,6 +176,10 @@ export const TextAnnotatorMenu = ({
       onUpdateAnchor,
       onNudgeAnchorSpan,
       onCommitAnchorSpanEdits,
+      editingAnchorKey,
+      hasPendingSpanEditChanges,
+      setEditingAnchorKey,
+      setHasPendingSpanEditChanges,
     }),
     [
       resolvedAnchors,
@@ -180,6 +188,8 @@ export const TextAnnotatorMenu = ({
       onUpdateAnchor,
       onNudgeAnchorSpan,
       onCommitAnchorSpanEdits,
+      editingAnchorKey,
+      hasPendingSpanEditChanges,
     ]
   );
 

--- a/packages/client/src/components/advanced/Annotator/AnnotatorMenuAnchorListRow.tsx
+++ b/packages/client/src/components/advanced/Annotator/AnnotatorMenuAnchorListRow.tsx
@@ -1,21 +1,38 @@
 import { EntityEnums } from "@shared/enums";
 import { IEntity } from "@shared/types";
-import React from "react";
+import { Button } from "components/basic/Button/Button";
+import React, { useState } from "react";
+import {
+  MdKeyboardDoubleArrowLeft,
+  MdKeyboardDoubleArrowRight,
+  MdOutlineOpenWith,
+} from "react-icons/md";
 import { EntityTag } from "../EntityTag/EntityTag";
 import { ElvlButtonGroup } from "../IconButtonGroups/ElvlButtonGroup";
 import { Tag } from "@inkvisitor/annotator/src/lib";
+import { ButtonSize } from "types";
 
 export const ANCHOR_GRID_COLUMNS = 2;
 /** One virtual row: two columns for EntityTag + elvl controls (allows wrapped labels). */
 export const ANCHOR_GRID_ROW_HEIGHT = 27;
 
-export type AnnotatorAnchorListItem = { anchor: Tag; anchorTagName: string };
+export type AnnotatorAnchorListItem = {
+  anchor: Tag;
+  anchorTagName: string;
+  stableKey: string;
+};
 
 export type AnnotatorAnchorGridRowData = {
   items: AnnotatorAnchorListItem[];
   entities: Record<string, IEntity | false>;
   onRemoveAnchor?: (anchor: Tag) => void;
   onUpdateAnchor?: (anchor: Tag, elvl: EntityEnums.Elvl) => void;
+  onNudgeAnchorSpan?: (
+    anchor: Tag,
+    boundary: "start" | "end",
+    direction: "left" | "right"
+  ) => boolean;
+  onCommitAnchorSpanEdits?: () => void;
 };
 
 export type AnnotatorAnchorGridRowProps = {
@@ -26,7 +43,16 @@ export type AnnotatorAnchorGridRowProps = {
 
 export const AnnotatorAnchorGridRow = React.memo(
   ({ index, style, data }: AnnotatorAnchorGridRowProps) => {
-    const { items, entities, onRemoveAnchor, onUpdateAnchor } = data;
+    const {
+      items,
+      entities,
+      onRemoveAnchor,
+      onUpdateAnchor,
+      onNudgeAnchorSpan,
+      onCommitAnchorSpanEdits,
+    } = data;
+    const [editingAnchorKey, setEditingAnchorKey] = useState<string | null>(null);
+    const [hasPendingSpanEditChanges, setHasPendingSpanEditChanges] = useState(false);
     const left = items[index * ANCHOR_GRID_COLUMNS];
     const right = items[index * ANCHOR_GRID_COLUMNS + 1];
 
@@ -38,6 +64,8 @@ export const AnnotatorAnchorGridRow = React.memo(
       if (!entity) {
         return null;
       }
+      const anchorKey = item.stableKey;
+      const isSpanEditActive = editingAnchorKey === anchorKey;
       return (
         <EntityTag
           fullWidth
@@ -47,13 +75,108 @@ export const AnnotatorAnchorGridRow = React.memo(
             },
           }}
           entity={entity}
-          elvlButtonGroup={
-            <ElvlButtonGroup
-              value={item.anchor.attributes.elvl as EntityEnums.Elvl}
-              onChange={(elvl) => {
-                onUpdateAnchor?.(item.anchor, elvl);
+          button={
+            <div
+              style={{ display: "flex", gap: "0.125rem", alignItems: "center" }}
+              onBlur={(event) => {
+                if (!isSpanEditActive) {
+                  return;
+                }
+                const nextFocused = event.relatedTarget as Node | null;
+                if (nextFocused && event.currentTarget.contains(nextFocused)) {
+                  return;
+                }
+                setEditingAnchorKey(null);
+                if (hasPendingSpanEditChanges) {
+                  onCommitAnchorSpanEdits?.();
+                  setHasPendingSpanEditChanges(false);
+                }
               }}
-            />
+            >
+              <Button
+                color={isSpanEditActive ? "warning" : "plain"}
+                inverted
+                size={ButtonSize.Small}
+                icon={<MdOutlineOpenWith size={14} />}
+                tooltipLabel={
+                  isSpanEditActive ? "Anchor span edit mode active" : "Edit anchor span bounds"
+                }
+                onClick={() => {
+                  if (!isSpanEditActive) {
+                    setHasPendingSpanEditChanges(false);
+                    setEditingAnchorKey(anchorKey);
+                  }
+                }}
+              />
+              {isSpanEditActive && (
+                <>
+                  <Button
+                    color="plain"
+                    inverted
+                    size={ButtonSize.Small}
+                    icon={<MdKeyboardDoubleArrowLeft size={14} />}
+                    tooltipLabel="Move start tag one character left"
+                    onClick={() => {
+                      const changed = onNudgeAnchorSpan?.(item.anchor, "start", "left");
+                      if (changed) {
+                        setHasPendingSpanEditChanges(true);
+                      }
+                    }}
+                  />
+                  <Button
+                    color="plain"
+                    inverted
+                    size={ButtonSize.Small}
+                    icon={<MdKeyboardDoubleArrowRight size={14} />}
+                    tooltipLabel="Move start tag one character right"
+                    onClick={() => {
+                      const changed = onNudgeAnchorSpan?.(item.anchor, "start", "right");
+                      if (changed) {
+                        setHasPendingSpanEditChanges(true);
+                      }
+                    }}
+                  />
+                  <Button
+                    color="plain"
+                    inverted
+                    size={ButtonSize.Small}
+                    icon={<MdKeyboardDoubleArrowLeft size={14} />}
+                    tooltipLabel="Move end tag one character left"
+                    onClick={() => {
+                      const changed = onNudgeAnchorSpan?.(item.anchor, "end", "left");
+                      if (changed) {
+                        setHasPendingSpanEditChanges(true);
+                      }
+                    }}
+                  />
+                  <Button
+                    color="plain"
+                    inverted
+                    size={ButtonSize.Small}
+                    icon={<MdKeyboardDoubleArrowRight size={14} />}
+                    tooltipLabel="Move end tag one character right"
+                    onClick={() => {
+                      const changed = onNudgeAnchorSpan?.(item.anchor, "end", "right");
+                      if (changed) {
+                        setHasPendingSpanEditChanges(true);
+                      }
+                    }}
+                  />
+                </>
+              )}
+            </div>
+          }
+          elvlButtonGroup={
+            isSpanEditActive ? (
+              false
+            ) : (
+              <ElvlButtonGroup
+                value={item.anchor.attributes.elvl as EntityEnums.Elvl}
+                onChange={(elvl) => {
+                  onUpdateAnchor?.(item.anchor, elvl);
+                }}
+              />
+            )
           }
         />
       );

--- a/packages/client/src/components/advanced/Annotator/AnnotatorMenuAnchorListRow.tsx
+++ b/packages/client/src/components/advanced/Annotator/AnnotatorMenuAnchorListRow.tsx
@@ -1,7 +1,7 @@
 import { EntityEnums } from "@shared/enums";
 import { IEntity } from "@shared/types";
 import { Button } from "components/basic/Button/Button";
-import React, { useState } from "react";
+import React from "react";
 import {
   MdKeyboardDoubleArrowLeft,
   MdKeyboardDoubleArrowRight,
@@ -33,6 +33,10 @@ export type AnnotatorAnchorGridRowData = {
     direction: "left" | "right"
   ) => boolean;
   onCommitAnchorSpanEdits?: () => void;
+  editingAnchorKey: string | null;
+  hasPendingSpanEditChanges: boolean;
+  setEditingAnchorKey: (key: string | null) => void;
+  setHasPendingSpanEditChanges: (hasChanges: boolean) => void;
 };
 
 export type AnnotatorAnchorGridRowProps = {
@@ -50,9 +54,11 @@ export const AnnotatorAnchorGridRow = React.memo(
       onUpdateAnchor,
       onNudgeAnchorSpan,
       onCommitAnchorSpanEdits,
+      editingAnchorKey,
+      hasPendingSpanEditChanges,
+      setEditingAnchorKey,
+      setHasPendingSpanEditChanges,
     } = data;
-    const [editingAnchorKey, setEditingAnchorKey] = useState<string | null>(null);
-    const [hasPendingSpanEditChanges, setHasPendingSpanEditChanges] = useState(false);
     const left = items[index * ANCHOR_GRID_COLUMNS];
     const right = items[index * ANCHOR_GRID_COLUMNS + 1];
 

--- a/packages/client/src/components/advanced/Annotator/AnnotatorMenuAnchorListRow.tsx
+++ b/packages/client/src/components/advanced/Annotator/AnnotatorMenuAnchorListRow.tsx
@@ -36,8 +36,8 @@ export type AnnotatorAnchorGridRowData = {
   onCommitAnchorSpanEdits?: () => void;
   editingAnchorKey: string | null;
   hasPendingSpanEditChanges: boolean;
-  setEditingAnchorKey: (key: string | null) => void;
-  setHasPendingSpanEditChanges: (hasChanges: boolean) => void;
+  setEditingAnchorKey: React.Dispatch<React.SetStateAction<string | null>>;
+  setHasPendingSpanEditChanges: React.Dispatch<React.SetStateAction<boolean>>;
 };
 
 export type AnnotatorAnchorGridRowProps = {
@@ -85,23 +85,7 @@ export const AnnotatorAnchorGridRow = React.memo(
           disableClick={isSpanEditActive}
           disableDoubleClick={isSpanEditActive}
           button={
-            <div
-              style={{ display: "flex", alignItems: "center" }}
-              onBlur={(event) => {
-                if (!isSpanEditActive) {
-                  return;
-                }
-                const nextFocused = event.relatedTarget as Node | null;
-                if (nextFocused && event.currentTarget.contains(nextFocused)) {
-                  return;
-                }
-                setEditingAnchorKey(null);
-                if (hasPendingSpanEditChanges) {
-                  onCommitAnchorSpanEdits?.();
-                  setHasPendingSpanEditChanges(false);
-                }
-              }}
-            >
+            <div style={{ display: "flex", alignItems: "center" }}>
               {isSpanEditActive && (
                 <>
                   <Button
@@ -176,6 +160,11 @@ export const AnnotatorAnchorGridRow = React.memo(
                     return;
                   }
                   if (!isSpanEditActive) {
+                    // Switching active span editor: commit previous anchor edits first.
+                    if (editingAnchorKey !== null && hasPendingSpanEditChanges) {
+                      onCommitAnchorSpanEdits?.();
+                    }
+
                     setHasPendingSpanEditChanges(false);
                     setEditingAnchorKey(anchorKey);
                   }

--- a/packages/client/src/components/advanced/Annotator/AnnotatorMenuAnchorListRow.tsx
+++ b/packages/client/src/components/advanced/Annotator/AnnotatorMenuAnchorListRow.tsx
@@ -75,6 +75,8 @@ export const AnnotatorAnchorGridRow = React.memo(
             },
           }}
           entity={entity}
+          disableClick={isSpanEditActive}
+          disableDoubleClick={isSpanEditActive}
           button={
             <div
               style={{ display: "flex", gap: "0.125rem", alignItems: "center" }}

--- a/packages/client/src/components/advanced/Annotator/AnnotatorMenuAnchorListRow.tsx
+++ b/packages/client/src/components/advanced/Annotator/AnnotatorMenuAnchorListRow.tsx
@@ -3,6 +3,7 @@ import { IEntity } from "@shared/types";
 import { Button } from "components/basic/Button/Button";
 import React from "react";
 import {
+  MdDone,
   MdKeyboardDoubleArrowLeft,
   MdKeyboardDoubleArrowRight,
   MdOutlineOpenWith,
@@ -85,7 +86,7 @@ export const AnnotatorAnchorGridRow = React.memo(
           disableDoubleClick={isSpanEditActive}
           button={
             <div
-              style={{ display: "flex", gap: "0.125rem", alignItems: "center" }}
+              style={{ display: "flex", alignItems: "center" }}
               onBlur={(event) => {
                 if (!isSpanEditActive) {
                   return;
@@ -101,25 +102,10 @@ export const AnnotatorAnchorGridRow = React.memo(
                 }
               }}
             >
-              <Button
-                color={isSpanEditActive ? "warning" : "plain"}
-                inverted
-                size={ButtonSize.Small}
-                icon={<MdOutlineOpenWith size={14} />}
-                tooltipLabel={
-                  isSpanEditActive ? "Anchor span edit mode active" : "Edit anchor span bounds"
-                }
-                onClick={() => {
-                  if (!isSpanEditActive) {
-                    setHasPendingSpanEditChanges(false);
-                    setEditingAnchorKey(anchorKey);
-                  }
-                }}
-              />
               {isSpanEditActive && (
                 <>
                   <Button
-                    color="plain"
+                    color="success"
                     inverted
                     size={ButtonSize.Small}
                     icon={<MdKeyboardDoubleArrowLeft size={14} />}
@@ -132,7 +118,7 @@ export const AnnotatorAnchorGridRow = React.memo(
                     }}
                   />
                   <Button
-                    color="plain"
+                    color="success"
                     inverted
                     size={ButtonSize.Small}
                     icon={<MdKeyboardDoubleArrowRight size={14} />}
@@ -145,7 +131,7 @@ export const AnnotatorAnchorGridRow = React.memo(
                     }}
                   />
                   <Button
-                    color="plain"
+                    color="info"
                     inverted
                     size={ButtonSize.Small}
                     icon={<MdKeyboardDoubleArrowLeft size={14} />}
@@ -158,7 +144,7 @@ export const AnnotatorAnchorGridRow = React.memo(
                     }}
                   />
                   <Button
-                    color="plain"
+                    color="info"
                     inverted
                     size={ButtonSize.Small}
                     icon={<MdKeyboardDoubleArrowRight size={14} />}
@@ -172,6 +158,29 @@ export const AnnotatorAnchorGridRow = React.memo(
                   />
                 </>
               )}
+              <Button
+                color={isSpanEditActive ? "warning" : "plain"}
+                inverted
+                size={ButtonSize.Small}
+                icon={isSpanEditActive ? <MdDone size={14} /> : <MdOutlineOpenWith size={14} />}
+                tooltipLabel={
+                  isSpanEditActive ? "Finish anchor span edit" : "Edit anchor span bounds"
+                }
+                onClick={() => {
+                  if (isSpanEditActive) {
+                    setEditingAnchorKey(null);
+                    if (hasPendingSpanEditChanges) {
+                      onCommitAnchorSpanEdits?.();
+                      setHasPendingSpanEditChanges(false);
+                    }
+                    return;
+                  }
+                  if (!isSpanEditActive) {
+                    setHasPendingSpanEditChanges(false);
+                    setEditingAnchorKey(anchorKey);
+                  }
+                }}
+              />
             </div>
           }
           elvlButtonGroup={

--- a/packages/client/src/components/advanced/EntityTag/EntityTag.tsx
+++ b/packages/client/src/components/advanced/EntityTag/EntityTag.tsx
@@ -43,6 +43,7 @@ interface EntityTag {
   moveFn?: (dragIndex: number, hoverIndex: number) => void;
   isSelected?: boolean;
   disableTooltip?: boolean;
+  disableClick?: boolean;
   disableDoubleClick?: boolean;
   disableDrag?: boolean;
   tooltipPosition?: Placement;
@@ -66,6 +67,7 @@ const EntityTagComponent: React.FC<EntityTag> = ({
   moveFn,
   isSelected,
   disableTooltip = false,
+  disableClick = false,
   disableDrag = false,
   disableDoubleClick = false,
   tooltipPosition,
@@ -249,16 +251,18 @@ const EntityTagComponent: React.FC<EntityTag> = ({
             {unlinkButton && renderUnlinkButton(unlinkButton)}
           </>
         }
-        onClick={() => setClickedOnce(true)}
-        onDoubleClick={() => {
-          setClickedOnce(false);
-          if (!disableDoubleClick) {
-            appendDetailId(entity.id);
-            if (detailBoxState === DetailBoxState.Minimized) {
-              dispatch(setDetailBoxState(DetailBoxState.Normal));
-            }
-          }
-        }}
+        onClick={disableClick ? undefined : () => setClickedOnce(true)}
+        onDoubleClick={
+          disableDoubleClick
+            ? undefined
+            : () => {
+                setClickedOnce(false);
+                appendDetailId(entity.id);
+                if (detailBoxState === DetailBoxState.Minimized) {
+                  dispatch(setDetailBoxState(DetailBoxState.Normal));
+                }
+              }
+        }
         onMouseEnter={handleTagHovered}
         onMouseLeave={handleTagUnhovered}
         onButtonOver={handleButtonHovered}
@@ -288,6 +292,7 @@ function areEntityTagsEqual(
   if (prev.showOnly !== next.showOnly) return false;
   if (prev.fullWidth !== next.fullWidth) return false;
   if (prev.disableTooltip !== next.disableTooltip) return false;
+  if (prev.disableClick !== next.disableClick) return false;
   if (prev.disableDoubleClick !== next.disableDoubleClick) return false;
   if (prev.statementsCount !== next.statementsCount) return false;
   if (Boolean(prev.button) !== Boolean(next.button)) return false;


### PR DESCRIPTION
Challenges:

- [x] crossing the boundaries of other xml tags
- [ ] freeze the order during the anchor span edit (don't switch anchors in the list while editing) => could be also solved by showing the arrows in different place than on the tag
- [ ] less calculations when moving the start span
- [ ] save edits by clicking the done button on modal too