### PR TITLE
2906 allow owner to download backup archive from inkvisitor interface

### DIFF
--- a/packages/client/src/api.tsx
+++ b/packages/client/src/api.tsx
@@ -8,6 +8,7 @@ import {
   IRequestQuery,
   IRequestStats,
   IResponseAudit,
+  IResponseBackup,
   IResponseBookmarkFolder,
   IResponseDetail,
   IResponseEntity,
@@ -923,6 +924,47 @@ class Api {
     try {
       const response = await this.connection.post(`/stats/aggregate`, data, options);
       return response;
+    } catch (err) {
+      throw this.handleError(err);
+    }
+  }
+
+  /**
+   * Backups
+   * Lists all available DB backup archives (admin/owner only).
+   */
+  async backupsGet(options?: IApiOptions): Promise<AxiosResponse<IResponseBackup[]>> {
+    try {
+      const response = await this.connection.get(`/backups`, options);
+      return response;
+    } catch (err) {
+      throw this.handleError(err);
+    }
+  }
+
+  /**
+   * Downloads a single backup archive and triggers a browser download.
+   * @param backupId relative archive id from backupsGet, e.g. "20240101/inkvisitor_backup.tar.gz"
+   * @param fileName optional override for the downloaded file name
+   */
+  async backupDownload(backupId: string, fileName?: string): Promise<void> {
+    try {
+      const response = await this.connection.get(`/backups/download`, {
+        params: { file: backupId },
+        responseType: "blob",
+      });
+
+      const url = window.URL.createObjectURL(response.data);
+      const a = document.createElement("a");
+
+      a.href = url;
+      a.download = fileName || backupId.replace(/\//g, "_");
+      document.body.appendChild(a);
+      a.click();
+
+      // Clean up
+      window.URL.revokeObjectURL(url);
+      document.body.removeChild(a);
     } catch (err) {
       throw this.handleError(err);
     }

--- a/packages/client/src/app.tsx
+++ b/packages/client/src/app.tsx
@@ -1,4 +1,4 @@
-import { InterfaceEnums } from "@shared/enums";
+import { InterfaceEnums, UserEnums } from "@shared/enums";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import api from "api";
@@ -65,6 +65,14 @@ export const PublicPath = (props: any) => {
 
 export const RequireAuth = ({ children }: { children: React.ReactNode }) => {
   return api.isLoggedIn() ? children : <Navigate to="/login" />;
+};
+
+export const RequireOwner = ({ children }: { children: React.ReactNode }) => {
+  if (!api.isLoggedIn()) {
+    return <Navigate to="/login" />;
+  }
+  const isOwner = localStorage.getItem("userrole") === UserEnums.Role.Owner;
+  return isOwner ? children : <Navigate to="/" />;
 };
 
 const queryClient = new QueryClient({
@@ -202,9 +210,9 @@ export const App: React.FC = () => {
                     <Route
                       path="/backups"
                       element={
-                        <RequireAuth>
+                        <RequireOwner>
                           <BackupsPage />
-                        </RequireAuth>
+                        </RequireOwner>
                       }
                     />
                     <Route

--- a/packages/client/src/app.tsx
+++ b/packages/client/src/app.tsx
@@ -12,6 +12,7 @@ import {
   AboutPage,
   AclPage,
   ActivatePage,
+  BackupsPage,
   DocumentsPage,
   LoginPage,
   MainPage,
@@ -195,6 +196,14 @@ export const App: React.FC = () => {
                       element={
                         <RequireAuth>
                           <DocumentsPage />
+                        </RequireAuth>
+                      }
+                    />
+                    <Route
+                      path="/backups"
+                      element={
+                        <RequireAuth>
+                          <BackupsPage />
                         </RequireAuth>
                       }
                     />

--- a/packages/client/src/components/advanced/Menu/Menu.tsx
+++ b/packages/client/src/components/advanced/Menu/Menu.tsx
@@ -80,6 +80,7 @@ export const Menu: React.FC<Menu> = ({
       color: "info",
       href: "/backups",
       admin: true,
+      owner: true,
       icon: <FaDatabase size={16} />,
     },
     {
@@ -142,12 +143,18 @@ export const Menu: React.FC<Menu> = ({
         <StyledMenuGroupWrapper>
           <StyledMenuGroup>
             {pages
-              .filter(
-                (p) =>
-                  !p.admin ||
-                  userRole === UserEnums.Role.Admin ||
-                  userRole === UserEnums.Role.Owner
-              )
+              .filter((p) => {
+                if (p.owner) {
+                  return userRole === UserEnums.Role.Owner;
+                }
+                if (p.admin) {
+                  return (
+                    userRole === UserEnums.Role.Admin ||
+                    userRole === UserEnums.Role.Owner
+                  );
+                }
+                return true;
+              })
               .map((page, key) => (
                 <MenuItem
                   key={key}

--- a/packages/client/src/components/advanced/Menu/Menu.tsx
+++ b/packages/client/src/components/advanced/Menu/Menu.tsx
@@ -7,6 +7,7 @@ import { CgFileDocument } from "react-icons/cg";
 import {
   FaBars,
   FaBookOpen,
+  FaDatabase,
   FaInfo,
   FaSearchengin,
   FaRegChartBar,
@@ -72,6 +73,14 @@ export const Menu: React.FC<Menu> = ({
       href: "/documents",
       admin: true,
       icon: <CgFileDocument size={18} />,
+    },
+    {
+      id: "backups",
+      label: "Backups",
+      color: "info",
+      href: "/backups",
+      admin: true,
+      icon: <FaDatabase size={16} />,
     },
     {
       id: "query",

--- a/packages/client/src/pages/Backups/BackupsPage.tsx
+++ b/packages/client/src/pages/Backups/BackupsPage.tsx
@@ -1,0 +1,96 @@
+import { useQuery } from "@tanstack/react-query";
+import { IResponseBackup } from "@shared/types";
+import api from "api";
+import { Button, ButtonGroup, Loader } from "components";
+import React, { useState } from "react";
+import { FaDownload } from "react-icons/fa";
+import {
+  StyledBackground,
+  StyledBoxWrap,
+  StyledCell,
+  StyledContent,
+  StyledEmpty,
+  StyledGrid,
+  StyledGridHeader,
+  StyledGridScrollArea,
+  StyledHeaderCell,
+  StyledHeading,
+  StyledRow,
+} from "./BackupsPageStyles";
+
+const formatBytes = (bytes: number): string => {
+  if (!bytes) {
+    return "0 B";
+  }
+  const units = ["B", "KB", "MB", "GB", "TB"];
+  const i = Math.floor(Math.log(bytes) / Math.log(1024));
+  return `${(bytes / Math.pow(1024, i)).toFixed(i === 0 ? 0 : 1)} ${units[i]}`;
+};
+
+export const BackupsPage: React.FC = () => {
+  const { data: backups = [], isFetching } = useQuery({
+    queryKey: ["backups"],
+    queryFn: async () => {
+      const res = await api.backupsGet();
+      return res.data ?? [];
+    },
+    enabled: api.isLoggedIn(),
+  });
+
+  const [downloadingId, setDownloadingId] = useState<string | false>(false);
+
+  const handleDownload = async (backup: IResponseBackup) => {
+    setDownloadingId(backup.id);
+    try {
+      await api.backupDownload(backup.id);
+    } finally {
+      setDownloadingId(false);
+    }
+  };
+
+  return (
+    <StyledContent>
+      <StyledBoxWrap>
+        <StyledBackground>
+          <StyledHeading>Backups</StyledHeading>
+          <StyledGridScrollArea>
+            <StyledGrid>
+              <StyledGridHeader>
+                <StyledHeaderCell>File</StyledHeaderCell>
+                <StyledHeaderCell>Created</StyledHeaderCell>
+                <StyledHeaderCell>Size</StyledHeaderCell>
+                <StyledHeaderCell>Action</StyledHeaderCell>
+              </StyledGridHeader>
+              {backups.map((backup) => (
+                <StyledRow key={backup.id}>
+                  <StyledCell>{backup.id}</StyledCell>
+                  <StyledCell>
+                    {new Date(backup.createdAt).toLocaleString()}
+                  </StyledCell>
+                  <StyledCell>{formatBytes(backup.sizeBytes)}</StyledCell>
+                  <StyledCell>
+                    <ButtonGroup>
+                      <Button
+                        icon={<FaDownload />}
+                        label="Download"
+                        color="primary"
+                        inverted
+                        disabled={downloadingId === backup.id}
+                        onClick={() => handleDownload(backup)}
+                      />
+                    </ButtonGroup>
+                  </StyledCell>
+                </StyledRow>
+              ))}
+            </StyledGrid>
+            {!isFetching && backups.length === 0 && (
+              <StyledEmpty>No backups found.</StyledEmpty>
+            )}
+          </StyledGridScrollArea>
+
+          <Loader show={isFetching} size={50} />
+        </StyledBackground>
+      </StyledBoxWrap>
+    </StyledContent>
+  );
+};

--- a/packages/client/src/pages/Backups/BackupsPageStyles.tsx
+++ b/packages/client/src/pages/Backups/BackupsPageStyles.tsx
@@ -1,0 +1,95 @@
+import styled from "styled-components";
+
+export const StyledContent = styled.div`
+  width: 100%;
+  height: 100%;
+  display: flex;
+  justify-content: center;
+  flex-direction: row;
+`;
+
+export const StyledBoxWrap = styled.div`
+  max-width: 100%;
+  height: 100%;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+`;
+
+export const StyledBackground = styled.div`
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  margin: 2rem;
+  padding: 1rem;
+  border: 1px dashed ${({ theme }) => theme.color["black"]};
+  background-color: ${({ theme }) => theme.color["white"]};
+  box-shadow: 2px 2px 2px rgba(0, 0, 0, 0.3);
+  overflow: hidden;
+`;
+
+export const StyledHeading = styled.div`
+  flex-shrink: 0;
+  color: ${({ theme }) => theme.color["black"]};
+  font-size: ${({ theme }) => theme.fontSize["lg"]};
+  font-weight: ${({ theme }) => theme.fontWeight["bold"]};
+  margin-bottom: ${({ theme }) => theme.space[2]};
+  padding-left: ${({ theme }) => theme.space[1]};
+`;
+
+export const StyledGridScrollArea = styled.div`
+  padding-right: 0.5rem;
+  min-height: 0;
+  width: 100%;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  align-self: stretch;
+  overflow: auto;
+`;
+
+export const StyledGrid = styled.div`
+  display: grid;
+  grid-template-columns: minmax(18rem, 1fr) max-content max-content max-content;
+  align-items: center;
+  min-width: min-content;
+  margin-bottom: 0.5rem;
+`;
+
+export const StyledGridHeader = styled.div`
+  display: contents;
+`;
+
+export const StyledRow = styled.div`
+  display: contents;
+`;
+
+export const StyledHeaderCell = styled.div`
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  min-height: 2.5rem;
+  background: ${({ theme }) => theme.color["white"]};
+  border-bottom: 1px solid ${({ theme }) => theme.color["gray"][500]};
+  padding: 0.5rem 1rem;
+  color: ${({ theme }) => theme.color["gray"][700]};
+  font-size: ${({ theme }) => theme.fontSize["xs"]};
+  font-weight: ${({ theme }) => theme.fontWeight["bold"]};
+  white-space: nowrap;
+`;
+
+export const StyledCell = styled.div`
+  padding: 0.4rem 1rem;
+  color: ${({ theme }) => theme.color["black"]};
+  font-size: ${({ theme }) => theme.fontSize["sm"]};
+  white-space: nowrap;
+`;
+
+export const StyledEmpty = styled.div`
+  padding: 1rem;
+  color: ${({ theme }) => theme.color["gray"][600]};
+  font-size: ${({ theme }) => theme.fontSize["sm"]};
+`;

--- a/packages/client/src/pages/index.tsx
+++ b/packages/client/src/pages/index.tsx
@@ -2,6 +2,7 @@
 import { AboutPage } from "pages/About/AboutPage";
 import AclPage from "pages/Acl/AclPage";
 import ActivatePage from "pages/Activate/ActivatePage";
+import { BackupsPage } from "pages/Backups/BackupsPage";
 import { DocumentsPage } from "pages/Documents/DocumentsPage";
 import LoginPage from "pages/Login/LoginPage";
 import MainPage from "pages/Main/MainPage";
@@ -14,6 +15,7 @@ export {
   AboutPage,
   AclPage,
   ActivatePage,
+  BackupsPage,
   DocumentsPage,
   LoginPage,
   MainPage,

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -116,7 +116,7 @@ export const ExtentedEntityColors: { [key: string]: IEntityColor } = {
 export type EntityKeys = keyof typeof EntityColors;
 
 export interface IPage {
-  id: "main" | "users" | "acl" | "about" | "documents" | "customize" | "stats" | "query";
+  id: "main" | "users" | "acl" | "about" | "documents" | "backups" | "customize" | "stats" | "query";
   label: string;
   color: "info" | "success" | "danger" | "warning";
   href: string | false;

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -121,6 +121,7 @@ export interface IPage {
   color: "info" | "success" | "danger" | "warning";
   href: string | false;
   admin?: boolean;
+  owner?: boolean;
   icon?: React.ReactElement;
 }
 

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -35,6 +35,7 @@ Make sure to have appropriate `.env.<ENV_FILE>` file accessible (e.g., running `
 - `NODE_ENV` = environment - production/development (security vs logging)
 - `DOMAIN` = identify the instance - points to the domain where the ui should be accessible (used in emails)
 - `STATIC_PATH` = http relative path to client files served by the server, use '/' for files hosted in root path
+- `BACKUP_DIR` = directory containing the DB backup archives (mounted read-only from the `inkvisitor-backup` PVC in deployments); empty/unset disables the backups API
 - `PORT` = port which should be used for this app
 - `SECRET` = for signing jwt token
 - `SMTP_HOST` / `SMTP_PORT` = SMTP relay (e.g. Mailjet `in-v3.mailjet.com`, port `587`)

--- a/packages/server/env/example.env
+++ b/packages/server/env/example.env
@@ -7,6 +7,9 @@ DOMAIN=dissinet.cz
 # path to client files served by the server
 STATIC_PATH=/apps/inkvisitor-development
 
+# directory containing the DB backup archives, mounted read-only from the inkvisitor-backup PVC (empty/unset = backups API disabled)
+BACKUP_DIR=/backup
+
 # serving swagger file from file (empty to disable), ie. ./swagger.json
 SWAGGER_FILE=
 

--- a/packages/server/src/Server.ts
+++ b/packages/server/src/Server.ts
@@ -15,6 +15,7 @@ import StatsRouter from "@modules/stats";
 import PythonApiRouter from "@modules/pythondata";
 import SettingsRouter from "@modules/settings";
 import DocumentsRouter from "@modules/documents";
+import BackupsRouter from "@modules/backups";
 import Acl from "@middlewares/acl";
 import customizeRequest from "@middlewares/request";
 import dbMiddleware from "@middlewares/db";
@@ -190,6 +191,7 @@ router.use("/stats", StatsRouter);
 router.use("/documents", DocumentsRouter);
 router.use("/pythondata", PythonApiRouter);
 router.use("/settings", SettingsRouter);
+router.use("/backups", BackupsRouter);
 
 // unknown paths (after jwt check) should return 404
 server.all("*", catchAll);

--- a/packages/server/src/models/backup/backup.test.ts
+++ b/packages/server/src/models/backup/backup.test.ts
@@ -1,0 +1,94 @@
+import { Backup } from "@models/backup/backup";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+
+describe("models/backup", () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), "ink-backup-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  const writeBackup = (relPath: string, content = "data") => {
+    const full = path.join(root, relPath);
+    fs.mkdirSync(path.dirname(full), { recursive: true });
+    fs.writeFileSync(full, content);
+    return full;
+  };
+
+  describe("list", () => {
+    it("returns an empty array for an empty backup dir path", () => {
+      expect(Backup.list("")).toEqual([]);
+    });
+
+    it("returns an empty array when the directory does not exist", () => {
+      expect(Backup.list(path.join(root, "missing"))).toEqual([]);
+    });
+
+    it("returns an empty array when no archives are present", () => {
+      writeBackup("20240101/readme.txt");
+      expect(Backup.list(root)).toEqual([]);
+    });
+
+    it("finds .tar.gz archives in dated subdirectories", () => {
+      writeBackup("20240101/inkvisitor_backup.tar.gz", "hello");
+      writeBackup("20240101/notes.txt");
+
+      const result = Backup.list(root);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toMatchObject({
+        id: "20240101/inkvisitor_backup.tar.gz",
+        filename: "inkvisitor_backup.tar.gz",
+        sizeBytes: 5,
+      });
+      expect(typeof result[0].createdAt).toBe("string");
+    });
+
+    it("sorts archives newest dated directory first", () => {
+      writeBackup("20240101/inkvisitor_backup.tar.gz");
+      writeBackup("20240301/inkvisitor_backup.tar.gz");
+      writeBackup("20240201/inkvisitor_backup.tar.gz");
+
+      const ids = Backup.list(root).map((b) => b.id);
+
+      expect(ids).toEqual([
+        "20240301/inkvisitor_backup.tar.gz",
+        "20240201/inkvisitor_backup.tar.gz",
+        "20240101/inkvisitor_backup.tar.gz",
+      ]);
+    });
+  });
+
+  describe("resolvePath", () => {
+    it("resolves a valid id to an absolute path inside the backup dir", () => {
+      writeBackup("20240101/inkvisitor_backup.tar.gz");
+
+      const resolved = Backup.resolvePath(root, "20240101/inkvisitor_backup.tar.gz");
+
+      expect(resolved).toBe(path.resolve(root, "20240101/inkvisitor_backup.tar.gz"));
+    });
+
+    it("rejects path traversal attempts", () => {
+      expect(Backup.resolvePath(root, "../../etc/passwd")).toBeNull();
+      expect(Backup.resolvePath(root, "20240101/../../../etc/passwd")).toBeNull();
+    });
+
+    it("rejects absolute path ids", () => {
+      expect(Backup.resolvePath(root, "/etc/passwd")).toBeNull();
+    });
+
+    it("rejects an empty id", () => {
+      expect(Backup.resolvePath(root, "")).toBeNull();
+    });
+
+    it("rejects any id when the backup dir is not configured", () => {
+      expect(Backup.resolvePath("", "20240101/inkvisitor_backup.tar.gz")).toBeNull();
+    });
+  });
+});

--- a/packages/server/src/models/backup/backup.ts
+++ b/packages/server/src/models/backup/backup.ts
@@ -1,0 +1,72 @@
+import { IResponseBackup } from "@shared/types";
+import * as fs from "fs";
+import * as path from "path";
+
+/**
+ * Backup encapsulates read-only access to the DB backup archives that the backup
+ * CronJob writes onto the shared volume (mounted read-only into the app at BACKUP_DIR).
+ * All access is filesystem based - backups are never exposed as a public/static link.
+ */
+export class Backup {
+  static readonly archiveSuffix = ".tar.gz";
+
+  /**
+   * Lists all backup archives found (recursively) under the given backup dir.
+   * Returns an empty list when the dir is not configured or does not exist.
+   */
+  static list(backupDir: string): IResponseBackup[] {
+    if (!backupDir) {
+      return [];
+    }
+
+    const root = path.resolve(backupDir);
+    if (!fs.existsSync(root)) {
+      return [];
+    }
+
+    const results: IResponseBackup[] = [];
+
+    const walk = (dir: string): void => {
+      for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+        const full = path.join(dir, entry.name);
+        if (entry.isDirectory()) {
+          walk(full);
+        } else if (entry.isFile() && entry.name.endsWith(Backup.archiveSuffix)) {
+          const stat = fs.statSync(full);
+          results.push({
+            id: path.relative(root, full).split(path.sep).join("/"),
+            filename: entry.name,
+            sizeBytes: stat.size,
+            createdAt: stat.mtime.toISOString(),
+          });
+        }
+      }
+    };
+
+    walk(root);
+
+    return results.sort((a, b) => (a.id < b.id ? 1 : -1));
+  }
+
+  /**
+   * Resolves a backup id (relative path) to an absolute path inside the backup dir.
+   * Returns null for empty input or any path that would escape the backup dir
+   * (path traversal / absolute paths) - guarding against arbitrary file reads.
+   * Does not check for existence.
+   */
+  static resolvePath(backupDir: string, id: string): string | null {
+    if (!backupDir || !id || !id.trim()) {
+      return null;
+    }
+
+    const root = path.resolve(backupDir);
+    const target = path.resolve(root, id);
+    const rel = path.relative(root, target);
+
+    if (!rel || rel.startsWith("..") || path.isAbsolute(rel)) {
+      return null;
+    }
+
+    return target;
+  }
+}

--- a/packages/server/src/modules/backups/backups.test.ts
+++ b/packages/server/src/modules/backups/backups.test.ts
@@ -1,0 +1,106 @@
+import { testErroneousResponse } from "@modules/common.test";
+import { BadParams, NotFound, UnauthorizedError } from "@shared/types/errors";
+import request from "supertest";
+import { supertestConfig } from "..";
+import { apiPath } from "@common/constants";
+import app from "../../Server";
+import { Db } from "@service/rethink";
+import { pool } from "@middlewares/db";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+
+describe("modules/backups", function () {
+  const db = new Db();
+  let backupDir: string;
+
+  beforeAll(async () => {
+    await db.initDb();
+
+    backupDir = fs.mkdtempSync(path.join(os.tmpdir(), "ink-backups-test-"));
+    fs.mkdirSync(path.join(backupDir, "20240101"), { recursive: true });
+    fs.writeFileSync(
+      path.join(backupDir, "20240101", "inkvisitor_backup.tar.gz"),
+      "backup-bytes"
+    );
+    process.env.BACKUP_DIR = backupDir;
+  });
+
+  afterAll(async () => {
+    delete process.env.BACKUP_DIR;
+    fs.rmSync(backupDir, { recursive: true, force: true });
+    await db.close();
+    await pool.end();
+  });
+
+  describe("auth - backups are not publicly accessible", () => {
+    it("rejects listing without a token", async () => {
+      await request(app)
+        .get(`${apiPath}/backups`)
+        .expect(401)
+        .expect(testErroneousResponse.bind(undefined, new UnauthorizedError("")));
+    });
+
+    it("rejects download without a token", async () => {
+      await request(app)
+        .get(`${apiPath}/backups/download?file=20240101/inkvisitor_backup.tar.gz`)
+        .expect(401)
+        .expect(testErroneousResponse.bind(undefined, new UnauthorizedError("")));
+    });
+  });
+
+  describe("GET /backups (authenticated)", () => {
+    it("lists available backup archives", async () => {
+      const response = await request(app)
+        .get(`${apiPath}/backups`)
+        .set("authorization", "Bearer " + supertestConfig.token)
+        .expect(200);
+
+      expect(Array.isArray(response.body)).toBe(true);
+      const entry = (response.body as any[]).find(
+        (b) => b.id === "20240101/inkvisitor_backup.tar.gz"
+      );
+      expect(entry).toBeTruthy();
+      expect(entry.filename).toBe("inkvisitor_backup.tar.gz");
+      expect(entry.sizeBytes).toBe("backup-bytes".length);
+    });
+  });
+
+  describe("GET /backups/download (authenticated)", () => {
+    it("streams a backup archive as an attachment", async () => {
+      const response = await request(app)
+        .get(`${apiPath}/backups/download?file=20240101/inkvisitor_backup.tar.gz`)
+        .set("authorization", "Bearer " + supertestConfig.token)
+        .expect(200);
+
+      expect(response.headers["content-type"]).toContain("application/gzip");
+      expect(response.headers["content-disposition"]).toContain(
+        'attachment; filename="inkvisitor_backup.tar.gz"'
+      );
+    });
+
+    it("returns BadParams when no file is provided", async () => {
+      await request(app)
+        .get(`${apiPath}/backups/download`)
+        .set("authorization", "Bearer " + supertestConfig.token)
+        .expect(400)
+        .expect(testErroneousResponse.bind(undefined, new BadParams("")));
+    });
+
+    it("returns NotFound for a path-traversal attempt", async () => {
+      await request(app)
+        .get(`${apiPath}/backups/download?file=../../etc/passwd`)
+        .set("authorization", "Bearer " + supertestConfig.token)
+        .expect(404)
+        .expect(testErroneousResponse.bind(undefined, new NotFound("")));
+    });
+
+    it("returns NotFound for a missing archive", async () => {
+      await request(app)
+        .get(`${apiPath}/backups/download?file=20990101/inkvisitor_backup.tar.gz`)
+        .set("authorization", "Bearer " + supertestConfig.token)
+        .expect(404)
+        .expect(testErroneousResponse.bind(undefined, new NotFound("")));
+    });
+  });
+});

--- a/packages/server/src/modules/backups/backups.test.ts
+++ b/packages/server/src/modules/backups/backups.test.ts
@@ -49,7 +49,9 @@ describe("modules/backups", function () {
     });
   });
 
-  describe("GET /backups (authenticated)", () => {
+  // Note: backups are owner-only - supertestConfig.token must belong to an owner
+  // for the cases below to pass (a non-owner, incl. admin, gets 403).
+  describe("GET /backups (owner)", () => {
     it("lists available backup archives", async () => {
       const response = await request(app)
         .get(`${apiPath}/backups`)
@@ -66,7 +68,7 @@ describe("modules/backups", function () {
     });
   });
 
-  describe("GET /backups/download (authenticated)", () => {
+  describe("GET /backups/download (owner)", () => {
     it("streams a backup archive as an attachment", async () => {
       const response = await request(app)
         .get(`${apiPath}/backups/download?file=20240101/inkvisitor_backup.tar.gz`)

--- a/packages/server/src/modules/backups/index.ts
+++ b/packages/server/src/modules/backups/index.ts
@@ -1,43 +1,50 @@
 import { asyncRouteHandler } from "../index";
 import { NextFunction, Response, Router } from "express";
+import { UserEnums } from "@shared/enums";
 import { IResponseBackup } from "@shared/types";
 import { IRequest } from "src/custom_typings/request";
 import { Backup } from "@models/backup/backup";
-import { BadParams, NotFound } from "@shared/types/errors";
+import { BadParams, NotFound, PermissionDeniedError } from "@shared/types/errors";
 import * as fs from "fs";
 import * as path from "path";
 
 const getBackupDir = (): string => process.env.BACKUP_DIR || "";
 
+/**
+ * Backups contain full database dumps - access is restricted to the owner only.
+ * Note: the generic acl admin/owner bypass is not enough here (it would also let
+ * admins through), so the owner role is enforced explicitly in each handler.
+ */
+const assertOwner = (request: IRequest): void => {
+  if (!request.getUserOrFail().hasRole([UserEnums.Role.Owner])) {
+    throw new PermissionDeniedError("only the owner can access backups");
+  }
+};
+
 export default Router()
   /**
-   * Lists all available backup archives. Restricted to admin/owner by default
-   * (no public ACL permission is registered for this controller).
+   * Lists all available backup archives. Owner only.
    */
   .get(
     "/",
-    asyncRouteHandler<IResponseBackup[]>(async () => {
+    asyncRouteHandler<IResponseBackup[]>(async (request: IRequest) => {
+      assertOwner(request);
       return Backup.list(getBackupDir());
     })
   )
   /**
-   * Streams a single backup archive as an attachment. The file is piped through
-   * the api (behind jwt + acl) - it is never exposed as a public/static link.
+   * Streams a single backup archive as an attachment. Owner only.
+   * The file is piped through the api (behind jwt) - it is never exposed as a
+   * public/static link.
    *
    * This is a raw handler (binary stream) so it does not go through
-   * asyncRouteHandler - the acl check is therefore enforced explicitly below.
+   * asyncRouteHandler - the owner check is therefore enforced explicitly below.
    */
   .get(
     "/download",
     async (request: IRequest, res: Response, next: NextFunction) => {
       try {
-        if (request.acl) {
-          const err = await request.acl.validate(request);
-          if (err) {
-            next(err);
-            return;
-          }
-        }
+        assertOwner(request);
 
         const file = (request.query.file as string) || "";
         if (!file) {

--- a/packages/server/src/modules/backups/index.ts
+++ b/packages/server/src/modules/backups/index.ts
@@ -1,0 +1,71 @@
+import { asyncRouteHandler } from "../index";
+import { NextFunction, Response, Router } from "express";
+import { IResponseBackup } from "@shared/types";
+import { IRequest } from "src/custom_typings/request";
+import { Backup } from "@models/backup/backup";
+import { BadParams, NotFound } from "@shared/types/errors";
+import * as fs from "fs";
+import * as path from "path";
+
+const getBackupDir = (): string => process.env.BACKUP_DIR || "";
+
+export default Router()
+  /**
+   * Lists all available backup archives. Restricted to admin/owner by default
+   * (no public ACL permission is registered for this controller).
+   */
+  .get(
+    "/",
+    asyncRouteHandler<IResponseBackup[]>(async () => {
+      return Backup.list(getBackupDir());
+    })
+  )
+  /**
+   * Streams a single backup archive as an attachment. The file is piped through
+   * the api (behind jwt + acl) - it is never exposed as a public/static link.
+   *
+   * This is a raw handler (binary stream) so it does not go through
+   * asyncRouteHandler - the acl check is therefore enforced explicitly below.
+   */
+  .get(
+    "/download",
+    async (request: IRequest, res: Response, next: NextFunction) => {
+      try {
+        if (request.acl) {
+          const err = await request.acl.validate(request);
+          if (err) {
+            next(err);
+            return;
+          }
+        }
+
+        const file = (request.query.file as string) || "";
+        if (!file) {
+          throw new BadParams("file query param has to be set");
+        }
+
+        const resolved = Backup.resolvePath(getBackupDir(), file);
+        if (
+          !resolved ||
+          !fs.existsSync(resolved) ||
+          !fs.statSync(resolved).isFile()
+        ) {
+          throw new NotFound(`backup '${file}' does not exist`);
+        }
+
+        const stat = fs.statSync(resolved);
+        res.setHeader("Content-Type", "application/gzip");
+        res.setHeader("Content-Length", stat.size);
+        res.setHeader(
+          "Content-Disposition",
+          `attachment; filename="${path.basename(resolved)}"`
+        );
+
+        const stream = fs.createReadStream(resolved);
+        stream.on("error", next);
+        stream.pipe(res);
+      } catch (err) {
+        next(err);
+      }
+    }
+  );

--- a/packages/shared/types/index.ts
+++ b/packages/shared/types/index.ts
@@ -42,6 +42,7 @@ import {
   IResponseUsedInMetaProp,
   IResponseUsedInStatement,
 } from "./response-detail";
+import { IResponseBackup } from "./response-backup";
 import { IResponseGeneric } from "./response-generic";
 import { IResponsePermission } from "./response-permission";
 import {
@@ -123,6 +124,7 @@ export type {
   IResource,
   IResourceData,
   IResponseAudit,
+  IResponseBackup,
   IResponseBookmarkFolder,
   IResponseDetail,
   IResponseEntity,

--- a/packages/shared/types/response-backup.ts
+++ b/packages/shared/types/response-backup.ts
@@ -1,0 +1,10 @@
+export interface IResponseBackup {
+  // relative path from the backup dir, used as the download identifier, e.g. "20240101/inkvisitor_backup.tar.gz"
+  id: string;
+  // base file name of the archive
+  filename: string;
+  // size of the archive in bytes
+  sizeBytes: number;
+  // ISO timestamp of when the archive file was last modified
+  createdAt: string;
+}


### PR DESCRIPTION
Lets admin/owner users browse and download the daily database backup archives
directly from the InkVisitor interface — without exposing them as public links.

env in server needs to be added BACKUP_DIR=./backup for example

close #2906 