### PR TITLE
3067 chip/tag UUID filter input for explorer page

### DIFF
--- a/packages/client/src/components/advanced/Dropdowns/EntityMultiDropdown.tsx
+++ b/packages/client/src/components/advanced/Dropdowns/EntityMultiDropdown.tsx
@@ -35,6 +35,8 @@ interface EntityMultiDropdown<T = string> {
   loggerId?: string;
   closeMenuOnSelect?: boolean;
   shortLabel?: boolean;
+  controlBackgroundColor?: string;
+  color?: string;
 }
 export const EntityMultiDropdown = <T extends string>({
   width,
@@ -55,6 +57,8 @@ export const EntityMultiDropdown = <T extends string>({
   loggerId,
   closeMenuOnSelect = true,
   shortLabel = false,
+  controlBackgroundColor,
+  color,
 }: EntityMultiDropdown<T>) => {
   const getValues = (items: DropdownItem[]) => items.map((i) => i.value as T);
 
@@ -149,6 +153,8 @@ export const EntityMultiDropdown = <T extends string>({
       limitSelectedItems={limitSelectedItems}
       closeMenuOnSelect={closeMenuOnSelect}
       shortLabel={shortLabel}
+      controlBackgroundColor={controlBackgroundColor}
+      color={color}
     />
   );
 };
@@ -179,6 +185,7 @@ const ValueContainer = ({
     const visibleChildren = limit
       ? filteredChildren.slice(0, remainingCount === 1 ? limit + 1 : limit)
       : filteredChildren;
+    const controlColor = props.selectProps.color;
     const displayRemainingCount = remainingCount > 1 ? remainingCount : 0;
 
     toBeRendered = [
@@ -190,7 +197,7 @@ const ValueContainer = ({
                 key="ellipsis"
                 style={{
                   padding: "0.2rem 0.2rem 0.2rem 0.3rem",
-                  color: theme.color.primary,
+                  color: controlColor ?? theme.color.primary,
                 }}
               >
                 +{displayRemainingCount} more

--- a/packages/client/src/components/basic/BaseDropdown/BaseDropdown.tsx
+++ b/packages/client/src/components/basic/BaseDropdown/BaseDropdown.tsx
@@ -57,6 +57,8 @@ interface BaseDropdown {
   closeMenuOnSelect?: boolean;
   shortLabel?: boolean;
   loading?: boolean;
+  controlBackgroundColor?: string;
+  color?: string;
 }
 export const BaseDropdown: React.FC<BaseDropdown> = ({
   options = [],
@@ -88,6 +90,8 @@ export const BaseDropdown: React.FC<BaseDropdown> = ({
   closeMenuOnSelect = true,
   shortLabel = false,
   loading = false,
+  controlBackgroundColor,
+  color,
 }) => {
   const isOneOptionSingleEntitySelect = options.length < 2 && !isMulti && entityDropdown;
 
@@ -175,6 +179,8 @@ export const BaseDropdown: React.FC<BaseDropdown> = ({
           loggerId={loggerId}
           limitSelectedItems={limitSelectedItems}
           shortLabel={shortLabel}
+          controlBackgroundColor={controlBackgroundColor}
+          color={color}
         />
         {loading && <Loader show size={7} loaderStyle="beat" />}
       </StyledSelectWrapper>

--- a/packages/client/src/components/basic/BaseDropdown/BaseDropdownStyles.tsx
+++ b/packages/client/src/components/basic/BaseDropdown/BaseDropdownStyles.tsx
@@ -33,6 +33,8 @@ export interface StyledSelect {
   loggerId?: string;
   limitSelectedItems?: number;
   shortLabel?: boolean;
+  controlBackgroundColor?: string;
+  color?: string;
 }
 export const StyledSelect = styled(Select)<StyledSelect>`
   display: inline-flex;
@@ -48,17 +50,24 @@ export const StyledSelect = styled(Select)<StyledSelect>`
     min-height: ${({ theme }) => theme.space[10]};
     // only for one row multi entity dropdown to avoid glitches during resizing
     height: ${({ limitSelectedItems }) => (limitSelectedItems ? "27px" : "")};
-    border-width: 1px;
+    border-width: ${({ controlBackgroundColor }) => (controlBackgroundColor ? 0 : "1px")};
     border-style: solid;
-    border-color: ${({ theme, suggester }) =>
-      suggester ? theme.color["black"] : theme.color["gray"]["400"]};
-    border-right: ${({ suggester }) => (suggester ? "none" : "")};
+    border-color: ${({ theme, suggester, controlBackgroundColor }) =>
+      controlBackgroundColor
+        ? "transparent"
+        : suggester
+          ? theme.color["black"]
+          : theme.color["gray"]["400"]};
+    border-right: ${({ suggester, controlBackgroundColor }) =>
+      suggester && !controlBackgroundColor ? "none" : ""};
     border-radius: 0;
-    background-color: ${({ theme, entityDropdown, suggester }) =>
-      entityDropdown && suggester ? theme.color["gray"][200] : theme.color["white"]};
+    background-color: ${({ theme, entityDropdown, suggester, controlBackgroundColor }) =>
+      controlBackgroundColor ??
+      (entityDropdown && suggester ? theme.color["gray"][200] : theme.color["white"])};
     &:hover {
-      border-color: ${({ theme }) => theme.color["info"]};
-      border-width: 1px;
+      border-color: ${({ theme, controlBackgroundColor }) =>
+        controlBackgroundColor ? "transparent" : theme.color["info"]};
+      border-width: ${({ controlBackgroundColor }) => (controlBackgroundColor ? 0 : "1px")};
     }
   }
   .react-select__control--is-disabled {
@@ -69,8 +78,9 @@ export const StyledSelect = styled(Select)<StyledSelect>`
     box-shadow: none;
 
     outline: 0;
-    border-color: ${({ theme }) => theme.color["info"]};
-    border-width: 1px;
+    border-color: ${({ theme, controlBackgroundColor }) =>
+      controlBackgroundColor ? "transparent" : theme.color["info"]};
+    border-width: ${({ controlBackgroundColor }) => (controlBackgroundColor ? 0 : "1px")};
   }
   .react-select__value-container {
     height: 100%;
@@ -85,8 +95,11 @@ export const StyledSelect = styled(Select)<StyledSelect>`
       entityDropdown && !wildCardChar ? theme.space[3] : theme.space[2]};
     margin-top: 1px;
 
-    color: ${({ theme }) => theme.color["primary"]};
+    color: ${({ theme, color }) => color ?? theme.color["primary"]};
     vertical-align: middle;
+  }
+  .react-select__placeholder {
+    color: ${({ theme, color }) => color ?? theme.color["gray"][500]};
   }
   .react-select__multi-value {
     background-color: ${({ theme, entityDropdown }) =>
@@ -95,13 +108,14 @@ export const StyledSelect = styled(Select)<StyledSelect>`
     border: 1px solid ${({ theme }) => theme.color["blue"][300]};
   }
   .react-select__indicator {
-    color: ${({ theme }) => theme.color["primary"]};
+    color: ${({ theme, color }) => color ?? theme.color["primary"]};
     svg {
       height: 18;
     }
   }
   .react-select__clear-indicator {
     padding: 0.2rem;
+    color: ${({ theme, color }) => color ?? theme.color["primary"]};
   }
   .react-select__indicator-separator {
     display: none;
@@ -117,7 +131,7 @@ export const StyledSelect = styled(Select)<StyledSelect>`
     padding-right: ${({ entityDropdown }) => (entityDropdown ? "0.2rem" : "")};
   }
   .react-select__input-container {
-    color: ${({ theme }) => theme.color["black"]};
+    color: ${({ theme, color }) => color ?? theme.color["black"]};
   }
   // portal menu style is in global stylesheet
 `;

--- a/packages/client/src/components/basic/Input/InputStyles.tsx
+++ b/packages/client/src/components/basic/Input/InputStyles.tsx
@@ -58,8 +58,8 @@ export const StyledInput = styled.input<IValueStyle>`
     $suggester
       ? theme.color["primary"]
       : $borderColor
-      ? theme.color[$borderColor]
-      : theme.color["gray"]["400"]};
+        ? theme.color[$borderColor]
+        : theme.color["gray"]["400"]};
   font-size: ${({ theme }) => theme.fontSize["xs"]};
   padding-left: ${({ theme }) => theme.space[2]};
 
@@ -86,6 +86,9 @@ export const StyledInput = styled.input<IValueStyle>`
   }
   &::placeholder {
     font-size: 1.1rem;
+    color: ${({ theme }) => theme.color["gray"][500]};
+    font-weight: inherit;
+    text-decoration: none;
   }
 
   /* Theming for native datetime picker icon */

--- a/packages/client/src/pages/Query/Explorer/ExplorerBox.tsx
+++ b/packages/client/src/pages/Query/Explorer/ExplorerBox.tsx
@@ -3,6 +3,7 @@ import React from "react";
 import { IResponseQueryEntity } from "@inkvisitor/shared/types";
 import { Explore } from "@inkvisitor/shared/types/query";
 import { ExplorerTable } from "./ExplorerTable/ExplorerTable";
+import ExplorerTableIdsFilter from "./ExplorerTable/ExplorerTableIdsFilter";
 import { ExploreAction } from "./state";
 import { FloatingSearchContainer } from "../FloatingSearchContainer/FloatingSearchContainer";
 
@@ -54,6 +55,7 @@ export const ExplorerBox: React.FC<ExplorerBoxProps> = ({
         onOpenEntityInDetail={onOpenEntityInDetail}
         onOpenEntitiesInDetail={onOpenEntitiesInDetail}
       />
+      <ExplorerTableIdsFilter filters={state.filters} dispatch={dispatch} />
       <FloatingSearchContainer
         rightInset={floatingSearchRightInset}
         filters={state.filters}

--- a/packages/client/src/pages/Query/Explorer/ExplorerTable/ExploreTableControl.tsx
+++ b/packages/client/src/pages/Query/Explorer/ExplorerTable/ExploreTableControl.tsx
@@ -13,7 +13,6 @@ import { Explore } from "@inkvisitor/shared/types/query";
 import { ThemeContext } from "styled-components";
 import { ExploreAction } from "../state";
 import ExplorerTableLabelFilter from "./ExplorerTableLabelFilter";
-import ExplorerTableIdsFilter from "./ExplorerTableIdsFilter";
 import { StyledCounter, StyledExploreFilters, StyledTableControl } from "./ExplorerTableStyles";
 import { BatchAction, batchOptions } from "./types";
 
@@ -142,7 +141,6 @@ const ExploreTableControl: React.FC<ExploreTableControlProps> = ({
 
       <StyledExploreFilters>
         <ExplorerTableLabelFilter filters={filters} dispatch={dispatch} />
-        <ExplorerTableIdsFilter filters={filters} dispatch={dispatch} />
       </StyledExploreFilters>
 
       <Button

--- a/packages/client/src/pages/Query/Explorer/ExplorerTable/ExplorerTableIdsFilter.tsx
+++ b/packages/client/src/pages/Query/Explorer/ExplorerTable/ExplorerTableIdsFilter.tsx
@@ -13,6 +13,7 @@ import React, {
   useRef,
   useState,
 } from "react";
+import { BiSearch } from "react-icons/bi";
 import { MdClose } from "react-icons/md";
 import { ExploreAction, ExploreActionType } from "../state";
 import {
@@ -27,6 +28,8 @@ import {
   StyledIdsPanelHeader,
   StyledIdsPanelTitle,
   StyledIdsToggleButton,
+  StyledIdsToggleClear,
+  StyledIdsToggleWrapper,
   StyledUuidChip,
   StyledUuidChipRemove,
 } from "./ExplorerTableStyles";
@@ -48,7 +51,7 @@ const shortenUuid = (id: string): string =>
 // positioned ancestor (the explorer area) so it never spills out of the page.
 const PANEL_BOTTOM_GAP = 8;
 const PANEL_TOP_MARGIN = 16;
-const PANEL_MIN_HEIGHT = 140;
+const PANEL_MIN_HEIGHT = 200;
 
 const ExplorerTableIdsFilter: React.FC<ExplorerTableIdsFilterProps> = ({ filters, dispatch }) => {
   const rowIdsFilter = getRowIdsFilter(filters);
@@ -59,10 +62,16 @@ const ExplorerTableIdsFilter: React.FC<ExplorerTableIdsFilterProps> = ({ filters
   const [allSelected, setAllSelected] = useState(false);
   const [maxPanelHeight, setMaxPanelHeight] = useState<number | undefined>(undefined);
   const inputRef = useRef<HTMLInputElement>(null);
+  const chipBoxRef = useRef<HTMLDivElement>(null);
   const rootRef = useRef<HTMLDivElement>(null);
-  const buttonRef = useRef<HTMLButtonElement>(null);
+  const buttonRef = useRef<HTMLDivElement>(null);
+  const scrollToBottomPendingRef = useRef(false);
 
   const showSelected = allSelected && appliedIds.length > 0;
+
+  const requestScrollToBottom = () => {
+    scrollToBottomPendingRef.current = true;
+  };
 
   const dispatchFilter = useCallback(
     (ids: string[]) => {
@@ -99,6 +108,12 @@ const ExplorerTableIdsFilter: React.FC<ExplorerTableIdsFilterProps> = ({ filters
     },
     [appliedIds, dispatchFilter],
   );
+
+  const clearAllIds = () => {
+    setAllSelected(false);
+    dispatchFilter([]);
+    setDraft("");
+  };
 
   const removeId = (id: string) => {
     setAllSelected(false);
@@ -153,6 +168,7 @@ const ExplorerTableIdsFilter: React.FC<ExplorerTableIdsFilterProps> = ({ filters
     if (showSelected) {
       replaceWith(pasted);
       setAllSelected(false);
+      requestScrollToBottom();
       return;
     }
 
@@ -165,6 +181,7 @@ const ExplorerTableIdsFilter: React.FC<ExplorerTableIdsFilterProps> = ({ filters
         pasted,
       ),
     );
+    requestScrollToBottom();
   };
 
   // The draft is flagged invalid only once it can no longer become a valid UUID,
@@ -180,6 +197,18 @@ const ExplorerTableIdsFilter: React.FC<ExplorerTableIdsFilterProps> = ({ filters
     const id = window.setTimeout(() => inputRef.current?.focus(), 0);
     return () => window.clearTimeout(id);
   }, [isOpen]);
+
+  // After paste, chips render on the next frame — scroll the box to the bottom then.
+  useLayoutEffect(() => {
+    if (!isOpen || !scrollToBottomPendingRef.current) {
+      return;
+    }
+    scrollToBottomPendingRef.current = false;
+    const el = chipBoxRef.current;
+    if (el) {
+      el.scrollTop = el.scrollHeight;
+    }
+  }, [appliedIds, draft, isOpen]);
 
   // Bound the panel height to the floating container's positioned ancestor (the
   // explorer area), so a long list of UUIDs scrolls inside the page instead of
@@ -234,7 +263,7 @@ const ExplorerTableIdsFilter: React.FC<ExplorerTableIdsFilterProps> = ({ filters
             </StyledUuidChipRemove>
           </StyledIdsPanelHeader>
 
-          <StyledChipInputBox onClick={() => inputRef.current?.focus()}>
+          <StyledChipInputBox ref={chipBoxRef} onClick={() => inputRef.current?.focus()}>
             {appliedIds.map((id) => (
               <StyledUuidChip key={id} title={id} $selected={showSelected}>
                 {shortenUuid(id)}
@@ -281,11 +310,7 @@ const ExplorerTableIdsFilter: React.FC<ExplorerTableIdsFilterProps> = ({ filters
               <StyledClearAllButton
                 type="button"
                 onMouseDown={(e) => e.preventDefault()}
-                onClick={() => {
-                  setAllSelected(false);
-                  dispatchFilter([]);
-                  setDraft("");
-                }}
+                onClick={clearAllIds}
               >
                 <MdClose size={13} />
                 Clear all
@@ -295,17 +320,29 @@ const ExplorerTableIdsFilter: React.FC<ExplorerTableIdsFilterProps> = ({ filters
         </StyledIdsPanel>
       )}
 
-      <StyledIdsToggleButton
-        ref={buttonRef}
-        type="button"
-        aria-expanded={isOpen}
-        onClick={() => setIsOpen((open) => !open)}
-      >
-        + UUIDs
+      <StyledIdsToggleWrapper ref={buttonRef}>
+        <StyledIdsToggleButton
+          type="button"
+          aria-expanded={isOpen}
+          onClick={() => setIsOpen((open) => !open)}
+        >
+          {appliedIds.length > 0 ? <BiSearch size={18} /> : "+ "}
+          UUIDs
+          {appliedIds.length > 0 && (
+            <StyledIdsCountBadge>{appliedIds.length}</StyledIdsCountBadge>
+          )}
+        </StyledIdsToggleButton>
         {appliedIds.length > 0 && (
-          <StyledIdsCountBadge>{appliedIds.length}</StyledIdsCountBadge>
+          <StyledIdsToggleClear
+            type="button"
+            aria-label="Clear all UUIDs"
+            onMouseDown={(e) => e.preventDefault()}
+            onClick={clearAllIds}
+          >
+            <MdClose size={16} />
+          </StyledIdsToggleClear>
         )}
-      </StyledIdsToggleButton>
+      </StyledIdsToggleWrapper>
     </StyledIdsFloatingRoot>
   );
 };

--- a/packages/client/src/pages/Query/Explorer/ExplorerTable/ExplorerTableIdsFilter.tsx
+++ b/packages/client/src/pages/Query/Explorer/ExplorerTable/ExplorerTableIdsFilter.tsx
@@ -2,6 +2,7 @@ import { Explore } from "@inkvisitor/shared/types/query";
 import {
   applyPasteToDraft,
   entityIdsEqual,
+  isViableUuidPrefix,
   mergeTokensIntoIds,
   unparsedRemainder,
 } from "pages/Query/utils";
@@ -85,6 +86,10 @@ const ExplorerTableIdsFilter: React.FC<ExplorerTableIdsFilterProps> = ({ filters
     );
   };
 
+  // The draft is flagged invalid only once it can no longer become a valid UUID,
+  // so a half-typed UUID stays neutral while junk (e.g. "foo bar") is emphasized.
+  const draftInvalid = draft.trim() !== "" && !isViableUuidPrefix(draft.trim());
+
   return (
     <StyledIdsFilter>
       <StyledChipInputBox onClick={() => inputRef.current?.focus()}>
@@ -107,6 +112,8 @@ const ExplorerTableIdsFilter: React.FC<ExplorerTableIdsFilterProps> = ({ filters
         <StyledChipTextInput
           ref={inputRef}
           value={draft}
+          $invalid={draftInvalid}
+          title={draftInvalid ? "Not a valid UUID — only complete UUIDs are allowed" : undefined}
           placeholder={appliedIds.length === 0 ? "Add entity UUIDs (paste or type)…" : "Add UUID…"}
           onChange={(e) => setDraft(e.target.value)}
           onKeyDown={handleKeyDown}

--- a/packages/client/src/pages/Query/Explorer/ExplorerTable/ExplorerTableIdsFilter.tsx
+++ b/packages/client/src/pages/Query/Explorer/ExplorerTable/ExplorerTableIdsFilter.tsx
@@ -82,7 +82,12 @@ const ExplorerTableIdsFilter: React.FC<ExplorerTableIdsFilterProps> = ({ filters
     const { selectionStart, selectionEnd } = e.currentTarget;
     const pasted = e.clipboardData.getData("text");
     commit(
-      applyPasteToDraft(draft, selectionStart ?? draft.length, selectionEnd ?? draft.length, pasted),
+      applyPasteToDraft(
+        draft,
+        selectionStart ?? draft.length,
+        selectionEnd ?? draft.length,
+        pasted,
+      ),
     );
   };
 
@@ -114,7 +119,7 @@ const ExplorerTableIdsFilter: React.FC<ExplorerTableIdsFilterProps> = ({ filters
           value={draft}
           $invalid={draftInvalid}
           title={draftInvalid ? "Not a valid UUID — only complete UUIDs are allowed" : undefined}
-          placeholder={appliedIds.length === 0 ? "Add entity UUIDs (paste or type)…" : "Add UUID…"}
+          placeholder={appliedIds.length === 0 ? "Add entity UUIDs (paste or type)" : "Add UUID…"}
           onChange={(e) => setDraft(e.target.value)}
           onKeyDown={handleKeyDown}
           onPaste={handlePaste}

--- a/packages/client/src/pages/Query/Explorer/ExplorerTable/ExplorerTableIdsFilter.tsx
+++ b/packages/client/src/pages/Query/Explorer/ExplorerTable/ExplorerTableIdsFilter.tsx
@@ -6,15 +6,27 @@ import {
   mergeTokensIntoIds,
   unparsedRemainder,
 } from "pages/Query/utils";
-import React, { useCallback, useRef, useState } from "react";
+import React, {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
 import { MdClose } from "react-icons/md";
 import { ExploreAction, ExploreActionType } from "../state";
 import {
   StyledChipInputBox,
   StyledChipTextInput,
   StyledClearAllButton,
-  StyledIdsFilter,
+  StyledIdsCountBadge,
   StyledIdsFilterHint,
+  StyledIdsFloatingRoot,
+  StyledIdsPanel,
+  StyledIdsPanelFooter,
+  StyledIdsPanelHeader,
+  StyledIdsPanelTitle,
+  StyledIdsToggleButton,
   StyledUuidChip,
   StyledUuidChipRemove,
 } from "./ExplorerTableStyles";
@@ -32,12 +44,25 @@ const getRowIdsFilter = (
 const shortenUuid = (id: string): string =>
   id.length > 13 ? `${id.slice(0, 8)}…${id.slice(-5)}` : id;
 
+// space the panel keeps from the button below it and from the top edge of the
+// positioned ancestor (the explorer area) so it never spills out of the page.
+const PANEL_BOTTOM_GAP = 8;
+const PANEL_TOP_MARGIN = 16;
+const PANEL_MIN_HEIGHT = 140;
+
 const ExplorerTableIdsFilter: React.FC<ExplorerTableIdsFilterProps> = ({ filters, dispatch }) => {
   const rowIdsFilter = getRowIdsFilter(filters);
   const appliedIds = rowIdsFilter?.ids ?? [];
 
   const [draft, setDraft] = useState("");
+  const [isOpen, setIsOpen] = useState(false);
+  const [allSelected, setAllSelected] = useState(false);
+  const [maxPanelHeight, setMaxPanelHeight] = useState<number | undefined>(undefined);
   const inputRef = useRef<HTMLInputElement>(null);
+  const rootRef = useRef<HTMLDivElement>(null);
+  const buttonRef = useRef<HTMLButtonElement>(null);
+
+  const showSelected = allSelected && appliedIds.length > 0;
 
   const dispatchFilter = useCallback(
     (ids: string[]) => {
@@ -62,10 +87,50 @@ const ExplorerTableIdsFilter: React.FC<ExplorerTableIdsFilterProps> = ({ filters
     [appliedIds, dispatchFilter],
   );
 
-  const removeId = (id: string) =>
+  // Replace the entire UUID set with whatever is in `text` (used when the chips
+  // are "select-all"ed and the user pastes/types a fresh batch).
+  const replaceWith = useCallback(
+    (text: string) => {
+      const next = mergeTokensIntoIds([], text);
+      if (!entityIdsEqual(next, appliedIds)) {
+        dispatchFilter(next);
+      }
+      setDraft(unparsedRemainder(text));
+    },
+    [appliedIds, dispatchFilter],
+  );
+
+  const removeId = (id: string) => {
+    setAllSelected(false);
     dispatchFilter(appliedIds.filter((x) => x.toLowerCase() !== id.toLowerCase()));
+  };
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    // Cmd/Ctrl+A selects all existing UUIDs so the next paste/type replaces them.
+    if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "a" && appliedIds.length > 0) {
+      e.preventDefault();
+      setAllSelected(true);
+      return;
+    }
+
+    if (showSelected) {
+      if (e.key === "Backspace" || e.key === "Delete") {
+        e.preventDefault();
+        dispatchFilter([]);
+        setDraft("");
+        setAllSelected(false);
+        return;
+      }
+      // a printable key replaces the whole set: clear now, let the char land in
+      // the (now empty) input via onChange below.
+      if (e.key.length === 1 && !e.metaKey && !e.ctrlKey) {
+        dispatchFilter([]);
+        setAllSelected(false);
+      } else if (e.key !== "Shift" && e.key !== "Meta" && e.key !== "Control") {
+        setAllSelected(false);
+      }
+    }
+
     // Note: Tab is intentionally not handled here — it commits via onBlur while
     // still moving focus normally (preventing it would trap keyboard focus).
     if (e.key === "Enter" || e.key === "," || e.key === " ") {
@@ -74,13 +139,24 @@ const ExplorerTableIdsFilter: React.FC<ExplorerTableIdsFilterProps> = ({ filters
     } else if (e.key === "Backspace" && draft === "" && appliedIds.length > 0) {
       e.preventDefault();
       dispatchFilter(appliedIds.slice(0, -1));
+    } else if (e.key === "Escape") {
+      e.preventDefault();
+      setIsOpen(false);
     }
   };
 
   const handlePaste = (e: React.ClipboardEvent<HTMLInputElement>) => {
     e.preventDefault();
-    const { selectionStart, selectionEnd } = e.currentTarget;
     const pasted = e.clipboardData.getData("text");
+
+    // With everything selected, paste swaps the whole set for the new UUIDs.
+    if (showSelected) {
+      replaceWith(pasted);
+      setAllSelected(false);
+      return;
+    }
+
+    const { selectionStart, selectionEnd } = e.currentTarget;
     commit(
       applyPasteToDraft(
         draft,
@@ -95,56 +171,142 @@ const ExplorerTableIdsFilter: React.FC<ExplorerTableIdsFilterProps> = ({ filters
   // so a half-typed UUID stays neutral while junk (e.g. "foo bar") is emphasized.
   const draftInvalid = draft.trim() !== "" && !isViableUuidPrefix(draft.trim());
 
+  // Focus the input as soon as the panel opens.
+  useEffect(() => {
+    if (!isOpen) {
+      setAllSelected(false);
+      return;
+    }
+    const id = window.setTimeout(() => inputRef.current?.focus(), 0);
+    return () => window.clearTimeout(id);
+  }, [isOpen]);
+
+  // Bound the panel height to the floating container's positioned ancestor (the
+  // explorer area), so a long list of UUIDs scrolls inside the page instead of
+  // overflowing past the top of the page content.
+  useLayoutEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+    const measure = () => {
+      const button = buttonRef.current;
+      const parent = (rootRef.current?.offsetParent as HTMLElement | null) ?? null;
+      if (!button) {
+        return;
+      }
+      const buttonRect = button.getBoundingClientRect();
+      const parentTop = parent ? parent.getBoundingClientRect().top : 0;
+      const available = buttonRect.top - parentTop - PANEL_BOTTOM_GAP - PANEL_TOP_MARGIN;
+      setMaxPanelHeight(Math.max(PANEL_MIN_HEIGHT, available));
+    };
+    measure();
+    window.addEventListener("resize", measure);
+    return () => window.removeEventListener("resize", measure);
+  }, [isOpen]);
+
+  // Close (committing any pending draft) when clicking outside the panel.
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+    const handleOutside = (e: MouseEvent) => {
+      if (rootRef.current && !rootRef.current.contains(e.target as Node)) {
+        commit(draft);
+        setIsOpen(false);
+      }
+    };
+    window.addEventListener("mousedown", handleOutside);
+    return () => window.removeEventListener("mousedown", handleOutside);
+  }, [isOpen, commit, draft]);
+
   return (
-    <StyledIdsFilter>
-      <StyledChipInputBox onClick={() => inputRef.current?.focus()}>
-        {appliedIds.map((id) => (
-          <StyledUuidChip key={id} title={id}>
-            {shortenUuid(id)}
+    <StyledIdsFloatingRoot ref={rootRef}>
+      {isOpen && (
+        <StyledIdsPanel style={maxPanelHeight ? { maxHeight: maxPanelHeight } : undefined}>
+          <StyledIdsPanelHeader>
+            <StyledIdsPanelTitle>Entity UUIDs</StyledIdsPanelTitle>
             <StyledUuidChipRemove
               type="button"
-              aria-label={`Remove ${id}`}
-              onMouseDown={(e) => e.preventDefault()}
-              onClick={(e) => {
-                e.stopPropagation();
-                removeId(id);
-              }}
+              aria-label="Close UUID filter"
+              onClick={() => setIsOpen(false)}
             >
-              <MdClose size={12} />
+              <MdClose size={16} />
             </StyledUuidChipRemove>
-          </StyledUuidChip>
-        ))}
-        <StyledChipTextInput
-          ref={inputRef}
-          value={draft}
-          $invalid={draftInvalid}
-          title={draftInvalid ? "Not a valid UUID — only complete UUIDs are allowed" : undefined}
-          placeholder={appliedIds.length === 0 ? "Add entity UUIDs (paste or type)" : "Add UUID…"}
-          onChange={(e) => setDraft(e.target.value)}
-          onKeyDown={handleKeyDown}
-          onPaste={handlePaste}
-          onBlur={() => commit(draft)}
-        />
-      </StyledChipInputBox>
-      {appliedIds.length > 0 && (
-        <>
-          <StyledIdsFilterHint>{`${appliedIds.length} UUID${
-            appliedIds.length === 1 ? "" : "s"
-          }`}</StyledIdsFilterHint>
-          <StyledClearAllButton
-            type="button"
-            onMouseDown={(e) => e.preventDefault()}
-            onClick={() => {
-              dispatchFilter([]);
-              setDraft("");
-            }}
-          >
-            <MdClose size={13} />
-            Clear all
-          </StyledClearAllButton>
-        </>
+          </StyledIdsPanelHeader>
+
+          <StyledChipInputBox onClick={() => inputRef.current?.focus()}>
+            {appliedIds.map((id) => (
+              <StyledUuidChip key={id} title={id} $selected={showSelected}>
+                {shortenUuid(id)}
+                <StyledUuidChipRemove
+                  type="button"
+                  aria-label={`Remove ${id}`}
+                  onMouseDown={(e) => e.preventDefault()}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    removeId(id);
+                  }}
+                >
+                  <MdClose size={12} />
+                </StyledUuidChipRemove>
+              </StyledUuidChip>
+            ))}
+            <StyledChipTextInput
+              ref={inputRef}
+              value={draft}
+              $invalid={draftInvalid}
+              title={
+                draftInvalid ? "Not a valid UUID — only complete UUIDs are allowed" : undefined
+              }
+              placeholder={
+                appliedIds.length === 0 ? "Add entity UUIDs (paste or type)" : "Add UUID…"
+              }
+              onChange={(e) => {
+                if (allSelected) {
+                  setAllSelected(false);
+                }
+                setDraft(e.target.value);
+              }}
+              onKeyDown={handleKeyDown}
+              onPaste={handlePaste}
+              onBlur={() => commit(draft)}
+            />
+          </StyledChipInputBox>
+
+          {appliedIds.length > 0 && (
+            <StyledIdsPanelFooter>
+              <StyledIdsFilterHint>{`${appliedIds.length} UUID${
+                appliedIds.length === 1 ? "" : "s"
+              }`}</StyledIdsFilterHint>
+              <StyledClearAllButton
+                type="button"
+                onMouseDown={(e) => e.preventDefault()}
+                onClick={() => {
+                  setAllSelected(false);
+                  dispatchFilter([]);
+                  setDraft("");
+                }}
+              >
+                <MdClose size={13} />
+                Clear all
+              </StyledClearAllButton>
+            </StyledIdsPanelFooter>
+          )}
+        </StyledIdsPanel>
       )}
-    </StyledIdsFilter>
+
+      <StyledIdsToggleButton
+        ref={buttonRef}
+        type="button"
+        aria-expanded={isOpen}
+        onClick={() => setIsOpen((open) => !open)}
+      >
+        + UUIDs
+        {appliedIds.length > 0 && (
+          <StyledIdsCountBadge>{appliedIds.length}</StyledIdsCountBadge>
+        )}
+      </StyledIdsToggleButton>
+    </StyledIdsFloatingRoot>
   );
 };
 

--- a/packages/client/src/pages/Query/Explorer/ExplorerTable/ExplorerTableIdsFilter.tsx
+++ b/packages/client/src/pages/Query/Explorer/ExplorerTable/ExplorerTableIdsFilter.tsx
@@ -6,13 +6,7 @@ import {
   mergeTokensIntoIds,
   unparsedRemainder,
 } from "pages/Query/utils";
-import React, {
-  useCallback,
-  useEffect,
-  useLayoutEffect,
-  useRef,
-  useState,
-} from "react";
+import React, { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 import { BiSearch } from "react-icons/bi";
 import { MdClose } from "react-icons/md";
 import { ExploreAction, ExploreActionType } from "../state";
@@ -328,9 +322,7 @@ const ExplorerTableIdsFilter: React.FC<ExplorerTableIdsFilterProps> = ({ filters
         >
           {appliedIds.length > 0 ? <BiSearch size={18} /> : "+ "}
           UUIDs
-          {appliedIds.length > 0 && (
-            <StyledIdsCountBadge>{appliedIds.length}</StyledIdsCountBadge>
-          )}
+          {appliedIds.length > 0 && <StyledIdsCountBadge>{appliedIds.length}</StyledIdsCountBadge>}
         </StyledIdsToggleButton>
         {appliedIds.length > 0 && (
           <StyledIdsToggleClear

--- a/packages/client/src/pages/Query/Explorer/ExplorerTable/ExplorerTableIdsFilter.tsx
+++ b/packages/client/src/pages/Query/Explorer/ExplorerTable/ExplorerTableIdsFilter.tsx
@@ -1,12 +1,22 @@
 import { Explore } from "@inkvisitor/shared/types/query";
-import { Input } from "components";
-import { useDebounce } from "hooks";
-import React, { useCallback, useEffect, useState } from "react";
+import {
+  applyPasteToDraft,
+  entityIdsEqual,
+  mergeTokensIntoIds,
+  unparsedRemainder,
+} from "pages/Query/utils";
+import React, { useCallback, useRef, useState } from "react";
+import { MdClose } from "react-icons/md";
 import { ExploreAction, ExploreActionType } from "../state";
-import { StyledIdsFilter, StyledIdsFilterHint } from "./ExplorerTableStyles";
-import { entityIdsEqual, parseEntityIdsFromText } from "pages/Query/utils";
-
-const IDS_FILTER_DEBOUNCE_MS = 400;
+import {
+  StyledChipInputBox,
+  StyledChipTextInput,
+  StyledClearAllButton,
+  StyledIdsFilter,
+  StyledIdsFilterHint,
+  StyledUuidChip,
+  StyledUuidChipRemove,
+} from "./ExplorerTableStyles";
 
 interface ExplorerTableIdsFilterProps {
   filters: Explore.IExploreSearchFilter[];
@@ -18,12 +28,15 @@ const getRowIdsFilter = (
 ): Explore.IExploreUuidsFilter | undefined =>
   filters.find((f): f is Explore.IExploreUuidsFilter => f.type === Explore.SearchOption.UUIDs);
 
+const shortenUuid = (id: string): string =>
+  id.length > 13 ? `${id.slice(0, 8)}…${id.slice(-5)}` : id;
+
 const ExplorerTableIdsFilter: React.FC<ExplorerTableIdsFilterProps> = ({ filters, dispatch }) => {
   const rowIdsFilter = getRowIdsFilter(filters);
   const appliedIds = rowIdsFilter?.ids ?? [];
 
-  const [inputValue, setInputValue] = useState(() => appliedIds.join(" "));
-  const debouncedInput = useDebounce(inputValue, IDS_FILTER_DEBOUNCE_MS);
+  const [draft, setDraft] = useState("");
+  const inputRef = useRef<HTMLInputElement>(null);
 
   const dispatchFilter = useCallback(
     (ids: string[]) => {
@@ -35,29 +48,89 @@ const ExplorerTableIdsFilter: React.FC<ExplorerTableIdsFilterProps> = ({ filters
     [dispatch],
   );
 
-  useEffect(() => {
-    const parsedIds = parseEntityIdsFromText(debouncedInput);
-    if (!entityIdsEqual(parsedIds, appliedIds)) {
-      dispatchFilter(parsedIds);
-    }
-  }, [debouncedInput, appliedIds, dispatchFilter]);
+  // Extract complete UUIDs from `text` into chips, keeping any half-typed / non-UUID
+  // remainder in the draft so a blur or stray separator never wipes what you typed.
+  const commit = useCallback(
+    (text: string) => {
+      const next = mergeTokensIntoIds(appliedIds, text);
+      if (!entityIdsEqual(next, appliedIds)) {
+        dispatchFilter(next);
+      }
+      setDraft(unparsedRemainder(text));
+    },
+    [appliedIds, dispatchFilter],
+  );
 
-  const parsedCount = parseEntityIdsFromText(inputValue).length;
+  const removeId = (id: string) =>
+    dispatchFilter(appliedIds.filter((x) => x.toLowerCase() !== id.toLowerCase()));
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    // Note: Tab is intentionally not handled here — it commits via onBlur while
+    // still moving focus normally (preventing it would trap keyboard focus).
+    if (e.key === "Enter" || e.key === "," || e.key === " ") {
+      e.preventDefault();
+      commit(draft);
+    } else if (e.key === "Backspace" && draft === "" && appliedIds.length > 0) {
+      e.preventDefault();
+      dispatchFilter(appliedIds.slice(0, -1));
+    }
+  };
+
+  const handlePaste = (e: React.ClipboardEvent<HTMLInputElement>) => {
+    e.preventDefault();
+    const { selectionStart, selectionEnd } = e.currentTarget;
+    const pasted = e.clipboardData.getData("text");
+    commit(
+      applyPasteToDraft(draft, selectionStart ?? draft.length, selectionEnd ?? draft.length, pasted),
+    );
+  };
 
   return (
     <StyledIdsFilter>
-      <Input
-        width="full"
-        placeholder="Filter by entity UUIDs (space-, tab-, or line-separated)"
-        changeOnType
-        value={inputValue}
-        onChangeFn={setInputValue}
-        clearable
-      />
-      {parsedCount > 0 && (
-        <StyledIdsFilterHint>{`${parsedCount} UUID${
-          parsedCount === 1 ? "" : "s"
-        }`}</StyledIdsFilterHint>
+      <StyledChipInputBox onClick={() => inputRef.current?.focus()}>
+        {appliedIds.map((id) => (
+          <StyledUuidChip key={id} title={id}>
+            {shortenUuid(id)}
+            <StyledUuidChipRemove
+              type="button"
+              aria-label={`Remove ${id}`}
+              onMouseDown={(e) => e.preventDefault()}
+              onClick={(e) => {
+                e.stopPropagation();
+                removeId(id);
+              }}
+            >
+              <MdClose size={12} />
+            </StyledUuidChipRemove>
+          </StyledUuidChip>
+        ))}
+        <StyledChipTextInput
+          ref={inputRef}
+          value={draft}
+          placeholder={appliedIds.length === 0 ? "Add entity UUIDs (paste or type)…" : "Add UUID…"}
+          onChange={(e) => setDraft(e.target.value)}
+          onKeyDown={handleKeyDown}
+          onPaste={handlePaste}
+          onBlur={() => commit(draft)}
+        />
+      </StyledChipInputBox>
+      {appliedIds.length > 0 && (
+        <>
+          <StyledIdsFilterHint>{`${appliedIds.length} UUID${
+            appliedIds.length === 1 ? "" : "s"
+          }`}</StyledIdsFilterHint>
+          <StyledClearAllButton
+            type="button"
+            onMouseDown={(e) => e.preventDefault()}
+            onClick={() => {
+              dispatchFilter([]);
+              setDraft("");
+            }}
+          >
+            <MdClose size={13} />
+            Clear all
+          </StyledClearAllButton>
+        </>
       )}
     </StyledIdsFilter>
   );

--- a/packages/client/src/pages/Query/Explorer/ExplorerTable/ExplorerTableStyles.tsx
+++ b/packages/client/src/pages/Query/Explorer/ExplorerTable/ExplorerTableStyles.tsx
@@ -159,11 +159,11 @@ export const StyledLabelFilterCheckboxWrapper = styled.div`
 export const StyledExploreFilters = styled.div`
   display: flex;
   flex-direction: row;
-  gap: 2rem;
+  gap: 1rem;
   flex: 1;
   min-width: 10rem;
-  max-width: 60%;
-  margin: 0 3rem;
+  max-width: 75%;
+  margin: 0 1.5rem;
 `;
 
 export const StyledIdsFilter = styled.div`
@@ -231,7 +231,7 @@ export const StyledUuidChipRemove = styled.button`
   }
 `;
 
-export const StyledChipTextInput = styled.input`
+export const StyledChipTextInput = styled.input<{ $invalid?: boolean }>`
   flex: 1;
   min-width: 8rem;
   border: none;
@@ -239,9 +239,17 @@ export const StyledChipTextInput = styled.input`
   background: transparent;
   padding: 0.2rem;
   font-size: ${({ theme }) => theme.fontSize["xs"]};
-  color: ${({ theme }) => theme.color["primary"]};
+  font-weight: ${({ $invalid }) => ($invalid ? 700 : "inherit")};
+  color: ${({ theme, $invalid }) =>
+    $invalid ? theme.color["danger"] : theme.color["primary"]};
+  text-decoration: ${({ $invalid }) => ($invalid ? "underline wavy" : "none")};
+  text-decoration-color: ${({ theme, $invalid }) =>
+    $invalid ? theme.color["danger"] : "transparent"};
+  text-decoration-skip-ink: none;
   &::placeholder {
     color: ${({ theme }) => theme.color["gray"][500]};
+    font-weight: inherit;
+    text-decoration: none;
   }
 `;
 

--- a/packages/client/src/pages/Query/Explorer/ExplorerTable/ExplorerTableStyles.tsx
+++ b/packages/client/src/pages/Query/Explorer/ExplorerTable/ExplorerTableStyles.tsx
@@ -189,7 +189,7 @@ export const StyledChipInputBox = styled.div`
   gap: 0.4rem;
   // grow with content, then scroll within the (height-bounded) panel
   flex: 1 1 auto;
-  min-height: ${({ theme }) => theme.space[10]};
+  min-height: ${({ theme }) => theme.space[28]};
   overflow-y: auto;
   padding: 0.3rem 0.5rem;
   cursor: text;
@@ -206,7 +206,7 @@ export const StyledChipInputBox = styled.div`
 export const StyledIdsFloatingRoot = styled.div`
   position: absolute;
   right: 2rem;
-  bottom: calc(2rem + ${FLOATING_SEARCH_COLLAPSED_SIZE}px + 0.75rem);
+  bottom: calc(2rem + ${FLOATING_SEARCH_COLLAPSED_SIZE}px + 1.5rem);
   z-index: 161;
   display: flex;
   flex-direction: column;
@@ -214,25 +214,45 @@ export const StyledIdsFloatingRoot = styled.div`
   gap: 0.5rem;
 `;
 
+export const StyledIdsToggleWrapper = styled.div`
+  display: inline-flex;
+  align-items: center;
+  gap: 0.2rem;
+  padding: 0.6rem 1.2rem;
+  border-radius: ${({ theme }) => theme.borderRadius.full};
+  background-color: ${({ theme }) => theme.color.invertedBg["info"]};
+  box-shadow: ${({ theme }) => theme.boxShadow.high};
+  transition: box-shadow 0.2s;
+  &:hover {
+    box-shadow: ${({ theme }) => theme.boxShadow.normal};
+  }
+`;
+
 export const StyledIdsToggleButton = styled.button`
   display: inline-flex;
   align-items: center;
   gap: 0.4rem;
-  padding: 0.6rem 1.2rem;
+  padding: 0;
   border: none;
-  border-radius: ${({ theme }) => theme.borderRadius.full};
   cursor: pointer;
   white-space: nowrap;
   font-size: ${({ theme }) => theme.fontSize["sm"]};
   font-weight: ${({ theme }) => theme.fontWeight.bold};
   color: ${({ theme }) => theme.color["info"]};
-  background-color: ${({ theme }) => theme.color.invertedBg["info"]};
-  box-shadow: ${({ theme }) => theme.boxShadow.high};
-  transition:
-    background-color 0.2s,
-    box-shadow 0.2s;
+  background: transparent;
+`;
+
+export const StyledIdsToggleClear = styled.button`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: ${({ theme }) => theme.color["info"]};
+  cursor: pointer;
   &:hover {
-    box-shadow: ${({ theme }) => theme.boxShadow.normal};
+    color: ${({ theme }) => theme.color["danger"]};
   }
 `;
 
@@ -253,7 +273,7 @@ export const StyledIdsPanel = styled.div`
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
-  width: 32rem;
+  width: 30rem;
   max-width: calc(100vw - 4rem);
   min-height: 0;
   padding: 0.75rem;

--- a/packages/client/src/pages/Query/Explorer/ExplorerTable/ExplorerTableStyles.tsx
+++ b/packages/client/src/pages/Query/Explorer/ExplorerTable/ExplorerTableStyles.tsx
@@ -189,7 +189,7 @@ export const StyledChipInputBox = styled.div`
   gap: 0.4rem;
   // grow with content, then scroll within the (height-bounded) panel
   flex: 1 1 auto;
-  min-height: ${({ theme }) => theme.space[28]};
+  min-height: 6rem;
   overflow-y: auto;
   padding: 0.3rem 0.5rem;
   cursor: text;

--- a/packages/client/src/pages/Query/Explorer/ExplorerTable/ExplorerTableStyles.tsx
+++ b/packages/client/src/pages/Query/Explorer/ExplorerTable/ExplorerTableStyles.tsx
@@ -1,4 +1,5 @@
 import styled from "styled-components";
+import { FLOATING_SEARCH_COLLAPSED_SIZE } from "../../FloatingSearchContainer/FloatingSearchContainerStyles";
 
 interface StyledTableWrapper {
   // $height: number;
@@ -163,7 +164,7 @@ export const StyledExploreFilters = styled.div`
   flex: 1;
   min-width: 10rem;
   max-width: 75%;
-  margin: 0 1.5rem;
+  margin: 0 3rem;
 `;
 
 export const StyledIdsFilter = styled.div`
@@ -181,13 +182,14 @@ export const StyledIdsFilterHint = styled.span`
 `;
 
 export const StyledChipInputBox = styled.div`
-  flex: 1;
   display: flex;
   flex-wrap: wrap;
-  align-items: center;
+  align-items: flex-start;
+  align-content: flex-start;
   gap: 0.4rem;
+  // grow with content, then scroll within the (height-bounded) panel
+  flex: 1 1 auto;
   min-height: ${({ theme }) => theme.space[10]};
-  max-height: 8rem;
   overflow-y: auto;
   padding: 0.3rem 0.5rem;
   cursor: text;
@@ -201,7 +203,89 @@ export const StyledChipInputBox = styled.div`
   }
 `;
 
-export const StyledUuidChip = styled.span`
+export const StyledIdsFloatingRoot = styled.div`
+  position: absolute;
+  right: 2rem;
+  bottom: calc(2rem + ${FLOATING_SEARCH_COLLAPSED_SIZE}px + 0.75rem);
+  z-index: 161;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 0.5rem;
+`;
+
+export const StyledIdsToggleButton = styled.button`
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.6rem 1.2rem;
+  border: none;
+  border-radius: ${({ theme }) => theme.borderRadius.full};
+  cursor: pointer;
+  white-space: nowrap;
+  font-size: ${({ theme }) => theme.fontSize["sm"]};
+  font-weight: ${({ theme }) => theme.fontWeight.bold};
+  color: ${({ theme }) => theme.color["info"]};
+  background-color: ${({ theme }) => theme.color.invertedBg["info"]};
+  box-shadow: ${({ theme }) => theme.boxShadow.high};
+  transition:
+    background-color 0.2s,
+    box-shadow 0.2s;
+  &:hover {
+    box-shadow: ${({ theme }) => theme.boxShadow.normal};
+  }
+`;
+
+export const StyledIdsCountBadge = styled.span`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 1.6rem;
+  height: 1.6rem;
+  padding: 0 0.4rem;
+  border-radius: ${({ theme }) => theme.borderRadius.full};
+  background-color: ${({ theme }) => theme.color["info"]};
+  color: ${({ theme }) => theme.color["white"]};
+  font-size: ${({ theme }) => theme.fontSize["xs"]};
+`;
+
+export const StyledIdsPanel = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  width: 32rem;
+  max-width: calc(100vw - 4rem);
+  min-height: 0;
+  padding: 0.75rem;
+  border-radius: ${({ theme }) => theme.borderRadius.md};
+  background-color: ${({ theme }) => theme.color["white"]};
+  box-shadow: ${({ theme }) => theme.boxShadow.high};
+  overflow: hidden;
+`;
+
+export const StyledIdsPanelHeader = styled.div`
+  display: flex;
+  flex-shrink: 0;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+`;
+
+export const StyledIdsPanelTitle = styled.span`
+  font-size: ${({ theme }) => theme.fontSize["sm"]};
+  font-weight: ${({ theme }) => theme.fontWeight.bold};
+  color: ${({ theme }) => theme.color["primary"]};
+`;
+
+export const StyledIdsPanelFooter = styled.div`
+  display: flex;
+  flex-shrink: 0;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+`;
+
+export const StyledUuidChip = styled.span<{ $selected?: boolean }>`
   display: inline-flex;
   align-items: center;
   gap: 0.3rem;
@@ -209,11 +293,13 @@ export const StyledUuidChip = styled.span`
   padding: 0.1rem 0.2rem 0.1rem 0.5rem;
   font-family: monospace;
   font-size: ${({ theme }) => theme.fontSize["xs"]};
-  color: ${({ theme }) => theme.color["primary"]};
-  background-color: ${({ theme }) => theme.color["gray"][200]};
+  color: ${({ theme, $selected }) => ($selected ? theme.color["white"] : theme.color["primary"])};
+  background-color: ${({ theme, $selected }) =>
+    $selected ? theme.color["info"] : theme.color["gray"][200]};
   border-width: ${({ theme }) => theme.borderWidth[1]};
   border-style: solid;
-  border-color: ${({ theme }) => theme.color["gray"][400]};
+  border-color: ${({ theme, $selected }) =>
+    $selected ? theme.color["info"] : theme.color["gray"][400]};
   border-radius: ${({ theme }) => theme.borderRadius["xs"]};
   white-space: nowrap;
 `;

--- a/packages/client/src/pages/Query/Explorer/ExplorerTable/ExplorerTableStyles.tsx
+++ b/packages/client/src/pages/Query/Explorer/ExplorerTable/ExplorerTableStyles.tsx
@@ -240,8 +240,7 @@ export const StyledChipTextInput = styled.input<{ $invalid?: boolean }>`
   padding: 0.2rem;
   font-size: ${({ theme }) => theme.fontSize["xs"]};
   font-weight: ${({ $invalid }) => ($invalid ? 700 : "inherit")};
-  color: ${({ theme, $invalid }) =>
-    $invalid ? theme.color["danger"] : theme.color["primary"]};
+  color: ${({ theme, $invalid }) => ($invalid ? theme.color["danger"] : theme.color["primary"])};
   text-decoration: ${({ $invalid }) => ($invalid ? "underline wavy" : "none")};
   text-decoration-color: ${({ theme, $invalid }) =>
     $invalid ? theme.color["danger"] : "transparent"};

--- a/packages/client/src/pages/Query/Explorer/ExplorerTable/ExplorerTableStyles.tsx
+++ b/packages/client/src/pages/Query/Explorer/ExplorerTable/ExplorerTableStyles.tsx
@@ -179,3 +179,85 @@ export const StyledIdsFilterHint = styled.span`
   color: ${({ theme }) => theme.color["gray"][600]};
   white-space: nowrap;
 `;
+
+export const StyledChipInputBox = styled.div`
+  flex: 1;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.4rem;
+  min-height: ${({ theme }) => theme.space[10]};
+  max-height: 8rem;
+  overflow-y: auto;
+  padding: 0.3rem 0.5rem;
+  cursor: text;
+  background-color: ${({ theme }) => theme.color["white"]};
+  border-width: ${({ theme }) => theme.borderWidth[1]};
+  border-style: solid;
+  border-color: ${({ theme }) => theme.color["gray"][400]};
+  border-radius: ${({ theme }) => theme.borderRadius["xs"]};
+  &:focus-within {
+    border-color: ${({ theme }) => theme.color["info"]};
+  }
+`;
+
+export const StyledUuidChip = styled.span`
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  max-width: 100%;
+  padding: 0.1rem 0.2rem 0.1rem 0.5rem;
+  font-family: monospace;
+  font-size: ${({ theme }) => theme.fontSize["xs"]};
+  color: ${({ theme }) => theme.color["primary"]};
+  background-color: ${({ theme }) => theme.color["gray"][200]};
+  border-width: ${({ theme }) => theme.borderWidth[1]};
+  border-style: solid;
+  border-color: ${({ theme }) => theme.color["gray"][400]};
+  border-radius: ${({ theme }) => theme.borderRadius["xs"]};
+  white-space: nowrap;
+`;
+
+export const StyledUuidChipRemove = styled.button`
+  display: inline-flex;
+  align-items: center;
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: ${({ theme }) => theme.color["gray"][600]};
+  cursor: pointer;
+  &:hover {
+    color: ${({ theme }) => theme.color["danger"]};
+  }
+`;
+
+export const StyledChipTextInput = styled.input`
+  flex: 1;
+  min-width: 8rem;
+  border: none;
+  outline: none;
+  background: transparent;
+  padding: 0.2rem;
+  font-size: ${({ theme }) => theme.fontSize["xs"]};
+  color: ${({ theme }) => theme.color["primary"]};
+  &::placeholder {
+    color: ${({ theme }) => theme.color["gray"][500]};
+  }
+`;
+
+export const StyledClearAllButton = styled.button`
+  display: inline-flex;
+  align-items: center;
+  gap: 0.2rem;
+  flex-shrink: 0;
+  padding: 0;
+  border: none;
+  background: transparent;
+  font-size: ${({ theme }) => theme.fontSize["xs"]};
+  color: ${({ theme }) => theme.color["gray"][600]};
+  cursor: pointer;
+  white-space: nowrap;
+  &:hover {
+    color: ${({ theme }) => theme.color["danger"]};
+  }
+`;

--- a/packages/client/src/pages/Query/FloatingSearchContainer/FloatingSearchContainer.tsx
+++ b/packages/client/src/pages/Query/FloatingSearchContainer/FloatingSearchContainer.tsx
@@ -340,8 +340,8 @@ export const FloatingSearchContainer: React.FC<FloatingSearchContainer> = ({
     [applyExpandedPosition, endDrag, getExpandedPanelHeight],
   );
 
-  const handleExpand = () => {
-    setIsExpanded(true);
+  const handleToggle = () => {
+    setIsExpanded((expanded) => !expanded);
   };
 
   const handleClose = () => {
@@ -355,21 +355,19 @@ export const FloatingSearchContainer: React.FC<FloatingSearchContainer> = ({
     };
   }, []);
 
-  const displayPosition = isExpanded ? expandedPosition : collapsedPosition;
-  const expandedPagePosition = viewportToPageRelative(displayPosition);
+  const expandedPagePosition = viewportToPageRelative(expandedPosition);
 
   return (
     <>
-      {!isExpanded && (
-        <StyledCollapsedButton
-          type="button"
-          onClick={handleExpand}
-          aria-label="Open search panel"
-          aria-expanded={false}
-        >
-          <BiSearch size={22} />
-        </StyledCollapsedButton>
-      )}
+      <StyledCollapsedButton
+        type="button"
+        $isActive={isExpanded}
+        onClick={handleToggle}
+        aria-label={isExpanded ? "Close search panel" : "Open search panel"}
+        aria-expanded={isExpanded}
+      >
+        <BiSearch size={22} />
+      </StyledCollapsedButton>
       {isExpanded && (
         <FloatingPortal id="page-content">
           <StyledFloatingRoot

--- a/packages/client/src/pages/Query/FloatingSearchContainer/FloatingSearchContainerStyles.tsx
+++ b/packages/client/src/pages/Query/FloatingSearchContainer/FloatingSearchContainerStyles.tsx
@@ -15,7 +15,7 @@ export const StyledFloatingRoot = styled.div<StyledFloatingRootProps>`
   z-index: 160;
 `;
 
-export const StyledCollapsedButton = styled.button`
+export const StyledCollapsedButton = styled.button<{ $isActive?: boolean }>`
   position: absolute;
   right: 2rem;
   bottom: 2rem;
@@ -27,9 +27,12 @@ export const StyledCollapsedButton = styled.button`
   border: none;
   border-radius: 50%;
   cursor: pointer;
+  z-index: 162;
   color: ${({ theme }) => theme.color.primary};
-  background-color: ${({ theme }) => theme.color.blue[100]};
-  box-shadow: ${({ theme }) => theme.boxShadow.high};
+  background-color: ${({ theme, $isActive }) =>
+    $isActive ? theme.color.blue[150] : theme.color.blue[100]};
+  box-shadow: ${({ theme, $isActive }) =>
+    $isActive ? theme.boxShadow.normal : theme.boxShadow.high};
   transition:
     background-color 0.2s,
     box-shadow 0.2s;

--- a/packages/client/src/pages/Query/Query/components/QueryGridNode.tsx
+++ b/packages/client/src/pages/Query/Query/components/QueryGridNode.tsx
@@ -212,6 +212,8 @@ export const QueryGridNode: React.FC<QueryGridNodeProps> = ({
               placeholder="all classes"
               disabled={node.params.entityId !== undefined}
               limitSelectedItems={Math.floor((270 - 110) / 37)}
+              controlBackgroundColor={isRoot ? nodeColor : undefined}
+              color={isRoot ? theme.color.white : undefined}
             />
           )}
           {paramEntityId && (

--- a/packages/client/src/pages/Query/utils.test.ts
+++ b/packages/client/src/pages/Query/utils.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from "vitest";
-import { computeWindowUpdate } from "./utils";
+import {
+  applyPasteToDraft,
+  computeWindowUpdate,
+  mergeTokensIntoIds,
+  unparsedRemainder,
+} from "./utils";
 
 describe("computeWindowUpdate", () => {
   const base = {
@@ -68,5 +73,82 @@ describe("computeWindowUpdate", () => {
       loadedCount: 0,
     });
     expect(r.shouldUpdate).toBe(false);
+  });
+});
+
+describe("mergeTokensIntoIds", () => {
+  const ID1 = "000033c5-472f-49a8-8d75-d82f955cce0b";
+  const ID2 = "a1b2c3d4-5678-41a8-9d75-d82f955cce0b";
+  const ID3 = "ffffffff-1111-2222-8888-cccccccccccc";
+
+  it("adds a single valid uuid to an empty list", () => {
+    expect(mergeTokensIntoIds([], ID1)).toEqual([ID1]);
+  });
+
+  it("returns the existing ids unchanged when the text has no valid uuid", () => {
+    expect(mergeTokensIntoIds([ID1], "foo bar not-a-uuid")).toEqual([ID1]);
+  });
+
+  it("appends several pasted uuids preserving paste order after existing ids", () => {
+    expect(mergeTokensIntoIds([ID1], `${ID2}, ${ID3}`)).toEqual([ID1, ID2, ID3]);
+  });
+
+  it("ignores a uuid already present, case-insensitively", () => {
+    expect(mergeTokensIntoIds([ID1], ID1.toUpperCase())).toEqual([ID1]);
+  });
+
+  it("dedups repeated uuids within the same pasted text", () => {
+    expect(mergeTokensIntoIds([], `${ID2} ${ID2}`)).toEqual([ID2]);
+  });
+
+  it("drops invalid tokens but keeps the valid ones from the same paste", () => {
+    expect(mergeTokensIntoIds([], `foo ${ID1} 12345 ${ID2}`)).toEqual([ID1, ID2]);
+  });
+});
+
+describe("unparsedRemainder", () => {
+  const ID1 = "000033c5-472f-49a8-8d75-d82f955cce0b";
+  const ID2 = "a1b2c3d4-5678-41a8-9d75-d82f955cce0b";
+
+  it("returns empty string for empty or whitespace-only input", () => {
+    expect(unparsedRemainder("")).toBe("");
+    expect(unparsedRemainder("   ")).toBe("");
+  });
+
+  it("returns empty string when the text is exactly one valid uuid", () => {
+    expect(unparsedRemainder(ID1)).toBe("");
+  });
+
+  it("returns empty string when every token is a valid uuid", () => {
+    expect(unparsedRemainder(`${ID1} ${ID2}`)).toBe("");
+  });
+
+  it("keeps a partially-typed (invalid) uuid", () => {
+    expect(unparsedRemainder("000033c5-472f")).toBe("000033c5-472f");
+  });
+
+  it("keeps non-uuid words and drops the extracted valid uuid", () => {
+    expect(unparsedRemainder(`foo ${ID1} bar`)).toBe("foo bar");
+  });
+
+  it("keeps the leftover junk after extracting a pasted uuid", () => {
+    expect(unparsedRemainder(`${ID1}, garbage`)).toBe("garbage");
+  });
+});
+
+describe("applyPasteToDraft", () => {
+  const UUID = "000033c5-472f-49a8-8d75-d82f955cce0b";
+
+  it("replaces the whole draft when everything is selected", () => {
+    // Bug: select-all + paste must replace, not append. "d2e3232sdsd" is 11 chars.
+    expect(applyPasteToDraft("d2e3232sdsd", 0, 11, UUID)).toBe(UUID);
+  });
+
+  it("inserts at the cursor when nothing is selected", () => {
+    expect(applyPasteToDraft("abc", 3, 3, "X")).toBe("abcX");
+  });
+
+  it("replaces only the selected range", () => {
+    expect(applyPasteToDraft("hello world", 0, 5, "bye")).toBe("bye world");
   });
 });

--- a/packages/client/src/pages/Query/utils.test.ts
+++ b/packages/client/src/pages/Query/utils.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   applyPasteToDraft,
   computeWindowUpdate,
+  isViableUuidPrefix,
   mergeTokensIntoIds,
   unparsedRemainder,
 } from "./utils";
@@ -150,5 +151,44 @@ describe("applyPasteToDraft", () => {
 
   it("replaces only the selected range", () => {
     expect(applyPasteToDraft("hello world", 0, 5, "bye")).toBe("bye world");
+  });
+});
+
+describe("isViableUuidPrefix", () => {
+  const FULL = "000033c5-472f-49a8-8d75-d82f955cce0b";
+
+  it("treats empty string as viable (nothing typed yet)", () => {
+    expect(isViableUuidPrefix("")).toBe(true);
+  });
+
+  it("accepts a partially-typed prefix of a valid uuid", () => {
+    expect(isViableUuidPrefix("000033c5")).toBe(true);
+    expect(isViableUuidPrefix("000033c5-472f")).toBe(true);
+    expect(isViableUuidPrefix("000033c5-472f-49a8-8d75")).toBe(true);
+  });
+
+  it("accepts a complete valid uuid", () => {
+    expect(isViableUuidPrefix(FULL)).toBe(true);
+  });
+
+  it("rejects a non-hex character", () => {
+    expect(isViableUuidPrefix("d2e3232sdsd")).toBe(false);
+    expect(isViableUuidPrefix("g0003")).toBe(false);
+  });
+
+  it("rejects an invalid version nibble (must be 1-5)", () => {
+    expect(isViableUuidPrefix("000033c5-472f-69a8")).toBe(false);
+  });
+
+  it("rejects an invalid variant nibble (must be 8/9/a/b)", () => {
+    expect(isViableUuidPrefix("000033c5-472f-49a8-0d75")).toBe(false);
+  });
+
+  it("rejects text with spaces (leftover junk)", () => {
+    expect(isViableUuidPrefix("foo bar")).toBe(false);
+  });
+
+  it("rejects anything longer than a uuid", () => {
+    expect(isViableUuidPrefix(`${FULL}0`)).toBe(false);
   });
 });

--- a/packages/client/src/pages/Query/utils.ts
+++ b/packages/client/src/pages/Query/utils.ts
@@ -401,3 +401,34 @@ export const applyPasteToDraft = (
   selectionEnd: number,
   pasted: string,
 ): string => draft.slice(0, selectionStart) + pasted + draft.slice(selectionEnd);
+
+// UUID slot template: x = hex, V = version [1-5], R = variant [89ab], - = literal.
+const UUID_TEMPLATE = "xxxxxxxx-xxxx-Vxxx-Rxxx-xxxxxxxxxxxx";
+
+/**
+ * True when `text` could still become a valid entity UUID by typing more chars
+ * (i.e. it matches the UUID template up to its length). Empty text is viable;
+ * anything that breaks the pattern (bad char, wrong version/variant, too long,
+ * or contains spaces) is not. Used to flag clearly-invalid draft input.
+ */
+export const isViableUuidPrefix = (text: string): boolean => {
+  if (text.length > UUID_TEMPLATE.length) {
+    return false;
+  }
+  for (let i = 0; i < text.length; i++) {
+    const slot = UUID_TEMPLATE[i];
+    const ch = text[i];
+    const ok =
+      slot === "-"
+        ? ch === "-"
+        : slot === "V"
+          ? /[1-5]/.test(ch)
+          : slot === "R"
+            ? /[89ab]/i.test(ch)
+            : /[0-9a-f]/i.test(ch);
+    if (!ok) {
+      return false;
+    }
+  }
+  return true;
+};

--- a/packages/client/src/pages/Query/utils.ts
+++ b/packages/client/src/pages/Query/utils.ts
@@ -365,3 +365,39 @@ export const entityIdsEqual = (a: string[], b: string[]): boolean => {
   const setB = new Set(b.map((id) => id.toLowerCase()));
   return a.every((id) => setB.has(id.toLowerCase()));
 };
+
+/**
+ * Merges valid UUIDs parsed from `rawText` into `existingIds`, appending any not
+ * already present (case-insensitive) in their parsed order. Existing order is
+ * preserved; invalid tokens and duplicates are dropped. Returns the same array
+ * reference when nothing new is added.
+ */
+export const mergeTokensIntoIds = (existingIds: string[], rawText: string): string[] => {
+  const present = new Set(existingIds.map((id) => id.toLowerCase()));
+  const toAdd = parseEntityIdsFromText(rawText).filter((id) => !present.has(id.toLowerCase()));
+  return toAdd.length > 0 ? [...existingIds, ...toAdd] : existingIds;
+};
+
+/**
+ * Returns the text left over after removing every valid-UUID token, space-joined.
+ * Used to keep a half-typed / non-UUID draft in the input instead of clearing it
+ * once the complete UUIDs have been extracted into chips.
+ */
+export const unparsedRemainder = (text: string): string =>
+  text
+    .split(/[\s,\t\n\r]+/)
+    .map((token) => token.trim())
+    .filter((token) => token !== "" && !ENTITY_ID_RE.test(token))
+    .join(" ");
+
+/**
+ * Applies a paste to `draft` the way a normal text input would: the text between
+ * `selectionStart` and `selectionEnd` is replaced by `pasted` (so select-all then
+ * paste replaces everything, and an empty selection inserts at the cursor).
+ */
+export const applyPasteToDraft = (
+  draft: string,
+  selectionStart: number,
+  selectionEnd: number,
+  pasted: string,
+): string => draft.slice(0, selectionStart) + pasted + draft.slice(selectionEnd);


### PR DESCRIPTION
Replaces the single comma/space-separated UUID text field on /explore with a chip input: each UUID is a removable chip, paste a blob to add several at once, per-chip remove, Backspace removes the last, and Clear all. Invalid tokens dropped, duplicates ignored, paste order preserved.

No backend/request-shape changes. Pure helpers are unit-tested.

close #3067 