### PR TITLE
fix(client): inline Muni webfont to stop FOUT blink and font warning

### DIFF
--- a/packages/client/fonts.d.ts
+++ b/packages/client/fonts.d.ts
@@ -1,2 +1,3 @@
 declare module "*.woff";
 declare module "*.woff2";
+declare module "*.woff2?inline";

--- a/packages/client/src/Theme/global.ts
+++ b/packages/client/src/Theme/global.ts
@@ -1,5 +1,4 @@
-import MuniArial from "assets/fonts/academicons.woff2";
-import MuniFont from "assets/fonts/muni-bold-webfont.woff2";
+import MuniFont from "assets/fonts/muni-bold-webfont.woff2?inline";
 import { createGlobalStyle } from "styled-components";
 import { ThemeType } from "./theme";
 
@@ -7,6 +6,11 @@ interface GlobalStyle {
   theme: ThemeType;
 }
 const GlobalStyle = createGlobalStyle<GlobalStyle>`
+  @font-face {
+    font-family: "Muni";
+    src: url("${MuniFont}") format("woff2");
+    font-display: swap;
+  }
   html {
     font-size: 62.5%;
   }
@@ -14,14 +18,6 @@ const GlobalStyle = createGlobalStyle<GlobalStyle>`
     font-family: "Roboto", sans-serif;
     letter-spacing: .2px;
     line-height: 1.3;
-    @font-face {
-      font-family: "Muni";
-      src: url("${MuniFont}") format("woff2");
-    }
-    @font-face {
-      font-family: "MuniArial";
-      src: url("${MuniArial}") format("woff2");
-    }
   }
   *, *::after, *::before {
     margin: 0;


### PR DESCRIPTION
This PR fixes the random blinking and refetching for the font (even if 304-gated).

The Muni @font-face had no font-display, so Chrome's slow-network font intervention swapped fallback->webfont on load (the blink) and logged repeated '[Intervention] Slow network is detected' warnings. The dev server also serves the font with Cache-Control: no-cache, re-fetching it on every reload.

Inline the 9.6 KB font as a base64 data URI via Vite's ?inline suffix so it is embedded in the stylesheet: zero network requests, available the instant the @font-face is parsed, no blink in dev or prod. Also lift @font-face to top level (it was nested in body{}) and drop the dead MuniArial/academicons declaration (registered under a misleading name, applied nowhere).

close #3043 