### PR TITLE
audit: record deletions and count them as edits in stats

### DIFF
--- a/packages/server/src/models/audit/audit.ts
+++ b/packages/server/src/models/audit/audit.ts
@@ -157,6 +157,42 @@ export default class Audit implements IAudit, IDbModel {
   }
 
   /**
+   * Resolves the deletion event type for an audit scope. Document deletions are
+   * recorded as anchor removals (their anchors disappear with them), entity
+   * deletions as plain deletions. Both fold into the matching edit type in the
+   * stats (ANCHOR_DELETE -> ANCHOR_EDIT, DELETE -> EDIT).
+   */
+  static deletionEventType(scope: AuditScope): EventType {
+    return scope === AuditScope.Document
+      ? EventType.ANCHOR_DELETE
+      : EventType.DELETE;
+  }
+
+  /**
+   * Records the single, minimal audit written when an entity or document is
+   * deleted: a deletion marker with empty changes, typed per scope via
+   * deletionEventType.
+   * @param db rethinkdb Connection
+   * @param modelId id of the deleted entity/document
+   * @param userId id of the user performing the deletion
+   * @param scope audit scope (entity or document)
+   */
+  static async createDeletionAudit(
+    db: Connection | undefined,
+    modelId: string,
+    userId: string,
+    scope: AuditScope
+  ): Promise<void> {
+    await new Audit({
+      modelId,
+      auditScope: scope,
+      user: userId,
+      changes: {},
+      type: Audit.deletionEventType(scope),
+    }).save(db);
+  }
+
+  /**
    * Retrieves first created audit entry for entity.
    * First audit entry stands for created-at entry.
    * @param db rethinkdb Connection

--- a/packages/server/src/models/audit/deletion.test.ts
+++ b/packages/server/src/models/audit/deletion.test.ts
@@ -1,0 +1,71 @@
+import "ts-jest";
+import { Db } from "@service/rethink";
+import { clean } from "@modules/common.test";
+import { AuditScope } from "@inkvisitor/shared/types";
+import { EventType } from "@inkvisitor/shared/types/stats";
+import Audit from "./audit";
+
+// DB setup/teardown (clean wipes several tables) can exceed jest's 5s default
+jest.setTimeout(60000);
+
+describe("Audit.createDeletionAudit", function () {
+  describe("entity scope", () => {
+    const db = new Db();
+    const entityId = `entity-${Math.random().toString()}`;
+    const userId = `user-${Math.random().toString()}`;
+
+    beforeAll(async () => {
+      await db.initDb();
+      await Audit.createDeletionAudit(
+        db.connection,
+        entityId,
+        userId,
+        AuditScope.Entity
+      );
+    });
+
+    afterAll(async () => await clean(db));
+
+    it("writes exactly one minimal DELETE audit for the entity", async () => {
+      const audits = await Audit.getLastNForEntity(db.connection, entityId, 10);
+
+      expect(audits).toHaveLength(1);
+      expect(audits[0].type).toBe(EventType.DELETE);
+      expect(audits[0].changes).toEqual({});
+      expect(audits[0].user).toBe(userId);
+      expect(audits[0].auditScope).toBe(AuditScope.Entity);
+    });
+  });
+
+  describe("document scope", () => {
+    const db = new Db();
+    const documentId = `document-${Math.random().toString()}`;
+    const userId = `user-${Math.random().toString()}`;
+
+    beforeAll(async () => {
+      await db.initDb();
+      await Audit.createDeletionAudit(
+        db.connection,
+        documentId,
+        userId,
+        AuditScope.Document
+      );
+    });
+
+    afterAll(async () => await clean(db));
+
+    it("writes exactly one minimal ANCHOR_DELETE audit for the document", async () => {
+      const audits = await Audit.getLastNForDocument(
+        db.connection,
+        documentId,
+        10
+      );
+
+      expect(audits).toHaveLength(1);
+      expect(audits[0].type).toBe(EventType.ANCHOR_DELETE);
+      expect(audits[0].changes).toEqual({});
+      expect(audits[0].user).toBe(userId);
+      expect(audits[0].auditScope).toBe(AuditScope.Document);
+    });
+  });
+});

--- a/packages/server/src/models/stats/event-type-fold.test.ts
+++ b/packages/server/src/models/stats/event-type-fold.test.ts
@@ -1,0 +1,92 @@
+import "ts-jest";
+import { EventType } from "@inkvisitor/shared/types/stats";
+import {
+  foldEventTypeForStats,
+  expandEventTypesForStats,
+  foldStatsValuesByEventType,
+} from "./event-type-fold";
+
+describe("foldEventTypeForStats", () => {
+  it("folds DELETE into EDIT", () => {
+    expect(foldEventTypeForStats(EventType.DELETE)).toBe(EventType.EDIT);
+  });
+
+  it("folds ANCHOR_DELETE into ANCHOR_EDIT", () => {
+    expect(foldEventTypeForStats(EventType.ANCHOR_DELETE)).toBe(
+      EventType.ANCHOR_EDIT
+    );
+  });
+
+  it("leaves every other event type unchanged", () => {
+    for (const type of [
+      EventType.EDIT,
+      EventType.CREATE,
+      EventType.TEXT_EDIT,
+      EventType.ANCHOR_ADD,
+      EventType.ANCHOR_EDIT,
+    ]) {
+      expect(foldEventTypeForStats(type)).toBe(type);
+    }
+  });
+});
+
+describe("expandEventTypesForStats", () => {
+  it("includes DELETE when EDIT is requested", () => {
+    expect(expandEventTypesForStats([EventType.EDIT])).toEqual(
+      expect.arrayContaining([EventType.EDIT, EventType.DELETE])
+    );
+  });
+
+  it("includes ANCHOR_DELETE when ANCHOR_EDIT is requested", () => {
+    expect(expandEventTypesForStats([EventType.ANCHOR_EDIT])).toEqual(
+      expect.arrayContaining([EventType.ANCHOR_EDIT, EventType.ANCHOR_DELETE])
+    );
+  });
+
+  it("does not add delete types when the matching edit type is not requested", () => {
+    const out = expandEventTypesForStats([EventType.CREATE, EventType.ANCHOR_ADD]);
+    expect(out).not.toContain(EventType.DELETE);
+    expect(out).not.toContain(EventType.ANCHOR_DELETE);
+  });
+
+  it("does not duplicate types already present", () => {
+    const out = expandEventTypesForStats([EventType.EDIT, EventType.DELETE]);
+    expect(out.filter((t) => t === EventType.DELETE)).toHaveLength(1);
+  });
+});
+
+describe("foldStatsValuesByEventType", () => {
+  it("merges delete counts into their edit type, summing per time bucket", () => {
+    const input = {
+      "2026-05-01": {
+        [EventType.EDIT]: 2,
+        [EventType.DELETE]: 3,
+        [EventType.ANCHOR_EDIT]: 1,
+        [EventType.ANCHOR_DELETE]: 4,
+        [EventType.CREATE]: 5,
+      },
+    };
+
+    expect(foldStatsValuesByEventType(input)).toEqual({
+      "2026-05-01": {
+        [EventType.EDIT]: 5,
+        [EventType.ANCHOR_EDIT]: 5,
+        [EventType.CREATE]: 5,
+      },
+    });
+  });
+
+  it("promotes a delete-only bucket to the edit type", () => {
+    const input = { day: { [EventType.DELETE]: 2 } };
+    expect(foldStatsValuesByEventType(input)).toEqual({
+      day: { [EventType.EDIT]: 2 },
+    });
+  });
+
+  it("leaves non-event-type keys (e.g. user ids) untouched", () => {
+    const input = { day: { "U-123": 7, "U-456": 1 } };
+    expect(foldStatsValuesByEventType(input)).toEqual({
+      day: { "U-123": 7, "U-456": 1 },
+    });
+  });
+});

--- a/packages/server/src/models/stats/event-type-fold.ts
+++ b/packages/server/src/models/stats/event-type-fold.ts
@@ -1,0 +1,56 @@
+import { EventType } from "@inkvisitor/shared/types/stats";
+
+/**
+ * Deletion event types are folded into their matching edit type for stats, so a
+ * deletion counts as an edit (contribution) rather than its own category:
+ *   DELETE        -> EDIT
+ *   ANCHOR_DELETE -> ANCHOR_EDIT
+ */
+const STATS_FOLD_MAP: Partial<Record<EventType, EventType>> = {
+  [EventType.DELETE]: EventType.EDIT,
+  [EventType.ANCHOR_DELETE]: EventType.ANCHOR_EDIT,
+};
+
+/** Maps a single event type to the type it is counted as in stats. */
+export function foldEventTypeForStats(type: EventType): EventType {
+  return STATS_FOLD_MAP[type] ?? type;
+}
+
+/**
+ * Expands a requested event-type filter so the raw deletion rows that fold into
+ * a requested edit type are still fetched from the DB. Requesting EDIT also
+ * pulls DELETE; requesting ANCHOR_EDIT also pulls ANCHOR_DELETE. Without this,
+ * the delete rows would be filtered out before they could be folded.
+ */
+export function expandEventTypesForStats(types: EventType[]): EventType[] {
+  const expanded = new Set<EventType>(types);
+  for (const [deletionType, editType] of Object.entries(STATS_FOLD_MAP) as [
+    EventType,
+    EventType
+  ][]) {
+    if (expanded.has(editType)) {
+      expanded.add(deletionType);
+    }
+  }
+  return Array.from(expanded);
+}
+
+/**
+ * Folds a stats values map (timeBucket -> aggregationKey -> count) by merging
+ * deletion-type counts into their edit type and summing. Non-event-type keys
+ * (e.g. user ids in USER aggregation) pass through unchanged.
+ */
+export function foldStatsValuesByEventType(
+  values: Record<string, Record<string, number>>
+): Record<string, Record<string, number>> {
+  const result: Record<string, Record<string, number>> = {};
+  for (const [bucket, counts] of Object.entries(values)) {
+    const foldedCounts: Record<string, number> = {};
+    for (const [key, count] of Object.entries(counts)) {
+      const foldedKey = foldEventTypeForStats(key as EventType);
+      foldedCounts[foldedKey] = (foldedCounts[foldedKey] ?? 0) + count;
+    }
+    result[bucket] = foldedCounts;
+  }
+  return result;
+}

--- a/packages/server/src/models/stats/hybrid-stats.test.ts
+++ b/packages/server/src/models/stats/hybrid-stats.test.ts
@@ -3,6 +3,7 @@ import {
   startOfDay,
   getLiveTailRange,
   mergeStatsValues,
+  sumMaterializedStats,
 } from "./hybrid-stats";
 
 describe("startOfDay", () => {
@@ -72,5 +73,39 @@ describe("mergeStatsValues", () => {
     const base = { "2026": { edit: 100 } };
     mergeStatsValues(base, { "2026": { edit: 3 } });
     expect(base).toEqual({ "2026": { edit: 100 } });
+  });
+});
+
+describe("sumMaterializedStats", () => {
+  test("sums rows sharing a bucket and aggregation key (USER: many types per user)", () => {
+    const rows = [
+      { date: "2026-05-01", aggregationKey: "U-1", count: 5 },
+      { date: "2026-05-01", aggregationKey: "U-1", count: 3 },
+      { date: "2026-05-01", aggregationKey: "U-2", count: 2 },
+    ];
+    expect(sumMaterializedStats(rows)).toEqual({
+      "2026-05-01": { "U-1": 8, "U-2": 2 },
+    });
+  });
+
+  test("keeps distinct keys separate (ACTIVITY_TYPE: one row per type)", () => {
+    const rows = [
+      { date: "2026-05-01", aggregationKey: "edit", count: 4 },
+      { date: "2026-05-01", aggregationKey: "delete", count: 1 },
+    ];
+    expect(sumMaterializedStats(rows)).toEqual({
+      "2026-05-01": { edit: 4, delete: 1 },
+    });
+  });
+
+  test("separates buckets by date", () => {
+    const rows = [
+      { date: "2026-05-01", aggregationKey: "U-1", count: 1 },
+      { date: "2026-05-02", aggregationKey: "U-1", count: 9 },
+    ];
+    expect(sumMaterializedStats(rows)).toEqual({
+      "2026-05-01": { "U-1": 1 },
+      "2026-05-02": { "U-1": 9 },
+    });
   });
 });

--- a/packages/server/src/models/stats/hybrid-stats.ts
+++ b/packages/server/src/models/stats/hybrid-stats.ts
@@ -39,6 +39,28 @@ export function getLiveTailRange(
 }
 
 /**
+ * Builds a stats value map (date bucket -> aggregation key -> count) from
+ * materialized rows, summing rows that share a bucket and aggregation key.
+ * This matters for USER aggregation, where there is one row per event type per
+ * user, so a user's edit and (folded) delete rows must be summed rather than
+ * overwrite each other. For ACTIVITY_TYPE the keys are distinct event types, so
+ * summing leaves them separate (to be folded afterwards).
+ */
+export function sumMaterializedStats(
+  rows: { date: string; aggregationKey: string; count: number }[]
+): Record<string, Record<string, number>> {
+  const values: Record<string, Record<string, number>> = {};
+  for (const row of rows) {
+    if (!values[row.date]) {
+      values[row.date] = {};
+    }
+    values[row.date][row.aggregationKey] =
+      (values[row.date][row.aggregationKey] ?? 0) + row.count;
+  }
+  return values;
+}
+
+/**
  * Merges two stats value maps (date bucket -> aggregation key -> count) by
  * summing counts. The base is not mutated.
  */

--- a/packages/server/src/models/stats/materialized-stats.ts
+++ b/packages/server/src/models/stats/materialized-stats.ts
@@ -1,6 +1,7 @@
 import { IDbModel, fillFlatObject } from "@models/common";
 import { r as rethink, Connection, WriteResult } from "rethinkdb-ts";
 import { EventType, Aggregation } from "@inkvisitor/shared/types/stats";
+import { expandEventTypesForStats } from "./event-type-fold";
 
 export interface IMaterializedStats {
   id: string;
@@ -115,7 +116,7 @@ export class MaterializedStats implements IMaterializedStats {
       .table(tableName)
       .between(fromDateStr, toDateStr, { index: "date" })
       .filter((doc: any) =>
-        rethink.expr(eventTypes).contains(doc("eventType"))
+        rethink.expr(expandEventTypesForStats(eventTypes)).contains(doc("eventType"))
       )
       .filter((doc: any) => doc("aggregateBy").eq(aggregateBy))
       .orderBy("date")

--- a/packages/server/src/models/stats/response.ts
+++ b/packages/server/src/models/stats/response.ts
@@ -4,6 +4,10 @@ import { IRequestStats } from "@inkvisitor/shared/types/request-stats";
 import { Aggregation, EventType, TimeUnit } from "@inkvisitor/shared/types/stats";
 import { RDatum, r as rethink } from "rethinkdb-ts";
 import { IRequest } from "src/custom_typings/request";
+import {
+  expandEventTypesForStats,
+  foldStatsValuesByEventType,
+} from "./event-type-fold";
 
 export class ResponseStats implements IResponseStats {
   fromDate: number;
@@ -65,7 +69,7 @@ export class ResponseStats implements IResponseStats {
         index: "date",
       })
       .filter((doc: RDatum) =>
-        rethink.expr(this.eventType).contains(doc("type"))
+        rethink.expr(expandEventTypesForStats(this.eventType)).contains(doc("type"))
       )
       .group(timeBucket, (doc: RDatum) =>
         aggregateBy === Aggregation.ACTIVITY_TYPE
@@ -87,6 +91,13 @@ export class ResponseStats implements IResponseStats {
       newValues[dateKey][aggregationGroup] = item.reduction;
     }
 
-    this.values = newValues;
+    // When aggregating by activity type the inner keys are event types, so fold
+    // deletion counts into their edit type (DELETE -> EDIT, ANCHOR_DELETE ->
+    // ANCHOR_EDIT). For other aggregations the deletion rows pulled in by the
+    // expanded filter are already counted under their key (e.g. user).
+    this.values =
+      aggregateBy === Aggregation.ACTIVITY_TYPE
+        ? foldStatsValuesByEventType(newValues)
+        : newValues;
   }
 }

--- a/packages/server/src/modules/documents/index.ts
+++ b/packages/server/src/modules/documents/index.ts
@@ -10,6 +10,7 @@ import {
   IResponseAudit,
   IResponseGeneric,
   IDocumentAuditAnchorChanges,
+  AuditScope,
 } from "@inkvisitor/shared/types";
 import {
   BadParams,
@@ -433,6 +434,12 @@ export default Router()
       const result = await existing.delete(request.db.connection);
 
       if (result.deleted === 1) {
+        await Audit.createDeletionAudit(
+          request.db.connection,
+          id,
+          request.getUserOrFail().id,
+          AuditScope.Document
+        );
         return {
           result: true,
         };

--- a/packages/server/src/modules/entities/index.ts
+++ b/packages/server/src/modules/entities/index.ts
@@ -24,6 +24,7 @@ import {
   IUser,
   Relation as RelationType,
   RequestSearch,
+  AuditScope,
 } from "@inkvisitor/shared/types";
 import {
   AuditDoesNotExist,
@@ -593,6 +594,12 @@ export default Router()
                   );
                 }
                 out.data[entityId] = true;
+                await Audit.createDeletionAudit(
+                  req.db.connection,
+                  entityId,
+                  req.getUserOrFail().id,
+                  AuditScope.Entity
+                );
                 removeDependency(entityId);
                 removedCount++;
               } catch (e) {

--- a/packages/server/src/modules/stats/index.ts
+++ b/packages/server/src/modules/stats/index.ts
@@ -7,7 +7,12 @@ import { IRequestStats } from "@inkvisitor/shared/types/request-stats";
 import { MaterializedStats } from "@models/stats/materialized-stats";
 import { TimeUnit, EventType, Aggregation } from "@inkvisitor/shared/types/stats";
 import { StatsAggregator } from "@models/stats/stats-aggregator";
-import { getLiveTailRange, mergeStatsValues } from "@models/stats/hybrid-stats";
+import {
+  getLiveTailRange,
+  mergeStatsValues,
+  sumMaterializedStats,
+} from "@models/stats/hybrid-stats";
+import { foldStatsValuesByEventType } from "@models/stats/event-type-fold";
 
 export default Router()
   .post(
@@ -58,15 +63,13 @@ export default Router()
         aggregateBy
       );
 
-      // Transform materialized data to match IResponseStats format
-      let values: Record<string, Record<string, number>> = {};
-
-      for (const item of materializedData) {
-        if (!values[item.date]) {
-          values[item.date] = {};
-        }
-        values[item.date][item.aggregationKey] = item.count;
-      }
+      // Transform materialized data to match IResponseStats format. Sum rows
+      // sharing a bucket/key: for USER aggregation there is one row per event
+      // type per user, so the (filter-expanded) delete rows must add to the
+      // user's total rather than overwrite it.
+      let values: Record<string, Record<string, number>> = sumMaterializedStats(
+        materializedData
+      );
 
       // Top up with live data for the current day. Aggregation always excludes
       // today (its upper bound is truncated to midnight, right-exclusive), so the
@@ -86,13 +89,21 @@ export default Router()
         );
       }
 
+      // When aggregating by activity type the inner keys are event types, so
+      // fold deletion counts into their edit type (DELETE -> EDIT, ANCHOR_DELETE
+      // -> ANCHOR_EDIT) across both the materialized and live-tail data.
+      const foldedValues =
+        aggregateBy === Aggregation.ACTIVITY_TYPE
+          ? foldStatsValuesByEventType(values)
+          : values;
+
       const response: IResponseStats = {
         fromDate,
         toDate,
         timeUnit,
         aggregateBy,
         eventType,
-        values
+        values: foldedValues
       };
 
       return response;


### PR DESCRIPTION
Entity deletion writes a single minimal DELETE audit; document deletion a minimal ANCHOR_DELETE. Covers single, bulk and cascaded-dependent deletes.

Stats fold these at read time so deletions count as edit contributions: DELETE -> EDIT, ANCHOR_DELETE -> ANCHOR_EDIT. Applied to both the live and materialized endpoints, with the type filter expanded so delete rows survive to be folded. Materialized storage stays raw, so no re-aggregation is needed.

Also fix a pre-existing bug (#2809) in the materialized read path where rows sharing a (date, key) bucket overwrote instead of summing, undercounting USER aggregation with multiple event types; extracted sumMaterializedStats.

(dont)close #2976 or so