### PR TITLE
Annotator: cursor-model refactor, undo/redo, and editor settings (#3086)

### DIFF
--- a/packages/annotator/src/caretAffinity.test.ts
+++ b/packages/annotator/src/caretAffinity.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Phase 3.2 — affinity-aware offset<->visual converters.
+ *
+ * At a soft-wrap boundary one document offset maps to two visual caret
+ * positions; the affinity bit picks which:
+ *   UPSTREAM   -> end of the wrapped visual line       e.g. (10,0)
+ *   DOWNSTREAM -> start of the next visual line         e.g. (0,1)
+ * (See characterization/wrap-navigation.test.ts for the behavior being preserved.)
+ */
+import Text, { CaretAffinity } from "./lib/Text";
+
+const WRAPPED = "supercalifragilistic"; // ["supercalif","ragilistic"] at width 10
+
+describe("Text.isWrapBoundary", () => {
+  test("true only at a soft-wrap boundary offset (start of a continuation line)", () => {
+    const t = new Text(WRAPPED, 10);
+    expect(t.isWrapBoundary(10)).toBe(true); // start of "ragilistic"
+    expect(t.isWrapBoundary(9)).toBe(false);
+    expect(t.isWrapBoundary(11)).toBe(false);
+    expect(t.isWrapBoundary(0)).toBe(false);
+  });
+
+  test("false at a hard newline boundary (segment start is lineIndex 0)", () => {
+    const t = new Text("abcde\nfghij", 100);
+    expect(t.isWrapBoundary(6)).toBe(false); // start of segment 1, not a soft wrap
+  });
+});
+
+describe("Text.visualFromOffset with affinity", () => {
+  test("UPSTREAM renders a boundary offset at end of the wrapped line", () => {
+    const t = new Text(WRAPPED, 10);
+    expect(t.visualFromOffset(10, CaretAffinity.UPSTREAM)).toEqual({
+      xLine: 10,
+      yLine: 0,
+    });
+  });
+
+  test("DOWNSTREAM (default) renders a boundary offset at start of next line", () => {
+    const t = new Text(WRAPPED, 10);
+    expect(t.visualFromOffset(10, CaretAffinity.DOWNSTREAM)).toEqual({
+      xLine: 0,
+      yLine: 1,
+    });
+    expect(t.visualFromOffset(10)).toEqual({ xLine: 0, yLine: 1 });
+  });
+
+  test("affinity is irrelevant for a non-boundary offset", () => {
+    const t = new Text(WRAPPED, 10);
+    expect(t.visualFromOffset(9, CaretAffinity.UPSTREAM)).toEqual(
+      t.visualFromOffset(9, CaretAffinity.DOWNSTREAM)
+    );
+  });
+});
+
+describe("Text.offsetWithAffinityFromVisual", () => {
+  test("end of a wrapped line -> UPSTREAM", () => {
+    const t = new Text(WRAPPED, 10);
+    expect(t.offsetWithAffinityFromVisual(10, 0)).toEqual({
+      offset: 10,
+      affinity: CaretAffinity.UPSTREAM,
+    });
+  });
+
+  test("start of the next visual line -> DOWNSTREAM", () => {
+    const t = new Text(WRAPPED, 10);
+    expect(t.offsetWithAffinityFromVisual(0, 1)).toEqual({
+      offset: 10,
+      affinity: CaretAffinity.DOWNSTREAM,
+    });
+  });
+
+  test("end of a segment's LAST visual line is DOWNSTREAM (no continuation)", () => {
+    const t = new Text("abcde\nfghij", 100);
+    expect(t.offsetWithAffinityFromVisual(5, 0)).toEqual({
+      offset: 5,
+      affinity: CaretAffinity.DOWNSTREAM,
+    });
+  });
+
+  test("round-trips with visualFromOffset at the boundary (both affinities)", () => {
+    const t = new Text(WRAPPED, 10);
+    for (const [x, y] of [
+      [10, 0],
+      [0, 1],
+      [9, 0],
+      [5, 1],
+    ]) {
+      const { offset, affinity } = t.offsetWithAffinityFromVisual(x, y);
+      expect(t.visualFromOffset(offset, affinity)).toEqual({
+        xLine: x,
+        yLine: y,
+      });
+    }
+  });
+});

--- a/packages/annotator/src/caretBoundsEditing.test.ts
+++ b/packages/annotator/src/caretBoundsEditing.test.ts
@@ -105,3 +105,29 @@ describe("offset positioning preserves normal typing behavior", () => {
     expect({ x: a.cursor.xLine, y: a.cursor.yLine }).toEqual({ x: 0, y: 1 });
   });
 });
+
+describe("multi-line insert places the caret at the end of the inserted text", () => {
+  test("onReplaceText with embedded newlines lands the caret after it", () => {
+    const a = mk("abc", EditMode.RAW, 100);
+    a.cursor.setPosition(1, 0); // between a and b -> raw offset 1
+    a.onReplaceText("X\nY");
+    expect(a.text.value).toBe("aX\nYbc");
+    // caret = offset 1 + 3 = 4 -> after "Y" on line 1
+    expect({ x: a.cursor.xLine, y: a.cursor.yLine }).toEqual({ x: 1, y: 1 });
+    expectCaretInBounds(a);
+  });
+
+  test("paste with embedded newlines lands the caret after it", async () => {
+    const a = mk("abc", EditMode.RAW, 100);
+    a.cursor.setPosition(1, 0);
+    (window.navigator.clipboard as any) = {
+      readText: () => Promise.resolve("X\nY"),
+      writeText: () => Promise.resolve(),
+    };
+    a.onPasteText();
+    await new Promise((r) => setTimeout(r, 0));
+    expect(a.text.value).toBe("aX\nYbc");
+    expect({ x: a.cursor.xLine, y: a.cursor.yLine }).toEqual({ x: 1, y: 1 });
+    expectCaretInBounds(a);
+  });
+});

--- a/packages/annotator/src/caretBoundsEditing.test.ts
+++ b/packages/annotator/src/caretBoundsEditing.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Phase 3 pivot (P2) — offset-based editing keeps the caret/selection in bounds.
+ *
+ * Two bounds bugs the fuzz (caretBoundsFuzz) surfaced, reproduced minimally:
+ *  1. Enter on the last visual line of a wrapped segment: the old blind
+ *     `moveToNewline` (yLine += 1) overshoots when the split re-wraps the prefix
+ *     into fewer visual lines, leaving the caret past the last line.
+ *  2. Typing with a stale (collapsed) selection present leaves selectStart/End
+ *     set; after the edit re-wraps they can point past the (now shorter) line.
+ * Both are fixed by setting the caret from the post-edit document OFFSET.
+ */
+import { Annotator } from "./lib/Annotator";
+import { EditMode } from "./lib/constants";
+
+const mk = (text: string, mode: EditMode, charsAtLine: number): Annotator => {
+  const c = document.createElement("canvas");
+  c.style.width = "800px";
+  c.style.height = "600px";
+  document.body.appendChild(c);
+  const a = new Annotator(c, text);
+  a.setMode(mode);
+  a.text.updateCharsAtLine(charsAtLine);
+  return a;
+};
+const key = (a: Annotator, k: string, mods: Partial<KeyboardEvent> = {}) =>
+  a.keys.onKeyDown({
+    key: k,
+    ctrlKey: false,
+    metaKey: false,
+    altKey: false,
+    shiftKey: false,
+    code: "",
+    preventDefault: () => {},
+    ...mods,
+  } as KeyboardEvent);
+
+const expectCaretInBounds = (a: Annotator) => {
+  expect(a.cursor.yLine).toBeGreaterThanOrEqual(0);
+  expect(a.cursor.yLine).toBeLessThanOrEqual(a.text.noLines - 1);
+  const lineLen = (a.text.getLine(a.cursor.yLine) ?? "").length;
+  expect(a.cursor.xLine).toBeGreaterThanOrEqual(0);
+  expect(a.cursor.xLine).toBeLessThanOrEqual(lineLen);
+  const off = a.text.offsetFromVisual(a.cursor.xLine, a.cursor.yLine);
+  expect(off).toBeGreaterThanOrEqual(0);
+  expect(off).toBeLessThanOrEqual(a.text.value.length);
+};
+
+describe("Enter keeps the caret in bounds when the split re-wraps", () => {
+  test("Enter mid last visual line of a wrapped segment", () => {
+    // Reproduces caretBoundsFuzz wrapped/seed=7 (the prefix loses a visual line).
+    const a = mk(
+      "s\nupercalifragilisticexpialidocious word twoaZ",
+      EditMode.RAW,
+      10
+    );
+    a.cursor.setPosition(1, 5); // inside "twoaZ", the last visual line
+    key(a, "Enter");
+    expectCaretInBounds(a);
+    // newline was inserted at raw offset of the pre-Enter caret; caret follows it.
+    expect(a.text.value).toContain("\n");
+  });
+});
+
+describe("typing collapses any stale selection (keeps selection in bounds)", () => {
+  test("a collapsed selection is cleared when a character is typed", () => {
+    const a = mk("hello world", EditMode.RAW, 100);
+    a.cursor.setPosition(5, 0);
+    a.cursor.selectStart = { xLine: 5, yLine: 0 };
+    a.cursor.selectEnd = { xLine: 5, yLine: 0 }; // stale degenerate selection
+    key(a, "x");
+    expect(a.cursor.selectStart).toBeUndefined();
+    expect(a.cursor.selectEnd).toBeUndefined();
+    expect(a.text.value).toBe("helloxx world".replace("xx", "x")); // "hellox world"
+    expectCaretInBounds(a);
+  });
+
+  test("typing near a wrap boundary with a stale selection stays in bounds", () => {
+    // Reproduces caretBoundsFuzz wrapped/seed=1337 shape: collapsed selection at
+    // an EOL that shrinks after the insert re-wraps.
+    const a = mk("supercalifragilistic word two", EditMode.RAW, 10);
+    a.cursor.setPosition(10, 0); // end of first wrapped visual line
+    a.cursor.selectStart = { xLine: 10, yLine: 0 };
+    a.cursor.selectEnd = { xLine: 10, yLine: 0 };
+    key(a, "Z");
+    expect(a.cursor.selectStart).toBeUndefined();
+    expect(a.cursor.selectEnd).toBeUndefined();
+    expectCaretInBounds(a);
+  });
+});
+
+describe("offset positioning preserves normal typing behavior", () => {
+  test("typing mid-line inserts and advances the caret", () => {
+    const a = mk("abc", EditMode.RAW, 100);
+    a.cursor.setPosition(1, 0);
+    key(a, "X");
+    expect(a.text.value).toBe("aXbc");
+    expect({ x: a.cursor.xLine, y: a.cursor.yLine }).toEqual({ x: 2, y: 0 });
+  });
+
+  test("Enter mid-line splits and moves to the new line start", () => {
+    const a = mk("abcd", EditMode.RAW, 100);
+    a.cursor.setPosition(2, 0);
+    key(a, "Enter");
+    expect(a.text.value).toBe("ab\ncd");
+    expect({ x: a.cursor.xLine, y: a.cursor.yLine }).toEqual({ x: 0, y: 1 });
+  });
+});

--- a/packages/annotator/src/caretBoundsFuzz.test.ts
+++ b/packages/annotator/src/caretBoundsFuzz.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Phase 3 pivot — caret always-in-bounds invariant (fuzz).
+ *
+ * The recurring class of bugs (#1/#3/#4) was the caret drifting out of bounds via
+ * the visual clamp/wrap/repair dance. This fuzzes long sequences of real key
+ * events from several starting documents and asserts, after EVERY key, that the
+ * caret is a valid position:
+ *   - yLine in [0, noLines-1]
+ *   - xLine in [0, current visual line length]
+ *   - the visual caret maps to a raw offset in [0, value.length]
+ *   - selection endpoints (if any) are likewise valid
+ *
+ * Seeded PRNG ⇒ reproducible. If this ever fails, the seed + step pinpoint it.
+ */
+import { Annotator } from "./lib/Annotator";
+import { EditMode } from "./lib/constants";
+
+const mk = (text: string, mode: EditMode, charsAtLine: number): Annotator => {
+  const c = document.createElement("canvas");
+  c.style.width = "800px";
+  c.style.height = "600px";
+  document.body.appendChild(c);
+  const a = new Annotator(c, text);
+  a.setMode(mode);
+  a.text.updateCharsAtLine(charsAtLine);
+  return a;
+};
+
+// Mulberry32 — tiny deterministic PRNG.
+const prng = (seed: number) => () => {
+  seed |= 0;
+  seed = (seed + 0x6d2b79f5) | 0;
+  let t = Math.imul(seed ^ (seed >>> 15), 1 | seed);
+  t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+  return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+};
+
+type KeySpec = { key: string; mods?: Partial<KeyboardEvent> };
+const KEYS: KeySpec[] = [
+  { key: "ArrowLeft" },
+  { key: "ArrowRight" },
+  { key: "ArrowUp" },
+  { key: "ArrowDown" },
+  { key: "ArrowLeft", mods: { shiftKey: true } },
+  { key: "ArrowRight", mods: { shiftKey: true } },
+  { key: "ArrowUp", mods: { shiftKey: true } },
+  { key: "ArrowDown", mods: { shiftKey: true } },
+  { key: "ArrowLeft", mods: { ctrlKey: true } },
+  { key: "ArrowRight", mods: { ctrlKey: true } },
+  { key: "Home" },
+  { key: "End" },
+  { key: "Home", mods: { ctrlKey: true } },
+  { key: "End", mods: { ctrlKey: true } },
+  { key: "a" },
+  { key: "Z" },
+  { key: " " },
+  { key: "Backspace" },
+  { key: "Delete" },
+  { key: "Enter" },
+];
+
+const sendKey = (a: Annotator, spec: KeySpec) =>
+  a.keys.onKeyDown({
+    key: spec.key,
+    ctrlKey: false,
+    metaKey: false,
+    altKey: false,
+    shiftKey: false,
+    code: "",
+    preventDefault: () => {},
+    ...spec.mods,
+  } as KeyboardEvent);
+
+const assertPointInBounds = (a: Annotator, x: number, y: number, ctx: string) => {
+  expect(`${ctx} yLine=${y}`).toBe(
+    `${ctx} yLine=${Math.max(0, Math.min(y, a.text.noLines - 1)) === y ? y : "OOB"}`
+  );
+  const lineLen = (a.text.getLine(y) ?? "").length;
+  expect(`${ctx} xLine=${x} (lineLen=${lineLen})`).toBe(
+    `${ctx} xLine=${x >= 0 && x <= lineLen ? x : "OOB"} (lineLen=${lineLen})`
+  );
+  const off = a.text.offsetFromVisual(x, y);
+  expect(`${ctx} offset=${off}`).toBe(
+    `${ctx} offset=${off >= 0 && off <= a.text.value.length ? off : "OOB"}`
+  );
+};
+
+const DOCS: Array<{ name: string; text: string; mode: EditMode; w: number }> = [
+  { name: "short-multiline", text: "abcde\nfghij\nklmno", mode: EditMode.RAW, w: 100 },
+  { name: "wrapped", text: "supercalifragilisticexpialidocious word two", mode: EditMode.RAW, w: 10 },
+  { name: "empty", text: "", mode: EditMode.RAW, w: 100 },
+  { name: "single", text: "x", mode: EditMode.RAW, w: 100 },
+  { name: "highlight-tags", text: "ab<x>hello</x>cd\nmore text here", mode: EditMode.HIGHLIGHT, w: 100 },
+];
+
+describe("caret stays in bounds under fuzzed key sequences", () => {
+  for (const doc of DOCS) {
+    for (const seed of [1, 7, 42, 1337]) {
+      test(`${doc.name} seed=${seed}`, () => {
+        const a = mk(doc.text, doc.mode, doc.w);
+        a.cursor.setPosition(0, 0);
+        const rand = prng(seed);
+        for (let step = 0; step < 200; step++) {
+          const spec = KEYS[Math.floor(rand() * KEYS.length)];
+          sendKey(a, spec);
+          const ctx = `${doc.name} seed=${seed} step=${step} key=${spec.key}`;
+          assertPointInBounds(a, a.cursor.xLine, a.cursor.yLine, ctx);
+          if (a.cursor.selectStart) {
+            assertPointInBounds(
+              a,
+              a.cursor.selectStart.xLine,
+              a.cursor.selectStart.yLine,
+              `${ctx} selStart`
+            );
+          }
+          if (a.cursor.selectEnd) {
+            assertPointInBounds(
+              a,
+              a.cursor.selectEnd.xLine,
+              a.cursor.selectEnd.yLine,
+              `${ctx} selEnd`
+            );
+          }
+        }
+      });
+    }
+  }
+});

--- a/packages/annotator/src/caretBoundsFuzz.test.ts
+++ b/packages/annotator/src/caretBoundsFuzz.test.ts
@@ -121,6 +121,15 @@ describe("caret stays in bounds under fuzzed key sequences", () => {
               `${ctx} selEnd`
             );
           }
+          // Canonical-offset invariant: head tracks the visual caret after any key.
+          const expectedHead = a.text.offsetFromVisual(
+            a.cursor.xLine,
+            a.cursor.yLine
+          );
+          expect({ ctx, head: a.cursor.head }).toEqual({
+            ctx,
+            head: expectedHead,
+          });
         }
       });
     }

--- a/packages/annotator/src/caretMouseOffset.test.ts
+++ b/packages/annotator/src/caretMouseOffset.test.ts
@@ -1,0 +1,35 @@
+/**
+ * Phase 3 (Step B) — mouse interactions set the canonical document offset.
+ *
+ * Click/drag go through getBoundingClientRect (0-sized in jsdom, so positioning
+ * isn't meaningfully testable here); double-click uses offsetX and IS testable.
+ * It must set anchor = word start offset, head = word end offset.
+ */
+import { Annotator } from "./lib/Annotator";
+import { EditMode } from "./lib/constants";
+
+const mk = (text: string): Annotator => {
+  const c = document.createElement("canvas");
+  c.style.width = "800px";
+  c.style.height = "600px";
+  document.body.appendChild(c);
+  const a = new Annotator(c, text);
+  a.setMode(EditMode.RAW);
+  return a;
+};
+
+describe("double-click sets canonical anchor/head offsets", () => {
+  test("selecting a word stores its start/end as offsets", () => {
+    const a = mk("foo bar baz");
+    const col = 5; // inside "bar" (cols 4..7)
+    a.onMouseDoubleClick({
+      offsetX: col * (a.charWidth / a.ratio),
+      offsetY: 0.5 * (a.lineHeight / a.ratio),
+      preventDefault: () => {},
+    } as unknown as MouseEvent);
+    expect(a.cursor.selectStart).toEqual({ xLine: 4, yLine: 0 });
+    expect(a.cursor.selectEnd).toEqual({ xLine: 7, yLine: 0 });
+    expect(a.cursor.anchor).toBe(4); // word start
+    expect(a.cursor.head).toBe(7); // word end (caret)
+  });
+});

--- a/packages/annotator/src/characterization/editing.test.ts
+++ b/packages/annotator/src/characterization/editing.test.ts
@@ -1,0 +1,179 @@
+/**
+ * Characterization tests — Phase 2, Task 2.3 (editing).
+ *
+ * These lock the CURRENT editing behavior of the annotator as a safety net
+ * before the cursor-model refactor (see packages/annotator/BASIC_EDITOR_BACKLOG.md).
+ * They assert what the editor does today, not necessarily what is "ideal" — if a
+ * value looks wrong, that is a separate bug to file, not something to change here.
+ *
+ * Each case records the resulting `text.value` and caret `{x,y}`.
+ */
+import { Annotator } from "../lib/Annotator";
+import { EditMode } from "../lib/constants";
+
+const mk = (text: string, mode: EditMode = EditMode.RAW): Annotator => {
+  const c = document.createElement("canvas");
+  c.style.width = "800px";
+  c.style.height = "600px";
+  document.body.appendChild(c);
+  const a = new Annotator(c, text);
+  a.setMode(mode);
+  return a;
+};
+const key = (a: Annotator, k: string, mods: Partial<KeyboardEvent> = {}) =>
+  a.keys.onKeyDown({
+    key: k,
+    ctrlKey: false,
+    metaKey: false,
+    altKey: false,
+    shiftKey: false,
+    code: "",
+    preventDefault: () => {},
+    ...mods,
+  } as KeyboardEvent);
+const pos = (a: Annotator) => ({ x: a.cursor.xLine, y: a.cursor.yLine });
+const flush = () => new Promise((r) => setTimeout(r, 0));
+
+/** Select "bc" in a "abcde"-style doc starting from caret at (1,0). */
+const selectBC = (a: Annotator) => {
+  a.cursor.setPosition(1, 0);
+  key(a, "ArrowRight", { shiftKey: true });
+  key(a, "ArrowRight", { shiftKey: true });
+};
+
+describe("characterization: insert character", () => {
+  test("typing inserts at the caret and advances it", () => {
+    const a = mk("abc");
+    a.cursor.setPosition(1, 0);
+    key(a, "X");
+    expect(a.text.value).toBe("aXbc");
+    expect(pos(a)).toEqual({ x: 2, y: 0 });
+  });
+
+  test("typing with an active selection replaces it", () => {
+    const a = mk("abcde");
+    selectBC(a);
+    key(a, "X");
+    expect(a.text.value).toBe("aXde");
+    expect(pos(a)).toEqual({ x: 2, y: 0 });
+  });
+
+  test("typing in HIGHLIGHT mode does not change the document", () => {
+    const a = mk("abc", EditMode.HIGHLIGHT);
+    a.cursor.setPosition(1, 0);
+    key(a, "X");
+    expect(a.text.value).toBe("abc");
+    expect(pos(a)).toEqual({ x: 1, y: 0 });
+  });
+});
+
+describe("characterization: Backspace", () => {
+  test("Backspace mid-line deletes the char before the caret", () => {
+    const a = mk("abc");
+    a.cursor.setPosition(2, 0);
+    key(a, "Backspace");
+    expect(a.text.value).toBe("ac");
+    expect(pos(a)).toEqual({ x: 1, y: 0 });
+  });
+
+  test("Backspace at line start joins with the previous line", () => {
+    const a = mk("ab\ncd");
+    a.cursor.setPosition(0, 1);
+    key(a, "Backspace");
+    expect(a.text.value).toBe("abcd");
+    expect(pos(a)).toEqual({ x: 2, y: 0 });
+  });
+
+  test("Backspace with a selection deletes the selection", () => {
+    const a = mk("abcde");
+    selectBC(a);
+    key(a, "Backspace");
+    expect(a.text.value).toBe("ade");
+    expect(pos(a)).toEqual({ x: 1, y: 0 });
+  });
+});
+
+describe("characterization: Delete", () => {
+  test("Delete mid-line deletes the char after the caret", () => {
+    const a = mk("abc");
+    a.cursor.setPosition(1, 0);
+    key(a, "Delete");
+    expect(a.text.value).toBe("ac");
+    expect(pos(a)).toEqual({ x: 1, y: 0 });
+  });
+
+  test("Delete at line end joins with the next line", () => {
+    const a = mk("ab\ncd");
+    a.cursor.setPosition(2, 0);
+    key(a, "Delete");
+    expect(a.text.value).toBe("abcd");
+    expect(pos(a)).toEqual({ x: 2, y: 0 });
+  });
+});
+
+describe("characterization: Enter", () => {
+  test("Enter splits the line at the caret", () => {
+    const a = mk("abcd");
+    a.cursor.setPosition(2, 0);
+    key(a, "Enter");
+    expect(a.text.value).toBe("ab\ncd");
+    expect(pos(a)).toEqual({ x: 0, y: 1 });
+  });
+
+  test("Enter with a selection replaces it then splits", () => {
+    const a = mk("abcde");
+    selectBC(a);
+    key(a, "Enter");
+    expect(a.text.value).toBe("a\nde");
+    expect(pos(a)).toEqual({ x: 0, y: 1 });
+  });
+});
+
+describe("characterization: paste", () => {
+  test("paste with no selection inserts at the caret", async () => {
+    const a = mk("abc");
+    a.cursor.setPosition(1, 0);
+    (window.navigator.clipboard as any) = {
+      readText: () => Promise.resolve("XY"),
+      writeText: () => Promise.resolve(),
+    };
+    a.onPasteText();
+    await flush();
+    expect(a.text.value).toBe("aXYbc");
+    expect(pos(a)).toEqual({ x: 3, y: 0 });
+  });
+
+  test("paste with a selection replaces it", async () => {
+    const a = mk("abcde");
+    selectBC(a);
+    (window.navigator.clipboard as any) = {
+      readText: () => Promise.resolve("ZZ"),
+      writeText: () => Promise.resolve(),
+    };
+    a.onPasteText();
+    await flush();
+    expect(a.text.value).toBe("aZZde");
+    expect(pos(a)).toEqual({ x: 3, y: 0 });
+  });
+});
+
+describe("characterization: cut (Ctrl+X)", () => {
+  test("cut removes the selection and writes it to the clipboard", () => {
+    const a = mk("abcde");
+    let written = "NONE";
+    (window.navigator.clipboard as any) = {
+      readText: () => Promise.resolve(""),
+      writeText: (t: string) => {
+        written = t;
+        return Promise.resolve();
+      },
+    };
+    a.onSelectText(() => {}); // wire up lastSelectedText tracking
+    selectBC(a);
+    a.draw(); // populates lastSelectedText from the current selection
+    key(a, "x", { ctrlKey: true });
+    expect(a.text.value).toBe("ade");
+    expect(pos(a)).toEqual({ x: 1, y: 0 });
+    expect(written).toBe("bc");
+  });
+});

--- a/packages/annotator/src/characterization/highlight-navigation.test.ts
+++ b/packages/annotator/src/characterization/highlight-navigation.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Characterization — HIGHLIGHT-mode caret navigation across hidden tag markup.
+ *
+ * Locks the CURRENT behavior before the full offset-model migration replaces the
+ * legacy visual nav path. In HIGHLIGHT the caret moves by VISIBLE (parsed)
+ * column; the underlying raw offset jumps over hidden `<tag>` markup. The
+ * migration must preserve exactly these visible movements.
+ */
+import { Annotator } from "../lib/Annotator";
+import { EditMode } from "../lib/constants";
+
+const mk = (text: string, w = 100): Annotator => {
+  const c = document.createElement("canvas");
+  c.style.width = "800px";
+  c.style.height = "600px";
+  document.body.appendChild(c);
+  const a = new Annotator(c, text);
+  a.setMode(EditMode.HIGHLIGHT);
+  a.text.updateCharsAtLine(w);
+  return a;
+};
+const key = (a: Annotator, k: string, mods: Partial<KeyboardEvent> = {}) =>
+  a.keys.onKeyDown({
+    key: k,
+    ctrlKey: false,
+    metaKey: false,
+    altKey: false,
+    shiftKey: false,
+    code: "",
+    preventDefault: () => {},
+    ...mods,
+  } as KeyboardEvent);
+const pos = (a: Annotator) => ({ x: a.cursor.xLine, y: a.cursor.yLine });
+
+const TAGGED = "ab<x>hello</x>cd"; // parsed: "abhellocd" (9 visible chars)
+
+describe("characterization: HIGHLIGHT navigation over hidden markup", () => {
+  test("parsed line strips the tags", () => {
+    const a = mk(TAGGED);
+    expect(a.text.segments[0].lines).toEqual(["abhellocd"]);
+  });
+
+  test("ArrowRight advances one visible column at a time and stops at EOL", () => {
+    const a = mk(TAGGED);
+    a.cursor.setPosition(0, 0);
+    const seq: number[] = [];
+    for (let i = 0; i < 10; i++) {
+      seq.push(a.cursor.xLine);
+      key(a, "ArrowRight");
+    }
+    seq.push(a.cursor.xLine);
+    expect(seq).toEqual([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 9]);
+  });
+
+  test("ArrowLeft retreats one visible column at a time and stops at BOL", () => {
+    const a = mk(TAGGED);
+    a.cursor.setPosition(9, 0);
+    const seq: number[] = [];
+    for (let i = 0; i < 10; i++) {
+      seq.push(a.cursor.xLine);
+      key(a, "ArrowLeft");
+    }
+    seq.push(a.cursor.xLine);
+    expect(seq).toEqual([9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0]);
+  });
+
+  test("the visible caret column maps to a raw offset that skips markup", () => {
+    const a = mk(TAGGED);
+    // col 1 -> raw 1 (after "ab"=a..b? offset of 'b'), col 2 jumps over "<x>"
+    expect(a.text.offsetFromVisual(1, 0)).toBe(1);
+    expect(a.text.offsetFromVisual(2, 0)).toBe(5); // skipped "<x>"
+    expect(a.text.offsetFromVisual(6, 0)).toBe(9);
+    expect(a.text.offsetFromVisual(7, 0)).toBe(14); // skipped "</x>"
+  });
+
+  test("crossing a hard newline between segments", () => {
+    const a = mk("ab<x>hi</x>\ncd"); // parsed segments: "abhi", "cd"
+    expect(a.text.segments.map((s) => s.lines)).toEqual([["abhi"], ["cd"]]);
+    a.cursor.setPosition(4, 0); // end of "abhi"
+    key(a, "ArrowRight");
+    expect(pos(a)).toEqual({ x: 0, y: 1 });
+    key(a, "ArrowRight");
+    expect(pos(a)).toEqual({ x: 1, y: 1 });
+    a.cursor.setPosition(0, 1);
+    key(a, "ArrowLeft");
+    expect(pos(a)).toEqual({ x: 4, y: 0 });
+  });
+});

--- a/packages/annotator/src/characterization/navigation.test.ts
+++ b/packages/annotator/src/characterization/navigation.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Characterization tests — Phase 2, Task 2.1 (navigation).
+ *
+ * These lock the CURRENT caret-navigation behavior of the annotator as a safety
+ * net before the cursor-model refactor (see packages/annotator/BASIC_EDITOR_BACKLOG.md).
+ * They assert what the editor does today, not necessarily what is "ideal" — if a
+ * value looks wrong, that is a separate bug to file, not something to change here.
+ */
+import { Annotator } from "../lib/Annotator";
+import { EditMode } from "../lib/constants";
+
+const mk = (text: string, mode: EditMode = EditMode.RAW): Annotator => {
+  const c = document.createElement("canvas");
+  c.style.width = "800px";
+  c.style.height = "600px";
+  document.body.appendChild(c);
+  const a = new Annotator(c, text);
+  a.setMode(mode);
+  return a;
+};
+const key = (a: Annotator, k: string, mods: Partial<KeyboardEvent> = {}) =>
+  a.keys.onKeyDown({
+    key: k,
+    ctrlKey: false,
+    metaKey: false,
+    altKey: false,
+    shiftKey: false,
+    preventDefault: () => {},
+    ...mods,
+  } as KeyboardEvent);
+const pos = (a: Annotator) => ({ x: a.cursor.xLine, y: a.cursor.yLine });
+
+const DOC = "abcde\nfghij\nklmno"; // 3 lines, each 5 chars
+
+describe("characterization: ArrowLeft / ArrowRight", () => {
+  test("ArrowRight mid-line advances the column", () => {
+    const a = mk(DOC);
+    a.cursor.setPosition(2, 0);
+    key(a, "ArrowRight");
+    expect(pos(a)).toEqual({ x: 3, y: 0 });
+  });
+
+  test("ArrowRight at end of a non-last line goes to start of next line", () => {
+    const a = mk(DOC);
+    a.cursor.setPosition(5, 0);
+    key(a, "ArrowRight");
+    expect(pos(a)).toEqual({ x: 0, y: 1 });
+  });
+
+  test("ArrowRight at end of document stays put", () => {
+    const a = mk(DOC);
+    a.cursor.setPosition(5, 2);
+    key(a, "ArrowRight");
+    expect(pos(a)).toEqual({ x: 5, y: 2 });
+  });
+
+  test("ArrowLeft at start of a non-first line goes to end of previous line", () => {
+    const a = mk(DOC);
+    a.cursor.setPosition(0, 1);
+    key(a, "ArrowLeft");
+    expect(pos(a)).toEqual({ x: 5, y: 0 });
+  });
+
+  test("ArrowLeft at document start stays put", () => {
+    const a = mk(DOC);
+    a.cursor.setPosition(0, 0);
+    key(a, "ArrowLeft");
+    expect(pos(a)).toEqual({ x: 0, y: 0 });
+  });
+});
+
+describe("characterization: ArrowUp / ArrowDown", () => {
+  test("ArrowDown keeps the column", () => {
+    const a = mk(DOC);
+    a.cursor.setPosition(2, 0);
+    key(a, "ArrowDown");
+    expect(pos(a)).toEqual({ x: 2, y: 1 });
+  });
+
+  test("ArrowUp keeps the column", () => {
+    const a = mk(DOC);
+    a.cursor.setPosition(2, 1);
+    key(a, "ArrowUp");
+    expect(pos(a)).toEqual({ x: 2, y: 0 });
+  });
+});
+
+describe("characterization: Home / End", () => {
+  test("Home goes to column 0 of the current line", () => {
+    const a = mk(DOC);
+    a.cursor.setPosition(3, 1);
+    key(a, "Home");
+    expect(pos(a)).toEqual({ x: 0, y: 1 });
+  });
+
+  test("End goes to the end of the current line", () => {
+    const a = mk(DOC);
+    a.cursor.setPosition(3, 1);
+    key(a, "End");
+    expect(pos(a)).toEqual({ x: 5, y: 1 });
+  });
+
+  test("Ctrl+Home goes to document start", () => {
+    const a = mk(DOC);
+    a.cursor.setPosition(3, 1);
+    key(a, "Home", { ctrlKey: true });
+    expect(pos(a)).toEqual({ x: 0, y: 0 });
+  });
+
+  test("Ctrl+End goes to document end", () => {
+    const a = mk(DOC);
+    a.cursor.setPosition(3, 1);
+    key(a, "End", { ctrlKey: true });
+    expect(pos(a)).toEqual({ x: 5, y: 2 });
+  });
+});
+
+describe("characterization: Cmd document jumps", () => {
+  test("Cmd+Up goes to document start", () => {
+    const a = mk(DOC);
+    a.cursor.setPosition(3, 1);
+    key(a, "ArrowUp", { metaKey: true });
+    expect(pos(a)).toEqual({ x: 0, y: 0 });
+  });
+
+  test("Cmd+Down goes to document end", () => {
+    const a = mk(DOC);
+    a.cursor.setPosition(3, 1);
+    key(a, "ArrowDown", { metaKey: true });
+    expect(pos(a)).toEqual({ x: 5, y: 2 });
+  });
+});
+
+describe("characterization: word jump (Ctrl+Arrow)", () => {
+  test("Ctrl+ArrowRight lands at the end of the current word", () => {
+    const a = mk("foo bar baz");
+    a.cursor.setPosition(0, 0);
+    key(a, "ArrowRight", { ctrlKey: true });
+    expect(pos(a)).toEqual({ x: 3, y: 0 });
+  });
+
+  test("Ctrl+ArrowLeft lands at the start of the previous word", () => {
+    const a = mk("foo bar baz");
+    a.cursor.setPosition(7, 0); // the space before "baz"
+    key(a, "ArrowLeft", { ctrlKey: true });
+    expect(pos(a)).toEqual({ x: 4, y: 0 });
+  });
+});
+
+describe("characterization: HIGHLIGHT mode", () => {
+  test("ArrowRight advances the column in HIGHLIGHT mode", () => {
+    const a = mk(DOC, EditMode.HIGHLIGHT);
+    a.cursor.setPosition(2, 0);
+    key(a, "ArrowRight");
+    expect(pos(a)).toEqual({ x: 3, y: 0 });
+  });
+});

--- a/packages/annotator/src/characterization/selection-collapse.test.ts
+++ b/packages/annotator/src/characterization/selection-collapse.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Characterization — how a non-extending (no-shift) arrow collapses an active
+ * selection. Locks current behavior before the anchor/head selection migration.
+ *
+ * Horizontal arrows collapse to the NEAR EDGE without moving further; vertical
+ * arrows move from the caret (head) and just clear the selection.
+ */
+import { Annotator } from "../lib/Annotator";
+import { EditMode } from "../lib/constants";
+
+const mk = (text: string): Annotator => {
+  const c = document.createElement("canvas");
+  c.style.width = "800px";
+  c.style.height = "600px";
+  document.body.appendChild(c);
+  const a = new Annotator(c, text);
+  a.setMode(EditMode.RAW);
+  return a;
+};
+const key = (a: Annotator, k: string, mods: Partial<KeyboardEvent> = {}) =>
+  a.keys.onKeyDown({
+    key: k,
+    ctrlKey: false,
+    metaKey: false,
+    altKey: false,
+    shiftKey: false,
+    code: "",
+    preventDefault: () => {},
+    ...mods,
+  } as KeyboardEvent);
+const pos = (a: Annotator) => ({ x: a.cursor.xLine, y: a.cursor.yLine });
+
+const DOC = "abcde\nfghij\nklmno";
+
+const selectBCD = (a: Annotator) => {
+  a.cursor.setPosition(1, 0);
+  key(a, "ArrowRight", { shiftKey: true });
+  key(a, "ArrowRight", { shiftKey: true }); // selection (1,0)-(3,0)
+};
+
+describe("characterization: non-shift arrow collapses an active selection", () => {
+  test("ArrowRight collapses to the RIGHT edge without moving further", () => {
+    const a = mk(DOC);
+    selectBCD(a);
+    key(a, "ArrowRight");
+    expect(pos(a)).toEqual({ x: 3, y: 0 });
+    expect(a.cursor.getSelectedArea()).toBeNull();
+  });
+
+  test("ArrowLeft collapses to the LEFT edge without moving further", () => {
+    const a = mk(DOC);
+    selectBCD(a);
+    key(a, "ArrowLeft");
+    expect(pos(a)).toEqual({ x: 1, y: 0 });
+    expect(a.cursor.getSelectedArea()).toBeNull();
+  });
+
+  test("ArrowDown moves from the caret and clears the selection", () => {
+    const a = mk(DOC);
+    a.cursor.setPosition(1, 0);
+    key(a, "ArrowRight", { shiftKey: true }); // selection (1,0)-(2,0), caret (2,0)
+    key(a, "ArrowDown");
+    expect(pos(a)).toEqual({ x: 2, y: 1 });
+    expect(a.cursor.getSelectedArea()).toBeNull();
+  });
+
+  test("ArrowUp moves from the caret and clears the selection", () => {
+    const a = mk(DOC);
+    a.cursor.setPosition(1, 1);
+    key(a, "ArrowRight", { shiftKey: true }); // selection (1,1)-(2,1), caret (2,1)
+    key(a, "ArrowUp");
+    expect(pos(a)).toEqual({ x: 2, y: 0 });
+    expect(a.cursor.getSelectedArea()).toBeNull();
+  });
+});

--- a/packages/annotator/src/characterization/selection.test.ts
+++ b/packages/annotator/src/characterization/selection.test.ts
@@ -1,0 +1,234 @@
+/**
+ * Characterization tests — Phase 2, Task 2.2 (selection).
+ *
+ * These lock the CURRENT selection behavior of the annotator as a safety net
+ * before the cursor-model refactor (see packages/annotator/BASIC_EDITOR_BACKLOG.md).
+ * They assert what the editor does today, not necessarily what is "ideal" — if a
+ * value looks wrong, that is a separate bug to file, not something to change here.
+ *
+ * Each case records: the resulting caret, selectStart/selectEnd (raw, unordered),
+ * the document-ordered getSelectedArea(), and the extracted range text.
+ */
+import { Annotator } from "../lib/Annotator";
+import { DIRECTION } from "../lib/Cursor";
+import { EditMode } from "../lib/constants";
+
+const mk = (text: string, mode: EditMode = EditMode.RAW): Annotator => {
+  const c = document.createElement("canvas");
+  c.style.width = "800px";
+  c.style.height = "600px";
+  document.body.appendChild(c);
+  const a = new Annotator(c, text);
+  a.setMode(mode);
+  return a;
+};
+const key = (a: Annotator, k: string, mods: Partial<KeyboardEvent> = {}) =>
+  a.keys.onKeyDown({
+    key: k,
+    ctrlKey: false,
+    metaKey: false,
+    altKey: false,
+    shiftKey: false,
+    preventDefault: () => {},
+    ...mods,
+  } as KeyboardEvent);
+
+const pos = (a: Annotator) => ({ x: a.cursor.xLine, y: a.cursor.yLine });
+const selText = (a: Annotator): string | null => {
+  const [s, e] = a.cursor.getAbsBounds();
+  if (!s || !e) return null;
+  return a.text.getRangeText(s, e);
+};
+
+const DOC = "abcde\nfghij\nklmno"; // 3 lines, each 5 chars
+
+describe("characterization: Shift+Arrow horizontal extend/shrink", () => {
+  test("Shift+ArrowRight extends the selection forward by one char", () => {
+    const a = mk(DOC);
+    a.cursor.setPosition(1, 0);
+    key(a, "ArrowRight", { shiftKey: true });
+    expect(pos(a)).toEqual({ x: 2, y: 0 });
+    expect(a.cursor.selectStart).toEqual({ xLine: 1, yLine: 0 });
+    expect(a.cursor.selectEnd).toEqual({ xLine: 2, yLine: 0 });
+    expect(a.cursor.selectDirection).toBe(DIRECTION.FORWARD);
+    expect(selText(a)).toBe("b");
+  });
+
+  test("Shift+ArrowRight twice extends to two chars", () => {
+    const a = mk(DOC);
+    a.cursor.setPosition(1, 0);
+    key(a, "ArrowRight", { shiftKey: true });
+    key(a, "ArrowRight", { shiftKey: true });
+    expect(a.cursor.selectStart).toEqual({ xLine: 1, yLine: 0 });
+    expect(a.cursor.selectEnd).toEqual({ xLine: 3, yLine: 0 });
+    expect(selText(a)).toBe("bc");
+  });
+
+  test("Shift+ArrowLeft after extending right shrinks the selection", () => {
+    const a = mk(DOC);
+    a.cursor.setPosition(1, 0);
+    key(a, "ArrowRight", { shiftKey: true });
+    key(a, "ArrowRight", { shiftKey: true });
+    key(a, "ArrowLeft", { shiftKey: true });
+    expect(pos(a)).toEqual({ x: 2, y: 0 });
+    expect(a.cursor.selectStart).toEqual({ xLine: 1, yLine: 0 });
+    expect(a.cursor.selectEnd).toEqual({ xLine: 2, yLine: 0 });
+    expect(selText(a)).toBe("b");
+  });
+
+  test("Shift+ArrowLeft extends the selection backward", () => {
+    const a = mk(DOC);
+    a.cursor.setPosition(3, 0);
+    key(a, "ArrowLeft", { shiftKey: true });
+    expect(pos(a)).toEqual({ x: 2, y: 0 });
+    expect(a.cursor.selectStart).toEqual({ xLine: 3, yLine: 0 });
+    expect(a.cursor.selectEnd).toEqual({ xLine: 2, yLine: 0 });
+    expect(a.cursor.selectDirection).toBe(DIRECTION.BACKWARD);
+    expect(a.cursor.getSelectedArea()).toEqual([
+      { xLine: 2, yLine: 0 },
+      { xLine: 3, yLine: 0 },
+    ]);
+    expect(selText(a)).toBe("c");
+  });
+
+  test("crossing the anchor flips the selection direction", () => {
+    const a = mk(DOC);
+    a.cursor.setPosition(2, 0);
+    key(a, "ArrowRight", { shiftKey: true }); // forward to (3,0)
+    key(a, "ArrowLeft", { shiftKey: true }); // collapse back to (2,0)
+    key(a, "ArrowLeft", { shiftKey: true }); // now backward to (1,0)
+    expect(pos(a)).toEqual({ x: 1, y: 0 });
+    expect(a.cursor.selectStart).toEqual({ xLine: 2, yLine: 0 });
+    expect(a.cursor.selectEnd).toEqual({ xLine: 1, yLine: 0 });
+    expect(a.cursor.selectDirection).toBe(DIRECTION.BACKWARD);
+    expect(selText(a)).toBe("b");
+  });
+});
+
+describe("characterization: Shift+Arrow vertical extend/shrink", () => {
+  test("Shift+ArrowDown extends across the line break", () => {
+    const a = mk(DOC);
+    a.cursor.setPosition(2, 0);
+    key(a, "ArrowDown", { shiftKey: true });
+    expect(pos(a)).toEqual({ x: 2, y: 1 });
+    expect(a.cursor.selectStart).toEqual({ xLine: 2, yLine: 0 });
+    expect(a.cursor.selectEnd).toEqual({ xLine: 2, yLine: 1 });
+    expect(a.cursor.selectDirection).toBe(DIRECTION.FORWARD);
+    expect(selText(a)).toBe("cde\nfg");
+  });
+
+  test("Shift+ArrowUp extends backward across the line break", () => {
+    const a = mk(DOC);
+    a.cursor.setPosition(2, 1);
+    key(a, "ArrowUp", { shiftKey: true });
+    expect(pos(a)).toEqual({ x: 2, y: 0 });
+    expect(a.cursor.selectStart).toEqual({ xLine: 2, yLine: 1 });
+    expect(a.cursor.selectEnd).toEqual({ xLine: 2, yLine: 0 });
+    expect(a.cursor.selectDirection).toBe(DIRECTION.BACKWARD);
+    expect(a.cursor.getSelectedArea()).toEqual([
+      { xLine: 2, yLine: 0 },
+      { xLine: 2, yLine: 1 },
+    ]);
+    expect(selText(a)).toBe("cde\nfg");
+  });
+
+  test("Shift+ArrowUp shrinks a downward selection back one line", () => {
+    const a = mk(DOC);
+    a.cursor.setPosition(2, 0);
+    key(a, "ArrowDown", { shiftKey: true });
+    key(a, "ArrowDown", { shiftKey: true });
+    key(a, "ArrowUp", { shiftKey: true });
+    expect(pos(a)).toEqual({ x: 2, y: 1 });
+    expect(a.cursor.selectStart).toEqual({ xLine: 2, yLine: 0 });
+    expect(a.cursor.selectEnd).toEqual({ xLine: 2, yLine: 1 });
+    expect(selText(a)).toBe("cde\nfg");
+  });
+});
+
+describe("characterization: Shift+Home / Shift+End", () => {
+  test("Shift+End selects from the caret to end of line", () => {
+    const a = mk(DOC);
+    a.cursor.setPosition(1, 1);
+    key(a, "End", { shiftKey: true });
+    expect(pos(a)).toEqual({ x: 5, y: 1 });
+    expect(a.cursor.selectStart).toEqual({ xLine: 1, yLine: 1 });
+    expect(a.cursor.selectEnd).toEqual({ xLine: 5, yLine: 1 });
+    expect(selText(a)).toBe("ghij");
+  });
+
+  test("Shift+Home selects from the caret back to start of line", () => {
+    const a = mk(DOC);
+    a.cursor.setPosition(3, 1);
+    key(a, "Home", { shiftKey: true });
+    expect(pos(a)).toEqual({ x: 0, y: 1 });
+    expect(a.cursor.selectStart).toEqual({ xLine: 3, yLine: 1 });
+    expect(a.cursor.selectEnd).toEqual({ xLine: 0, yLine: 1 });
+    expect(a.cursor.getSelectedArea()).toEqual([
+      { xLine: 0, yLine: 1 },
+      { xLine: 3, yLine: 1 },
+    ]);
+    expect(selText(a)).toBe("fgh");
+  });
+});
+
+describe("characterization: Cmd+Shift+Up / Cmd+Shift+Down", () => {
+  test("Cmd+Shift+Down selects from the caret to document end", () => {
+    const a = mk(DOC);
+    a.cursor.setPosition(2, 0);
+    key(a, "ArrowDown", { metaKey: true, shiftKey: true });
+    expect(pos(a)).toEqual({ x: 5, y: 2 });
+    expect(a.cursor.selectStart).toEqual({ xLine: 2, yLine: 0 });
+    expect(a.cursor.selectEnd).toEqual({ xLine: 5, yLine: 2 });
+    expect(selText(a)).toBe("cde\nfghij\nklmno");
+  });
+
+  test("Cmd+Shift+Up selects from the caret to document start", () => {
+    const a = mk(DOC);
+    a.cursor.setPosition(2, 2);
+    key(a, "ArrowUp", { metaKey: true, shiftKey: true });
+    expect(pos(a)).toEqual({ x: 0, y: 0 });
+    expect(a.cursor.selectStart).toEqual({ xLine: 0, yLine: 0 });
+    expect(a.cursor.selectEnd).toEqual({ xLine: 2, yLine: 2 });
+    expect(selText(a)).toBe("abcde\nfghij\nkl");
+  });
+});
+
+describe("characterization: select-all (Ctrl+A)", () => {
+  test("Ctrl+A selects the whole document", () => {
+    const a = mk(DOC);
+    key(a, "a", { ctrlKey: true });
+    expect(a.cursor.selectStart).toEqual({ xLine: 0, yLine: 0 });
+    expect(a.cursor.selectEnd).toEqual({ xLine: 5, yLine: 2 });
+    expect(selText(a)).toBe("abcde\nfghij\nklmno");
+  });
+});
+
+describe("characterization: double-click word selection", () => {
+  test("double-click inside a word selects that word", () => {
+    const a = mk("foo bar baz");
+    // Click roughly in the middle of "bar" (chars 4..7). Map a char column to
+    // a canvas offsetX through the current charWidth/ratio.
+    const col = 5;
+    const evt = {
+      offsetX: col * (a.charWidth / a.ratio),
+      offsetY: 0.5 * (a.lineHeight / a.ratio),
+      preventDefault: () => {},
+    } as unknown as MouseEvent;
+    a.onMouseDoubleClick(evt);
+    expect(a.cursor.selectStart).toEqual({ xLine: 4, yLine: 0 });
+    expect(a.cursor.selectEnd).toEqual({ xLine: 7, yLine: 0 });
+    expect(a.cursor.selectDirection).toBe(DIRECTION.FORWARD);
+    expect(selText(a)).toBe("bar");
+  });
+});
+
+describe("characterization: selection in HIGHLIGHT mode", () => {
+  test("Shift+ArrowRight extends a selection in HIGHLIGHT mode", () => {
+    const a = mk(DOC, EditMode.HIGHLIGHT);
+    a.cursor.setPosition(1, 0);
+    key(a, "ArrowRight", { shiftKey: true });
+    expect(a.cursor.selectStart).toEqual({ xLine: 1, yLine: 0 });
+    expect(a.cursor.selectEnd).toEqual({ xLine: 2, yLine: 0 });
+    expect(selText(a)).toBe("b");
+  });
+});

--- a/packages/annotator/src/characterization/wrap-navigation.test.ts
+++ b/packages/annotator/src/characterization/wrap-navigation.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Characterization tests — Phase 2 gap fill / Phase 3 guard (wrap-boundary nav).
+ *
+ * Locks the CURRENT caret behavior at a soft-wrap boundary, where ONE document
+ * offset corresponds to TWO distinct, reachable visual caret positions:
+ *   - end of the wrapped visual line   e.g. (10,0)
+ *   - start of the next visual line    e.g. (0,1)
+ * i.e. the editor today preserves caret *affinity* across a soft wrap.
+ *
+ * This is the behavior any offset-model migration (Phase 3.2/3.3) must either
+ * preserve (with an affinity bit) or deliberately change — these tests make the
+ * choice explicit instead of silent. They assert what the editor does today.
+ */
+import { Annotator } from "../lib/Annotator";
+import { EditMode } from "../lib/constants";
+
+const mk = (text: string, mode: EditMode = EditMode.RAW): Annotator => {
+  const c = document.createElement("canvas");
+  c.style.width = "800px";
+  c.style.height = "600px";
+  document.body.appendChild(c);
+  const a = new Annotator(c, text);
+  a.setMode(mode);
+  a.text.updateCharsAtLine(10); // force a soft wrap at column 10
+  return a;
+};
+const key = (a: Annotator, k: string, mods: Partial<KeyboardEvent> = {}) =>
+  a.keys.onKeyDown({
+    key: k,
+    ctrlKey: false,
+    metaKey: false,
+    altKey: false,
+    shiftKey: false,
+    code: "",
+    preventDefault: () => {},
+    ...mods,
+  } as KeyboardEvent);
+const pos = (a: Annotator) => ({ x: a.cursor.xLine, y: a.cursor.yLine });
+
+// "supercalifragilistic" wraps to ["supercalif", "ragilistic"] at width 10.
+const WRAPPED = "supercalifragilistic";
+
+describe("characterization: caret affinity at a soft-wrap boundary", () => {
+  test("the wrapped doc has two visual lines of 10", () => {
+    const a = mk(WRAPPED);
+    expect(a.text.segments[0].lines).toEqual(["supercalif", "ragilistic"]);
+  });
+
+  test("ArrowLeft from start of the next line lands at end of the wrapped line", () => {
+    const a = mk(WRAPPED);
+    a.cursor.setPosition(0, 1);
+    key(a, "ArrowLeft");
+    expect(pos(a)).toEqual({ x: 10, y: 0 }); // end-of-line position is reachable
+  });
+
+  test("a second ArrowLeft then steps one real char back", () => {
+    const a = mk(WRAPPED);
+    a.cursor.setPosition(0, 1);
+    key(a, "ArrowLeft"); // (10,0)
+    key(a, "ArrowLeft"); // (9,0)
+    expect(pos(a)).toEqual({ x: 9, y: 0 });
+  });
+
+  test("ArrowRight from end of the wrapped line stops at the boundary first", () => {
+    const a = mk(WRAPPED);
+    a.cursor.setPosition(9, 0);
+    key(a, "ArrowRight");
+    expect(pos(a)).toEqual({ x: 10, y: 0 }); // pauses at end-of-line, not (0,1)
+  });
+
+  test("a second ArrowRight then moves to start of the next line", () => {
+    const a = mk(WRAPPED);
+    a.cursor.setPosition(9, 0);
+    key(a, "ArrowRight"); // (10,0)
+    key(a, "ArrowRight"); // (0,1)
+    expect(pos(a)).toEqual({ x: 0, y: 1 });
+  });
+
+  test("the end-of-wrapped-line position (10,0) is itself a valid caret position", () => {
+    const a = mk(WRAPPED);
+    a.cursor.setPosition(10, 0);
+    // it resolves to a real document position (raw index 10)...
+    const seg = a.text.cursorToIndex(a.viewport, a.cursor);
+    expect(seg).not.toBeNull();
+    expect(seg!.rawTextIndex).toBe(10);
+    // ...and ArrowLeft from it moves one real char back (not to (0,1)).
+    key(a, "ArrowLeft");
+    expect(pos(a)).toEqual({ x: 9, y: 0 });
+  });
+});

--- a/packages/annotator/src/characterization/wrapping-cursor.test.ts
+++ b/packages/annotator/src/characterization/wrapping-cursor.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Characterization tests — Phase 2, Task 2.4 (wrapping <-> cursor).
+ *
+ * These lock the CURRENT interaction between line wrapping and the
+ * visual<->document coordinate converters, plus tag-position queries, as a
+ * safety net before the cursor-model refactor (see
+ * packages/annotator/BASIC_EDITOR_BACKLOG.md). The Phase 3 offset model is built
+ * directly on these converters, so the round-trip guarantees captured here are
+ * the contract that refactor must preserve.
+ *
+ * They assert what the editor does today, not necessarily what is "ideal".
+ */
+import { Annotator } from "../lib/Annotator";
+import Text from "../lib/Text";
+import { EditMode } from "../lib/constants";
+
+const mk = (text: string, mode: EditMode = EditMode.RAW): Annotator => {
+  const c = document.createElement("canvas");
+  c.style.width = "800px";
+  c.style.height = "600px";
+  document.body.appendChild(c);
+  const a = new Annotator(c, text);
+  a.setMode(mode);
+  return a;
+};
+const key = (a: Annotator, k: string, mods: Partial<KeyboardEvent> = {}) =>
+  a.keys.onKeyDown({
+    key: k,
+    ctrlKey: false,
+    metaKey: false,
+    altKey: false,
+    shiftKey: false,
+    code: "",
+    preventDefault: () => {},
+    ...mods,
+  } as KeyboardEvent);
+
+// positionToCursor only reads viewport.lineStart; with 0 the visual yLine equals
+// the absolute line index.
+const vp = { lineStart: 0 } as any;
+
+describe("characterization: char-break wrapping", () => {
+  test("an over-long word is character-broken at the width", () => {
+    const t = new Text("supercalifragilistic", 10); // 20 chars, width 10
+    expect(t.segments[0].lines).toEqual(["supercalif", "ragilistic"]);
+    expect(t.noLines).toBe(2);
+  });
+
+  test("HIGHLIGHT mode strips tags before wrapping", () => {
+    const t = new Text("ab<x>hello</x>cd", 100);
+    t.mode = EditMode.HIGHLIGHT;
+    t.calculateLines();
+    expect(t.segments[0].lines).toEqual(["abhellocd"]);
+  });
+});
+
+describe("characterization: raw-offset round-trip", () => {
+  test("every raw offset round-trips across a wrapped single segment", () => {
+    const input = "supercalifragilistic"; // wrapped to 2 lines at width 10
+    const t = new Text(input, 10);
+    for (let i = 0; i <= input.length; i++) {
+      const pos = t.getSegmentFromAbsTextIndex(i);
+      expect(pos).not.toBeNull();
+      expect(t.getAbsTextIndexFromPosition(pos)).toBe(i);
+    }
+  });
+
+  test("every raw offset round-trips across a wrapped multi-segment doc", () => {
+    const input = "supercalifragilistic\nanotherlongword";
+    const t = new Text(input, 10);
+    // 2 segments, each char-broken into 2 visual lines.
+    expect(t.noLines).toBe(4);
+    expect(t.segments.map((s) => s.lines)).toEqual([
+      ["supercalif", "ragilistic"],
+      ["anotherlon", "gword"],
+    ]);
+    for (let i = 0; i <= input.length; i++) {
+      const pos = t.getSegmentFromAbsTextIndex(i);
+      expect(pos).not.toBeNull();
+      expect(t.getAbsTextIndexFromPosition(pos)).toBe(i);
+    }
+  });
+
+  test("every raw offset round-trips in HIGHLIGHT mode with tags", () => {
+    const input = "ab<x>hello</x>cd";
+    const t = new Text(input, 100);
+    t.mode = EditMode.HIGHLIGHT;
+    t.calculateLines();
+    for (let i = 0; i <= input.length; i++) {
+      const pos = t.getSegmentFromAbsTextIndex(i);
+      expect(pos).not.toBeNull();
+      expect(t.getAbsTextIndexFromPosition(pos)).toBe(i);
+    }
+  });
+});
+
+describe("characterization: visual-position round-trip", () => {
+  test("every visual (line,col) round-trips across a wrapped segment", () => {
+    const input = "supercalifragilistic";
+    const t = new Text(input, 10);
+    for (let y = 0; y < t.noLines; y++) {
+      const lineLen = t.segments[0].lines[y].length;
+      for (let x = 0; x <= lineLen; x++) {
+        const pos = t.getSegmentPosition(y, x);
+        expect(pos).not.toBeNull();
+        const cur = t.positionToCursor(vp, pos!);
+        expect(cur).toEqual({ xLine: x, yLine: y });
+      }
+    }
+  });
+});
+
+describe("characterization: getTagPosition", () => {
+  test("returns the parsed tag bounds, identical in RAW and HIGHLIGHT", () => {
+    const input = "ab<x>hello</x>cd";
+
+    const tRaw = new Text(input, 100);
+    tRaw.mode = EditMode.RAW;
+    tRaw.calculateLines();
+
+    const tHl = new Text(input, 100);
+    tHl.mode = EditMode.HIGHLIGHT;
+    tHl.calculateLines();
+
+    const expected = [
+      { xLine: 2, yLine: 0 },
+      { xLine: 7, yLine: 0 },
+    ];
+    expect(tRaw.getTagPosition("x")).toEqual(expected);
+    expect(tHl.getTagPosition("x")).toEqual(expected);
+  });
+
+  test("returns an empty array for an unmatched tag", () => {
+    const t = new Text("ab<x>hello</x>cd", 100);
+    expect(t.getTagPosition("nope")).toEqual([]);
+  });
+});
+
+describe("characterization: caret stays within width while a word grows", () => {
+  test("typing a word past the width char-breaks and keeps the caret in bounds", () => {
+    const a = mk("");
+    a.text.updateCharsAtLine(10);
+    for (const ch of "abcdefghijklmn") {
+      key(a, ch);
+      expect(a.cursor.xLine).toBeLessThanOrEqual(a.text.charsAtLine);
+    }
+    expect(a.text.value).toBe("abcdefghijklmn");
+    expect(a.text.segments[0].lines).toEqual(["abcdefghij", "klmn"]);
+    expect({ x: a.cursor.xLine, y: a.cursor.yLine }).toEqual({ x: 4, y: 1 });
+  });
+});

--- a/packages/annotator/src/cursorOffsetModel.test.ts
+++ b/packages/annotator/src/cursorOffsetModel.test.ts
@@ -1,0 +1,177 @@
+/**
+ * Phase 3, Task 3.1 — the document-offset cursor model (ADDITIVE).
+ *
+ * These prove the offset<->visual converters and Cursor's sync helpers in
+ * isolation, before navigation/editing are rewired onto them (Tasks 3.2+). The
+ * canonical round-trip is offset -> visual -> offset (the soft-wrap boundary
+ * means visual -> offset -> visual is intentionally NOT 1:1).
+ */
+import Text from "./lib/Text";
+import Cursor, { DIRECTION } from "./lib/Cursor";
+import { EditMode } from "./lib/constants";
+
+describe("Text.visualFromOffset / offsetFromVisual", () => {
+  test("offset round-trips through visual coords (unwrapped doc, RAW)", () => {
+    const input = "abcde\nfghij\nklmno";
+    const t = new Text(input, 100);
+    for (let off = 0; off <= input.length; off++) {
+      const v = t.visualFromOffset(off);
+      expect(v).not.toBeNull();
+      expect(t.offsetFromVisual(v!.xLine, v!.yLine)).toBe(off);
+    }
+  });
+
+  test("offset round-trips across a wrapped multi-segment doc", () => {
+    const input = "supercalifragilistic\nanotherlongword";
+    const t = new Text(input, 10);
+    for (let off = 0; off <= input.length; off++) {
+      const v = t.visualFromOffset(off);
+      expect(v).not.toBeNull();
+      expect(t.offsetFromVisual(v!.xLine, v!.yLine)).toBe(off);
+    }
+  });
+
+  // Every VALID caret position round-trips visual -> offset -> visual. This is
+  // the invariant the offset model relies on (the cached visual state stays
+  // stable). NB: the reverse (every raw offset -> visual -> offset) is NOT 1:1
+  // in HIGHLIGHT — raw offsets inside hidden tag markup are not caret positions
+  // and snap to a visible boundary instead (characterized below).
+  test.each([
+    ["RAW", EditMode.RAW],
+    ["HIGHLIGHT", EditMode.HIGHLIGHT],
+  ])("every caret position round-trips visual->offset->visual (%s)", (_n, mode) => {
+    const t = new Text("ab<x>hello</x>cd", 100);
+    t.mode = mode as EditMode;
+    t.calculateLines();
+    for (let y = 0; y < t.noLines; y++) {
+      const lineLen = t.segments[0].lines[y].length;
+      for (let x = 0; x <= lineLen; x++) {
+        const off = t.offsetFromVisual(x, y);
+        expect(off).toBeGreaterThanOrEqual(0);
+        expect(t.visualFromOffset(off)).toEqual({ xLine: x, yLine: y });
+      }
+    }
+  });
+
+  test("a raw offset inside hidden markup snaps to a non-negative column (HIGHLIGHT)", () => {
+    const t = new Text("ab<x>hello</x>cd", 100);
+    t.mode = EditMode.HIGHLIGHT;
+    t.calculateLines();
+    // offset 2 is the '<' of "<x>" — inside hidden markup, not a caret position.
+    const v = t.visualFromOffset(2);
+    expect(v).not.toBeNull();
+    expect(v!.xLine).toBeGreaterThanOrEqual(0);
+    expect(v!.yLine).toBe(0);
+  });
+
+  test("yLine is an ABSOLUTE line index (spans segments)", () => {
+    const t = new Text("abcde\nfghij\nklmno", 100);
+    expect(t.visualFromOffset(0)).toEqual({ xLine: 0, yLine: 0 });
+    expect(t.visualFromOffset(6)).toEqual({ xLine: 0, yLine: 1 }); // start of "fghij"
+    expect(t.visualFromOffset(12)).toEqual({ xLine: 0, yLine: 2 }); // start of "klmno"
+    expect(t.visualFromOffset(17)).toEqual({ xLine: 5, yLine: 2 }); // EOF
+  });
+
+  test("a soft-wrap boundary offset maps to the start of the next visual line", () => {
+    const t = new Text("supercalifragilistic", 10); // lines: 10 + 10
+    expect(t.visualFromOffset(10)).toEqual({ xLine: 0, yLine: 1 });
+    // ...and that visual position maps back to the same offset.
+    expect(t.offsetFromVisual(0, 1)).toBe(10);
+  });
+
+  test("offset is clamped into [0, value.length]", () => {
+    const t = new Text("abc", 100);
+    expect(t.visualFromOffset(-5)).toEqual({ xLine: 0, yLine: 0 });
+    expect(t.visualFromOffset(999)).toEqual({ xLine: 3, yLine: 0 });
+  });
+
+  test("offsetFromVisual returns -1 for an out-of-bounds line", () => {
+    const t = new Text("abc", 100);
+    expect(t.offsetFromVisual(0, 5)).toBe(-1);
+    expect(t.offsetFromVisual(0, -1)).toBe(-1);
+  });
+});
+
+describe("Cursor.syncVisualFromOffset", () => {
+  test("a collapsed caret derives xLine/yLine and clears the selection", () => {
+    const t = new Text("abcde\nfghij\nklmno", 100);
+    const c = new Cursor(1);
+    c.anchor = 8;
+    c.head = 8; // visual (2,1)
+    c.selectStart = { xLine: 0, yLine: 0 }; // stale, must be cleared
+    c.selectEnd = { xLine: 1, yLine: 0 };
+    c.syncVisualFromOffset(t);
+    expect({ x: c.xLine, y: c.yLine }).toEqual({ x: 2, y: 1 });
+    expect(c.selectStart).toBeUndefined();
+    expect(c.selectEnd).toBeUndefined();
+  });
+
+  test("a forward range derives ordered visual endpoints + direction", () => {
+    const t = new Text("abcde\nfghij\nklmno", 100);
+    const c = new Cursor(1);
+    c.anchor = 2; // visual (2,0)
+    c.head = 8; // visual (2,1)
+    c.syncVisualFromOffset(t);
+    expect({ x: c.xLine, y: c.yLine }).toEqual({ x: 2, y: 1 }); // caret at head
+    expect(c.selectStart).toEqual({ xLine: 2, yLine: 0 });
+    expect(c.selectEnd).toEqual({ xLine: 2, yLine: 1 });
+    expect(c.getSelectedArea()).toEqual([
+      { xLine: 2, yLine: 0 },
+      { xLine: 2, yLine: 1 },
+    ]);
+    expect(c.selectDirection).toBe(DIRECTION.FORWARD);
+    expect(t.getRangeText(c.getAbsBounds()[0]!, c.getAbsBounds()[1]!)).toBe(
+      "cde\nfg"
+    );
+  });
+
+  test("a backward range (head before anchor) reports BACKWARD direction", () => {
+    const t = new Text("abcde\nfghij\nklmno", 100);
+    const c = new Cursor(1);
+    c.anchor = 8; // visual (2,1)
+    c.head = 2; // visual (2,0)
+    c.syncVisualFromOffset(t);
+    expect({ x: c.xLine, y: c.yLine }).toEqual({ x: 2, y: 0 });
+    expect(c.selectDirection).toBe(DIRECTION.BACKWARD);
+    // getSelectedArea is document-ordered regardless of direction.
+    expect(c.getSelectedArea()).toEqual([
+      { xLine: 2, yLine: 0 },
+      { xLine: 2, yLine: 1 },
+    ]);
+  });
+});
+
+describe("Cursor.syncOffsetFromVisual", () => {
+  test("derives head and anchor from the current visual caret", () => {
+    const t = new Text("abcde\nfghij\nklmno", 100);
+    const c = new Cursor(1);
+    c.xLine = 2;
+    c.yLine = 1; // offset 8
+    c.syncOffsetFromVisual(t);
+    expect(c.head).toBe(8);
+    expect(c.anchor).toBe(8);
+  });
+
+  test("keepAnchor preserves the anchor (selection extension)", () => {
+    const t = new Text("abcde\nfghij\nklmno", 100);
+    const c = new Cursor(1);
+    c.anchor = 2;
+    c.xLine = 2;
+    c.yLine = 1; // offset 8
+    c.syncOffsetFromVisual(t, true);
+    expect(c.head).toBe(8);
+    expect(c.anchor).toBe(2);
+  });
+
+  test("offset -> visual -> offset is stable through the Cursor helpers", () => {
+    const t = new Text("supercalifragilistic\nanotherlongword", 10);
+    const c = new Cursor(1);
+    for (let off = 0; off <= t.value.length; off++) {
+      c.anchor = off;
+      c.head = off;
+      c.syncVisualFromOffset(t);
+      c.syncOffsetFromVisual(t);
+      expect(c.head).toBe(off);
+    }
+  });
+});

--- a/packages/annotator/src/history.test.ts
+++ b/packages/annotator/src/history.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Phase 4 (#3086) — undo/redo history. The History holds full document
+ * snapshots ({ value, anchor, head, affinities }) — trivial because the Phase 3
+ * offset model made the caret a pair of raw offsets. Coalescing merges only a
+ * contiguous run of single-character typing into one undo step; everything else
+ * is a discrete step.
+ */
+import History, { HistorySnapshot } from "./lib/History";
+import { CaretAffinity } from "./lib/Text";
+
+const snap = (value: string, head: number, anchor: number = head): HistorySnapshot => ({
+  value,
+  head,
+  anchor,
+  headAffinity: CaretAffinity.DOWNSTREAM,
+  anchorAffinity: CaretAffinity.DOWNSTREAM,
+});
+
+describe("History", () => {
+  test("undo returns the recorded before-state; redo returns the present", () => {
+    const h = new History();
+    // doc "" -> backspace-like discrete edit producing "a"
+    h.record(snap("", 0), false, 1);
+    const present = snap("a", 1);
+    expect(h.canUndo()).toBe(true);
+    const undone = h.undo(present);
+    expect(undone).toEqual(snap("", 0));
+    expect(h.canRedo()).toBe(true);
+    const redone = h.redo(snap("", 0));
+    expect(redone).toEqual(present);
+  });
+
+  test("a contiguous typing run collapses into a single undo entry", () => {
+    const h = new History();
+    h.record(snap("", 0), true, 1); // type 'a' (before="")
+    h.record(snap("a", 1), true, 2); // type 'b' (before="a", contiguous)
+    h.record(snap("ab", 2), true, 3); // type 'c' (before="ab", contiguous)
+    const present = snap("abc", 3);
+    expect(h.undo(present)).toEqual(snap("", 0)); // single step back to ""
+    expect(h.canUndo()).toBe(false);
+  });
+
+  test("a non-contiguous insert starts a new entry (caret jump breaks the run)", () => {
+    const h = new History();
+    h.record(snap("", 0), true, 1); // type 'a'
+    // caret jumped: next insert's before.head (5) != lastAfterHead (1)
+    h.record(snap("a    ", 5), true, 6);
+    const present = snap("a    x", 6);
+    expect(h.undo(present)).toEqual(snap("a    ", 5)); // undoes only the 2nd run
+    expect(h.canUndo()).toBe(true);
+    expect(h.undo(snap("a    ", 5))).toEqual(snap("", 0));
+  });
+
+  test("a non-coalesce op after a typing run is its own entry", () => {
+    const h = new History();
+    h.record(snap("", 0), true, 1); // type 'a'
+    h.record(snap("a", 1), false, 0); // backspace (discrete)
+    const present = snap("", 0);
+    expect(h.undo(present)).toEqual(snap("a", 1)); // undo the delete
+    expect(h.undo(snap("a", 1))).toEqual(snap("", 0)); // undo the typing
+  });
+
+  test("a new edit after undo clears the redo stack", () => {
+    const h = new History();
+    h.record(snap("", 0), false, 1);
+    h.undo(snap("a", 1));
+    expect(h.canRedo()).toBe(true);
+    h.record(snap("", 0), false, 1); // fresh edit invalidates redo
+    expect(h.canRedo()).toBe(false);
+  });
+
+  test("the stack is bounded — oldest entries drop past maxSize", () => {
+    const h = new History(2);
+    h.record(snap("1", 0), false, 0);
+    h.record(snap("2", 0), false, 0);
+    h.record(snap("3", 0), false, 0); // drops "1"
+    expect(h.undo(snap("p", 0))).toEqual(snap("3", 0));
+    expect(h.undo(snap("3", 0))).toEqual(snap("2", 0));
+    expect(h.canUndo()).toBe(false); // "1" was dropped
+  });
+
+  test("undo/redo on an empty stack are no-ops returning null", () => {
+    const h = new History();
+    expect(h.canUndo()).toBe(false);
+    expect(h.undo(snap("a", 1))).toBeNull();
+    expect(h.canRedo()).toBe(false);
+    expect(h.redo(snap("a", 1))).toBeNull();
+  });
+
+  test("undo resets coalescing so a following typing op does not merge", () => {
+    const h = new History();
+    h.record(snap("", 0), true, 1); // type 'a' -> "a"
+    h.undo(snap("a", 1)); // back to ""
+    // redo path not taken; user types again from "" — must be a new entry,
+    // not merged onto the (now redo-side) run.
+    h.record(snap("", 0), true, 1);
+    expect(h.canRedo()).toBe(false); // recording cleared redo
+    expect(h.undo(snap("a", 1))).toEqual(snap("", 0));
+  });
+});

--- a/packages/annotator/src/lib/Annotator.ts
+++ b/packages/annotator/src/lib/Annotator.ts
@@ -1,6 +1,8 @@
 import Cursor, { DIRECTION } from "./Cursor";
 import Highlighter, { IAbsCoordinates, CursorStyle } from "./Highlighter";
 import History, { HistorySnapshot } from "./History";
+import { ContextMenu, ContextMenuItem } from "./ContextMenu";
+import { SettingsOverlay } from "./SettingsOverlay";
 import Keys from "./Keys";
 import { Lines } from "./Lines";
 import Scroller from "./Scroller";
@@ -56,12 +58,22 @@ export interface HighlightSchema {
   };
 }
 
+/** localStorage key for persisted user settings (caret width, colors, FPS). */
+const SETTINGS_STORAGE_KEY = "inkvisitor.annotator.settings";
+
+interface PersistedSettings {
+  caretWidth?: number;
+  highlightColor?: string;
+  showFps?: boolean;
+}
+
 // DrawingOptions bundles required sizes shared by multiple components while drawing into canvas
 export interface DrawingOptions {
   charWidth: number;
   lineHeight: number;
   charsAtLine: number;
   color?: string; // override
+  caretWidth?: number; // collapsed-caret width in device px (defaults to 1)
 }
 
 export interface Selected {
@@ -105,6 +117,8 @@ export class Annotator {
   lines?: Lines;
   keys: Keys;
   warnings: Warnings;
+  contextMenu: ContextMenu = new ContextMenu();
+  settingsOverlay: SettingsOverlay = new SettingsOverlay();
 
   /** Phase 4 (#3086) — bounded undo/redo stack of document snapshots. */
   history: History = new History();
@@ -120,6 +134,20 @@ export class Annotator {
   private lastSelectPointer: { cx: number; cy: number } | null = null;
 
   private selectionScrollRaf: number = 0;
+
+  /** Collapsed-caret width in CSS px (scaled by ratio at draw time). */
+  private caretWidth = 1;
+
+  /**
+   * User-chosen selection highlight color (`#rrggbb`), or undefined to defer to
+   * the host theme set via setSelectStyle. When set it wins over the theme.
+   */
+  private highlightColor: string | undefined = undefined;
+
+  /** Debug FPS counter — smoothed frames-per-second of draw() calls. */
+  private showFps = false;
+  private lastFrameTime = 0;
+  private fps = 0;
 
   // callbacks
   onSelectTextCb?: (text: Selected) => void;
@@ -137,6 +165,9 @@ export class Annotator {
   hoverDebounceTimeout?: NodeJS.Timeout; // For debouncing mousemove events
 
   private readonly boundOnMouseMove = (e: MouseEvent) => this.onMouseMove(e);
+
+  private readonly boundOnContextMenu = (e: MouseEvent) =>
+    this.onContextMenu(e);
 
   private readonly boundOnCanvasMouseLeave = () => {
     if (this.hoverDebounceTimeout) {
@@ -210,10 +241,13 @@ export class Annotator {
     );
     this.element.addEventListener("mousemove", this.boundOnMouseMove);
     this.element.addEventListener("mouseleave", this.boundOnCanvasMouseLeave);
+    this.element.addEventListener("contextmenu", this.boundOnContextMenu);
 
     this.clickCount = 0;
 
     this.previousRenderViewportLineStart = 0;
+
+    this.loadSettings();
 
     this.draw();
 
@@ -236,6 +270,14 @@ export class Annotator {
       opacity: this.selectOpacity,
       selectorColor: selectorColor,
     } as CursorStyle;
+
+    // A user-chosen highlight color (persisted) takes precedence over the theme.
+    if (this.highlightColor !== undefined) {
+      this.cursor.style = {
+        ...this.cursor.style,
+        color: this.highlightColor,
+      };
+    }
   }
 
   /**
@@ -1098,6 +1140,64 @@ export class Annotator {
   }
 
   /**
+   * onContextMenu opens the right-click context menu at the pointer.
+   * TODO (#3086): wire real actions / let the host supply items via a callback.
+   * For now these are placeholder entries.
+   * @param e
+   */
+  onContextMenu(e: MouseEvent) {
+    e.preventDefault();
+    this.contextMenu.open(e.clientX, e.clientY, this.buildContextMenuItems());
+  }
+
+  /** Context-menu entries. For now just a toggle for the debug FPS counter. */
+  private buildContextMenuItems(): ContextMenuItem[] {
+    return [
+      {
+        label: `${this.showFps ? "✓ " : ""}Show FPS counter`,
+        onClick: () => this.setShowFps(!this.showFps),
+      },
+      { separator: true },
+      { label: "Options…", onClick: () => this.openSettings() },
+    ];
+  }
+
+  /** Open the settings overlay with the current options. */
+  private openSettings(): void {
+    this.settingsOverlay.open(
+      [
+        {
+          type: "segmented",
+          label: "Cursor size",
+          options: [
+            { label: "1px", value: 1 },
+            { label: "2px", value: 2 },
+            { label: "3px", value: 3 },
+          ],
+          value: this.caretWidth,
+          onChange: (px) => this.setCaretWidth(px),
+        },
+        {
+          type: "color",
+          label: "Highlight color",
+          value: this.getHighlightColor(),
+          onChange: (hex) => this.setHighlightColor(hex),
+        },
+      ],
+      this.element,
+      [
+        {
+          label: "Reset to defaults",
+          onClick: () => {
+            this.resetSettings();
+            this.openSettings(); // re-render so controls show the defaults
+          },
+        },
+      ]
+    );
+  }
+
+  /**
    * onWheel is handler for mouse-wheel-event. Uses fluent scroll: accumulates deltaY
    * so text and line numbers scroll smoothly together.
    * @param e
@@ -1446,6 +1546,10 @@ export class Annotator {
    * TODO - this should be done in conjunction with requestAnimationFrame
    */
   draw() {
+    if (this.showFps) {
+      this.updateFps();
+    }
+
     this.syncLineNumbersCanvasToMain();
 
     this.ctx.reset();
@@ -1484,6 +1588,7 @@ export class Annotator {
         lineHeight: this.lineHeight,
         charWidth: this.charWidth,
         charsAtLine: this.text.charsAtLine,
+        caretWidth: this.caretWidth * this.ratio,
       });
     }
 
@@ -1622,6 +1727,182 @@ export class Annotator {
       this.onScrollCb?.(thisRenderVieportLineStart);
       this.previousRenderViewportLineStart = thisRenderVieportLineStart;
     }
+
+    if (this.showFps) {
+      this.drawFpsCounter();
+    }
+  }
+
+  /** Current collapsed-caret width in CSS px. */
+  getCaretWidth(): number {
+    return this.caretWidth;
+  }
+
+  /** Set the collapsed-caret width in CSS px (e.g. 1, 2, 3) and redraw. */
+  setCaretWidth(px: number): void {
+    this.caretWidth = Math.max(1, px);
+    this.saveSettings();
+    this.draw();
+  }
+
+  /**
+   * Load persisted settings from localStorage and apply them to the fields
+   * (without redrawing — the constructor draws once afterwards). Safe to call
+   * when storage is unavailable or holds malformed data.
+   */
+  private loadSettings(): void {
+    let parsed: PersistedSettings | null = null;
+    try {
+      const raw =
+        typeof localStorage !== "undefined" &&
+        localStorage.getItem(SETTINGS_STORAGE_KEY);
+      if (raw) {
+        parsed = JSON.parse(raw) as PersistedSettings;
+      }
+    } catch {
+      return; // storage blocked or corrupt — fall back to defaults
+    }
+    if (!parsed) {
+      return;
+    }
+
+    if (typeof parsed.caretWidth === "number") {
+      this.caretWidth = Math.max(1, parsed.caretWidth);
+    }
+    if (typeof parsed.highlightColor === "string") {
+      this.highlightColor = parsed.highlightColor;
+      this.cursor.style = { ...this.cursor.style, color: this.highlightColor };
+    }
+    if (typeof parsed.showFps === "boolean") {
+      this.showFps = parsed.showFps;
+    }
+  }
+
+  /** Reset all persisted settings to their defaults, clear storage, and redraw. */
+  resetSettings(): void {
+    this.caretWidth = 1;
+    this.highlightColor = undefined;
+    // Revert the highlight color to the host theme color (last setSelectStyle).
+    this.cursor.style = { ...this.cursor.style, color: this.selectColor };
+    this.showFps = false;
+    this.lastFrameTime = 0;
+    this.fps = 0;
+
+    try {
+      if (typeof localStorage !== "undefined") {
+        localStorage.removeItem(SETTINGS_STORAGE_KEY);
+      }
+    } catch {
+      // ignore storage errors
+    }
+
+    this.draw();
+  }
+
+  /** Persist the current settings to localStorage (best-effort). */
+  private saveSettings(): void {
+    try {
+      if (typeof localStorage === "undefined") {
+        return;
+      }
+      const data: PersistedSettings = {
+        caretWidth: this.caretWidth,
+        highlightColor: this.highlightColor,
+        showFps: this.showFps,
+      };
+      localStorage.setItem(SETTINGS_STORAGE_KEY, JSON.stringify(data));
+    } catch {
+      // storage full or blocked — settings just won't persist this session
+    }
+  }
+
+  /**
+   * Current selection highlight color as a `#rrggbb` hex string. When the user
+   * hasn't picked one, this reflects the effective (theme) color so the picker
+   * shows the real default rather than black.
+   */
+  getHighlightColor(): string {
+    return (
+      this.highlightColor ??
+      this.cssColorToHex(this.cursor.style.color as string)
+    );
+  }
+
+  /**
+   * Normalize any CSS color (named/rgb/hex) to `#rrggbb` using the canvas, which
+   * a native color input requires. Falls back to black for non-opaque colors.
+   */
+  private cssColorToHex(color: string): string {
+    try {
+      const prev = this.ctx.fillStyle;
+      this.ctx.fillStyle = color;
+      const normalized = this.ctx.fillStyle;
+      this.ctx.fillStyle = prev;
+      if (typeof normalized === "string" && normalized.startsWith("#")) {
+        return normalized;
+      }
+    } catch {
+      // ignore and fall through to default
+    }
+    return "#000000";
+  }
+
+  /** Set the selection highlight color (`#rrggbb`) and redraw. */
+  setHighlightColor(hex: string): void {
+    this.highlightColor = hex;
+    this.cursor.style = { ...this.cursor.style, color: hex };
+    this.saveSettings();
+    this.draw();
+  }
+
+  /**
+   * Toggle the debug FPS counter in the top-left corner. Disabled by default.
+   */
+  setShowFps(show: boolean): void {
+    this.showFps = show;
+    this.lastFrameTime = 0;
+    this.fps = 0;
+    this.saveSettings();
+    this.draw();
+  }
+
+  /**
+   * Update the smoothed FPS from the interval between draw() calls. This is an
+   * on-demand renderer (no rAF loop), so the value reflects redraw frequency
+   * during activity and dips after idle gaps.
+   */
+  private updateFps() {
+    const now =
+      typeof performance !== "undefined" ? performance.now() : Date.now();
+    if (this.lastFrameTime > 0) {
+      const dt = now - this.lastFrameTime;
+      if (dt > 0) {
+        const instantaneous = 1000 / dt;
+        // Exponential moving average smooths jitter between on-demand redraws.
+        this.fps =
+          this.fps === 0
+            ? instantaneous
+            : this.fps * 0.8 + instantaneous * 0.2;
+      }
+    }
+    this.lastFrameTime = now;
+  }
+
+  /** Draw the debug FPS counter in the top-left corner (screen space). */
+  private drawFpsCounter() {
+    const text = `${Math.round(this.fps)} FPS`;
+    const pad = 4 * this.ratio;
+    const fontSize = 11 * this.ratio;
+
+    this.ctx.save();
+    this.ctx.font = `${fontSize}px ${DEFAULT_FONT}`;
+    this.ctx.textBaseline = "top";
+    const textW = this.ctx.measureText(text).width;
+    this.ctx.fillStyle = "rgba(0, 0, 0, 0.6)";
+    this.ctx.fillRect(0, 0, textW + pad * 2, fontSize + pad * 2);
+    this.ctx.fillStyle = "#0f0";
+    this.ctx.fillText(text, pad, pad);
+    this.ctx.restore();
   }
 
   /**

--- a/packages/annotator/src/lib/Annotator.ts
+++ b/packages/annotator/src/lib/Annotator.ts
@@ -2046,10 +2046,21 @@ export class Annotator {
           this.cursor.reset();
           this.cursor.setPosition(area[0].xLine, area[0].yLine);
         }
+        // Place the caret at insert-offset + length via the offset model. Unlike
+        // move(len, 0) — which only shifts xLine and mishandles pasted newlines —
+        // this lands correctly for multi-line text and stays in bounds.
+        const insertOffset = this.text.offsetFromVisual(
+          this.cursor.xLine,
+          this.cursor.yLine
+        );
         this.text.insertText(this.viewport, this.cursor, clipText);
-        this.cursor.move(clipText.length, 0);
-        this.cursor.fixOutOfBounds(this.viewport, this.text);
-        this.cursor.goalColumn = null;
+        if (insertOffset >= 0) {
+          this.cursor.moveToOffset(this.text, insertOffset + clipText.length);
+        } else {
+          this.cursor.move(clipText.length, 0);
+          this.cursor.fixOutOfBounds(this.viewport, this.text);
+          this.cursor.goalColumn = null;
+        }
         this.keys.scrollCursorIntoView();
 
         this.runWarningChecks();
@@ -2067,10 +2078,19 @@ export class Annotator {
       this.cursor.reset();
       this.cursor.setPosition(area[0].xLine, area[0].yLine);
     }
+    // See onPasteText: offset-based caret placement handles multi-line text.
+    const insertOffset = this.text.offsetFromVisual(
+      this.cursor.xLine,
+      this.cursor.yLine
+    );
     this.text.insertText(this.viewport, this.cursor, text);
-    this.cursor.move(text.length, 0);
-    this.cursor.fixOutOfBounds(this.viewport, this.text);
-    this.cursor.goalColumn = null;
+    if (insertOffset >= 0) {
+      this.cursor.moveToOffset(this.text, insertOffset + text.length);
+    } else {
+      this.cursor.move(text.length, 0);
+      this.cursor.fixOutOfBounds(this.viewport, this.text);
+      this.cursor.goalColumn = null;
+    }
     this.keys.scrollCursorIntoView();
 
     this.runWarningChecks();

--- a/packages/annotator/src/lib/Annotator.ts
+++ b/packages/annotator/src/lib/Annotator.ts
@@ -1,9 +1,10 @@
 import Cursor, { DIRECTION } from "./Cursor";
 import Highlighter, { IAbsCoordinates, CursorStyle } from "./Highlighter";
+import History, { HistorySnapshot } from "./History";
 import Keys from "./Keys";
 import { Lines } from "./Lines";
 import Scroller from "./Scroller";
-import Text, { Tag, SegmentPosition } from "./Text";
+import Text, { Tag, SegmentPosition, CaretAffinity } from "./Text";
 import Viewport from "./Viewport";
 import { AsymmetricalAnchor, Warnings, WarningData } from "./warnings";
 import {
@@ -104,6 +105,9 @@ export class Annotator {
   lines?: Lines;
   keys: Keys;
   warnings: Warnings;
+
+  /** Phase 4 (#3086) — bounded undo/redo stack of document snapshots. */
+  history: History = new History();
 
   annotatedPosition: SegmentPosition | null = null;
 
@@ -1625,6 +1629,9 @@ export class Annotator {
    * @param mode
    */
   setMode(mode: EditMode) {
+    // A mode switch ends any in-progress typing run for undo coalescing.
+    this.history.endCoalescing();
+
     let absIndex: number | null = null;
     if (this.cursor.xLine >= 0 && this.cursor.yLine >= 0) {
       const segPos = this.text.cursorToIndex(this.viewport, this.cursor);
@@ -2048,6 +2055,86 @@ export class Annotator {
     }
   }
 
+  // ===== Phase 4 (#3086): undo/redo =====
+
+  /** Capture the live editor state (raw value + canonical caret/selection offsets). */
+  captureSnapshot(): HistorySnapshot {
+    return {
+      value: this.text.value,
+      anchor: this.cursor.anchor,
+      head: this.cursor.head,
+      anchorAffinity: this.cursor.anchorAffinity,
+      headAffinity: this.cursor.headAffinity,
+    };
+  }
+
+  /**
+   * Restore a snapshot: reload the document string, reparse/rewrap, set the
+   * caret/selection offsets and derive the visual caret, scroll it into view,
+   * fire onTextChangeCb (when the value changed and editing is allowed) and draw.
+   */
+  private restoreSnapshot(snap: HistorySnapshot): void {
+    const changed = this.text.value !== snap.value;
+
+    this.text.value = snap.value;
+    this.text.prepareSegments();
+    this.text.calculateLines();
+
+    this.cursor.anchor = snap.anchor;
+    this.cursor.head = snap.head;
+    this.cursor.anchorAffinity = snap.anchorAffinity;
+    this.cursor.headAffinity = snap.headAffinity;
+    this.cursor.syncVisualFromOffset(this.text);
+
+    this.keys.scrollCursorIntoView();
+    this.runWarningChecks();
+
+    if (
+      changed &&
+      this.text.mode !== EditMode.HIGHLIGHT &&
+      this.onTextChangeCb
+    ) {
+      this.onTextChangeCb(this.text.value);
+    }
+    this.draw();
+  }
+
+  /**
+   * Record the pre-mutation state on the undo stack. `coalesce` is true only for
+   * a single-character typing insert, so a contiguous typing run becomes one
+   * undo step; every other op is discrete. The post-edit caret offset is read
+   * from the (already-updated) cursor for contiguity tracking.
+   */
+  recordHistory(before: HistorySnapshot, coalesce: boolean): void {
+    this.history.record(before, coalesce, this.cursor.head);
+  }
+
+  canUndo(): boolean {
+    return this.history.canUndo();
+  }
+
+  canRedo(): boolean {
+    return this.history.canRedo();
+  }
+
+  /** Restore the previous document state, if any. */
+  undo(): void {
+    const target = this.history.undo(this.captureSnapshot());
+    if (target === null) {
+      return;
+    }
+    this.restoreSnapshot(target);
+  }
+
+  /** Re-apply the most recently undone document state, if any. */
+  redo(): void {
+    const target = this.history.redo(this.captureSnapshot());
+    if (target === null) {
+      return;
+    }
+    this.restoreSnapshot(target);
+  }
+
   onCopyText() {
     window.navigator.clipboard.writeText(this.lastSelectedText?.text || "");
   }
@@ -2056,6 +2143,9 @@ export class Annotator {
     window.navigator.clipboard
       .readText()
       .then((clipText: string) => {
+        // Snapshot the pre-paste state for undo (a paste is one discrete step).
+        this.cursor.reconcileOffsetsFromVisual(this.text);
+        const before = this.captureSnapshot();
         const area = this.cursor.getSelectedArea();
         if (area) {
           this.text.deleteRangeText(area[0], area[1]);
@@ -2072,6 +2162,9 @@ export class Annotator {
         this.text.insertText(this.viewport, this.cursor, clipText);
         const pasteAt = insertOffset >= 0 ? insertOffset : this.cursor.head;
         this.cursor.moveToOffset(this.text, pasteAt + clipText.length);
+        if (this.text.value !== before.value) {
+          this.recordHistory(before, false);
+        }
         this.keys.scrollCursorIntoView();
 
         this.runWarningChecks();
@@ -2083,6 +2176,9 @@ export class Annotator {
   }
 
   onReplaceText(text: string) {
+    // Snapshot the pre-replace state for undo (replace is one discrete step).
+    this.cursor.reconcileOffsetsFromVisual(this.text);
+    const before = this.captureSnapshot();
     const area = this.cursor.getSelectedArea();
     if (area) {
       this.text.deleteRangeText(area[0], area[1]);
@@ -2097,6 +2193,9 @@ export class Annotator {
     this.text.insertText(this.viewport, this.cursor, text);
     const insertAt = insertOffset >= 0 ? insertOffset : this.cursor.head;
     this.cursor.moveToOffset(this.text, insertAt + text.length);
+    if (this.text.value !== before.value) {
+      this.recordHistory(before, false);
+    }
     this.keys.scrollCursorIntoView();
 
     this.runWarningChecks();

--- a/packages/annotator/src/lib/Annotator.ts
+++ b/packages/annotator/src/lib/Annotator.ts
@@ -2119,6 +2119,12 @@ export class Annotator {
 
   /** Restore the previous document state, if any. */
   undo(): void {
+    // Editing is disabled in HIGHLIGHT mode; undo would mutate the document
+    // while restoreSnapshot suppresses onTextChangeCb, silently desyncing the
+    // editor from the host app. Leave the stack untouched.
+    if (this.text.mode === EditMode.HIGHLIGHT) {
+      return;
+    }
     const target = this.history.undo(this.captureSnapshot());
     if (target === null) {
       return;
@@ -2128,6 +2134,9 @@ export class Annotator {
 
   /** Re-apply the most recently undone document state, if any. */
   redo(): void {
+    if (this.text.mode === EditMode.HIGHLIGHT) {
+      return;
+    }
     const target = this.history.redo(this.captureSnapshot());
     if (target === null) {
       return;

--- a/packages/annotator/src/lib/Annotator.ts
+++ b/packages/annotator/src/lib/Annotator.ts
@@ -1470,7 +1470,10 @@ export class Annotator {
     if (textSegment) {
       const line = this.text.getLineFromPosition(textSegment);
       if (this.cursor.xLine > line.length) {
-        this.cursor.fixOutOfBounds(this.viewport, this.text);
+        // Offset-model navigation/editing keeps the caret in bounds; this is a
+        // defensive clamp for a caret set visually (setPosition) without a sync,
+        // replacing the legacy fixOutOfBounds line-flow repair.
+        this.cursor.xLine = line.length;
       }
 
       this.cursor.draw(this.ctx, this.viewport, this.text, {
@@ -2067,13 +2070,8 @@ export class Annotator {
           this.cursor.yLine
         );
         this.text.insertText(this.viewport, this.cursor, clipText);
-        if (insertOffset >= 0) {
-          this.cursor.moveToOffset(this.text, insertOffset + clipText.length);
-        } else {
-          this.cursor.move(clipText.length, 0);
-          this.cursor.fixOutOfBounds(this.viewport, this.text);
-          this.cursor.goalColumn = null;
-        }
+        const pasteAt = insertOffset >= 0 ? insertOffset : this.cursor.head;
+        this.cursor.moveToOffset(this.text, pasteAt + clipText.length);
         this.keys.scrollCursorIntoView();
 
         this.runWarningChecks();
@@ -2097,13 +2095,8 @@ export class Annotator {
       this.cursor.yLine
     );
     this.text.insertText(this.viewport, this.cursor, text);
-    if (insertOffset >= 0) {
-      this.cursor.moveToOffset(this.text, insertOffset + text.length);
-    } else {
-      this.cursor.move(text.length, 0);
-      this.cursor.fixOutOfBounds(this.viewport, this.text);
-      this.cursor.goalColumn = null;
-    }
+    const insertAt = insertOffset >= 0 ? insertOffset : this.cursor.head;
+    this.cursor.moveToOffset(this.text, insertAt + text.length);
     this.keys.scrollCursorIntoView();
 
     this.runWarningChecks();

--- a/packages/annotator/src/lib/Annotator.ts
+++ b/packages/annotator/src/lib/Annotator.ts
@@ -878,7 +878,11 @@ export class Annotator {
       }
     }
 
+    // First pointer event starts a (collapsed) selection → set both offsets;
+    // subsequent drag events move only head (keep the click anchor fixed).
+    const wasSelecting = this.cursor.isSelecting();
     this.cursor.selectArea();
+    this.cursor.syncOffsetFromVisual(this.text, wasSelecting);
   }
 
   private cancelSelectionEdgeScroll() {
@@ -1077,6 +1081,15 @@ export class Annotator {
     };
     this.cursor.xLine = this.cursor.selectEnd.xLine;
     this.cursor.selectDirection = DIRECTION.FORWARD;
+    // Canonical offsets: anchor = word start, head = word end (caret).
+    this.cursor.anchor = this.text.offsetFromVisual(
+      this.cursor.selectStart.xLine,
+      this.cursor.selectStart.yLine
+    );
+    this.cursor.head = this.text.offsetFromVisual(
+      this.cursor.selectEnd.xLine,
+      this.cursor.selectEnd.yLine
+    );
     this.draw();
   }
 

--- a/packages/annotator/src/lib/Annotator.ts
+++ b/packages/annotator/src/lib/Annotator.ts
@@ -1663,14 +1663,14 @@ export class Annotator {
       if (segPos !== null) {
         const coords = this.text.positionToCursor(this.viewport, segPos);
         if (coords !== null) {
+          // Re-derive the caret's visual position in the new mode so its
+          // document position is preserved across the switch. Deliberately do
+          // NOT scroll the viewport to the caret here: switching edit modes
+          // keeps the reader on the same content (the viewport was just
+          // restored above, per #2904). Snapping to an off-screen caret —
+          // one the user had scrolled away from — would defeat that.
           const absY = this.viewport.lineStart + coords.yLine;
           this.cursor.setPosition(coords.xLine, absY);
-          if (
-            absY < this.viewport.lineStart ||
-            absY > this.viewport.lineEnd - 1
-          ) {
-            this.viewport.scrollTo(absY, this.scrollExtentLineCount());
-          }
         }
       }
     }

--- a/packages/annotator/src/lib/ContextMenu.ts
+++ b/packages/annotator/src/lib/ContextMenu.ts
@@ -1,0 +1,139 @@
+/**
+ * Lightweight right-click context menu for the annotator.
+ *
+ * The editor renders to a canvas, so a real menu can't live "inside" it — this
+ * builds a small absolutely-positioned DOM overlay instead. It is self-contained
+ * (no host wiring needed) and closes on outside-click, Escape, scroll, or blur.
+ */
+
+export interface ContextMenuItem {
+  /** Text shown for the row. Ignored when `separator` is true. */
+  label?: string;
+  /** Invoked on click; the menu closes automatically afterwards. */
+  onClick?: () => void;
+  /** Render a horizontal divider instead of a clickable row. */
+  separator?: boolean;
+  /** Greyed-out, non-interactive row. */
+  disabled?: boolean;
+}
+
+export class ContextMenu {
+  private el: HTMLDivElement | null = null;
+
+  /** Whether the menu is currently shown. */
+  get isOpen(): boolean {
+    return this.el !== null;
+  }
+
+  /**
+   * Open the menu at the given viewport coordinates (e.g. MouseEvent.clientX/Y).
+   * Any previously-open menu is replaced.
+   */
+  open(clientX: number, clientY: number, items: ContextMenuItem[]): void {
+    this.close();
+
+    const menu = document.createElement("div");
+    Object.assign(menu.style, {
+      position: "fixed",
+      left: `${clientX}px`,
+      top: `${clientY}px`,
+      zIndex: "10000",
+      minWidth: "160px",
+      padding: "4px 0",
+      background: "#ffffff",
+      border: "1px solid #d0d0d0",
+      borderRadius: "4px",
+      boxShadow: "0 2px 8px rgba(0, 0, 0, 0.15)",
+      font: '13px "Roboto Mono", monospace',
+      color: "#222",
+      userSelect: "none",
+    } as Partial<CSSStyleDeclaration>);
+
+    for (const item of items) {
+      if (item.separator) {
+        const sep = document.createElement("div");
+        Object.assign(sep.style, {
+          height: "1px",
+          margin: "4px 0",
+          background: "#e0e0e0",
+        } as Partial<CSSStyleDeclaration>);
+        menu.appendChild(sep);
+        continue;
+      }
+
+      const row = document.createElement("div");
+      row.textContent = item.label ?? "";
+      Object.assign(row.style, {
+        padding: "5px 14px",
+        cursor: item.disabled ? "default" : "pointer",
+        color: item.disabled ? "#aaa" : "inherit",
+        whiteSpace: "nowrap",
+      } as Partial<CSSStyleDeclaration>);
+
+      if (!item.disabled) {
+        row.addEventListener("mouseenter", () => {
+          row.style.background = "#f0f0f0";
+        });
+        row.addEventListener("mouseleave", () => {
+          row.style.background = "transparent";
+        });
+        row.addEventListener("mousedown", (e) => {
+          // mousedown (not click) so we fire before the outside-click handler.
+          e.preventDefault();
+          e.stopPropagation();
+          this.close();
+          item.onClick?.();
+        });
+      }
+
+      menu.appendChild(row);
+    }
+
+    document.body.appendChild(menu);
+    this.el = menu;
+
+    // Keep the menu inside the viewport if it would overflow the edges.
+    const rect = menu.getBoundingClientRect();
+    if (rect.right > window.innerWidth) {
+      menu.style.left = `${Math.max(0, window.innerWidth - rect.width)}px`;
+    }
+    if (rect.bottom > window.innerHeight) {
+      menu.style.top = `${Math.max(0, window.innerHeight - rect.height)}px`;
+    }
+
+    document.addEventListener("mousedown", this.onOutsidePointer, true);
+    document.addEventListener("keydown", this.onKeyDown, true);
+    window.addEventListener("blur", this.onDismiss);
+    window.addEventListener("resize", this.onDismiss);
+    document.addEventListener("scroll", this.onDismiss, true);
+  }
+
+  /** Remove the menu and detach all listeners. Safe to call when already closed. */
+  close(): void {
+    if (!this.el) {
+      return;
+    }
+    this.el.remove();
+    this.el = null;
+
+    document.removeEventListener("mousedown", this.onOutsidePointer, true);
+    document.removeEventListener("keydown", this.onKeyDown, true);
+    window.removeEventListener("blur", this.onDismiss);
+    window.removeEventListener("resize", this.onDismiss);
+    document.removeEventListener("scroll", this.onDismiss, true);
+  }
+
+  private readonly onOutsidePointer = (e: MouseEvent) => {
+    if (this.el && !this.el.contains(e.target as Node)) {
+      this.close();
+    }
+  };
+
+  private readonly onKeyDown = (e: KeyboardEvent) => {
+    if (e.key === "Escape") {
+      this.close();
+    }
+  };
+
+  private readonly onDismiss = () => this.close();
+}

--- a/packages/annotator/src/lib/Cursor.ts
+++ b/packages/annotator/src/lib/Cursor.ts
@@ -4,7 +4,7 @@ import Highlighter, {
   IAbsCoordinates,
   IRelativeCoordinates,
 } from "./Highlighter";
-import Text from "./Text";
+import Text, { CaretAffinity } from "./Text";
 import Viewport from "./Viewport";
 import { HighlightMode } from "./constants";
 
@@ -35,6 +35,9 @@ export default class Cursor
    */
   anchor: number = 0;
   head: number = 0;
+  /** Affinity for `head`/`anchor` at a soft-wrap boundary (see {@link CaretAffinity}). */
+  headAffinity: CaretAffinity = CaretAffinity.DOWNSTREAM;
+  anchorAffinity: CaretAffinity = CaretAffinity.DOWNSTREAM;
 
   selectDirection?: DIRECTION;
 
@@ -97,7 +100,7 @@ export default class Cursor
    * visual state in sync after any offset mutation.
    */
   syncVisualFromOffset(text: Text) {
-    const headVisual = text.visualFromOffset(this.head);
+    const headVisual = text.visualFromOffset(this.head, this.headAffinity);
     if (headVisual) {
       this.xLine = headVisual.xLine;
       this.yLine = headVisual.yLine;
@@ -107,7 +110,10 @@ export default class Cursor
       this.selectStart = undefined;
       this.selectEnd = undefined;
     } else {
-      const anchorVisual = text.visualFromOffset(this.anchor);
+      const anchorVisual = text.visualFromOffset(
+        this.anchor,
+        this.anchorAffinity
+      );
       if (anchorVisual && headVisual) {
         this.selectStart = {
           xLine: anchorVisual.xLine,
@@ -127,13 +133,18 @@ export default class Cursor
    * Out-of-bounds visual coords leave the offsets unchanged.
    */
   syncOffsetFromVisual(text: Text, keepAnchor: boolean = false) {
-    const offset = text.offsetFromVisual(this.xLine, this.yLine);
+    const { offset, affinity } = text.offsetWithAffinityFromVisual(
+      this.xLine,
+      this.yLine
+    );
     if (offset < 0) {
       return;
     }
     this.head = offset;
+    this.headAffinity = affinity;
     if (!keepAnchor) {
       this.anchor = offset;
+      this.anchorAffinity = affinity;
     }
   }
 

--- a/packages/annotator/src/lib/Cursor.ts
+++ b/packages/annotator/src/lib/Cursor.ts
@@ -27,6 +27,15 @@ export default class Cursor
   /** Desired column for vertical movement; null = follow xLine. Reset on any horizontal move/edit/click. */
   goalColumn: number | null = null;
 
+  /**
+   * Phase 3 offset model (additive; not yet wired into navigation). Canonical
+   * caret/selection state as raw document offsets (indices into `Text.value`):
+   * `head` is the moving caret, `anchor` the fixed selection end. Collapsed
+   * selection ⇔ `anchor === head`. `xLine`/`yLine` are derived from these.
+   */
+  anchor: number = 0;
+  head: number = 0;
+
   selectDirection?: DIRECTION;
 
   // highlighted area must use absolute coordinates - highlighted area stays in position while scrolling
@@ -78,6 +87,54 @@ export default class Cursor
     this.xLine = lineX;
     this.yLine = lineY;
     this.goalColumn = null;
+  }
+
+  /**
+   * Phase 3 offset model — derive the cached visual caret (`xLine`/`yLine`) and
+   * the selection's visual endpoints from the canonical `head`/`anchor` offsets.
+   * Selection is collapsed (start/end cleared) when `anchor === head`. The draw
+   * pipeline keeps reading `xLine`/`yLine`, so this is the bridge that keeps the
+   * visual state in sync after any offset mutation.
+   */
+  syncVisualFromOffset(text: Text) {
+    const headVisual = text.visualFromOffset(this.head);
+    if (headVisual) {
+      this.xLine = headVisual.xLine;
+      this.yLine = headVisual.yLine;
+    }
+
+    if (this.anchor === this.head) {
+      this.selectStart = undefined;
+      this.selectEnd = undefined;
+    } else {
+      const anchorVisual = text.visualFromOffset(this.anchor);
+      if (anchorVisual && headVisual) {
+        this.selectStart = {
+          xLine: anchorVisual.xLine,
+          yLine: anchorVisual.yLine,
+        };
+        this.selectEnd = { xLine: headVisual.xLine, yLine: headVisual.yLine };
+      }
+    }
+
+    this.setTrueSelectionDirection();
+  }
+
+  /**
+   * Phase 3 offset model — derive `head` (and `anchor` unless `keepAnchor`) from
+   * the current visual caret. Used at the boundary while navigation still
+   * mutates `xLine`/`yLine` directly (before Tasks 3.2–3.5 migrate them).
+   * Out-of-bounds visual coords leave the offsets unchanged.
+   */
+  syncOffsetFromVisual(text: Text, keepAnchor: boolean = false) {
+    const offset = text.offsetFromVisual(this.xLine, this.yLine);
+    if (offset < 0) {
+      return;
+    }
+    this.head = offset;
+    if (!keepAnchor) {
+      this.anchor = offset;
+    }
   }
 
   /**

--- a/packages/annotator/src/lib/Cursor.ts
+++ b/packages/annotator/src/lib/Cursor.ts
@@ -147,6 +147,42 @@ export default class Cursor
   }
 
   /**
+   * Phase 3 offset model — reconcile the canonical `head`/`anchor` offsets with
+   * the current VISUAL caret + selection. Needed because `setPosition`,
+   * `setMode` and mouse handlers set `xLine`/`yLine` (and `selectStart`/`End`)
+   * without touching the offsets, so they can be stale at the start of a key.
+   * `head` follows the caret; `anchor` follows the non-caret selection end (or
+   * collapses to `head` when there is no active selection).
+   */
+  reconcileOffsetsFromVisual(text: Text) {
+    if (this.xLine < 0 || this.yLine < 0) {
+      return;
+    }
+    const headInfo = text.offsetWithAffinityFromVisual(this.xLine, this.yLine);
+    if (headInfo.offset < 0) {
+      return;
+    }
+    this.head = headInfo.offset;
+    this.headAffinity = headInfo.affinity;
+
+    if (this.selectStart && this.selectEnd && this.isSelected()) {
+      const caretAtStart =
+        this.xLine === this.selectStart.xLine &&
+        this.yLine === this.selectStart.yLine;
+      const anchorPt = caretAtStart ? this.selectEnd : this.selectStart;
+      const anchorInfo = text.offsetWithAffinityFromVisual(
+        anchorPt.xLine,
+        anchorPt.yLine
+      );
+      this.anchor = anchorInfo.offset;
+      this.anchorAffinity = anchorInfo.affinity;
+    } else {
+      this.anchor = this.head;
+      this.anchorAffinity = this.headAffinity;
+    }
+  }
+
+  /**
    * Phase 3 offset model — derive `head` (and `anchor` unless `keepAnchor`) from
    * the current visual caret. Used at the boundary while navigation still
    * mutates `xLine`/`yLine` directly (before Tasks 3.2–3.5 migrate them).

--- a/packages/annotator/src/lib/Cursor.ts
+++ b/packages/annotator/src/lib/Cursor.ts
@@ -353,14 +353,6 @@ export default class Cursor
   }
 
   /**
-   * move the cursor to start of the next line
-   */
-  moveToNewline() {
-    this.xLine = 0;
-    this.yLine += 1;
-  }
-
-  /**
    * draw places cursor and optionally highlighted area into the canvas
    * @param ctx
    * @param viewport

--- a/packages/annotator/src/lib/Cursor.ts
+++ b/packages/annotator/src/lib/Cursor.ts
@@ -127,6 +127,26 @@ export default class Cursor
   }
 
   /**
+   * Phase 3 offset model — place a COLLAPSED caret at a raw document offset and
+   * derive the visual position. Clears any selection (anchor === head) and the
+   * goal column. The canonical way to position the caret after an edit: the
+   * post-edit offset is known exactly, and deriving the visual from it is always
+   * in bounds (replaces `move()` + `fixOutOfBounds`).
+   */
+  moveToOffset(
+    text: Text,
+    offset: number,
+    affinity: CaretAffinity = CaretAffinity.DOWNSTREAM
+  ) {
+    this.head = offset;
+    this.anchor = offset;
+    this.headAffinity = affinity;
+    this.anchorAffinity = affinity;
+    this.goalColumn = null;
+    this.syncVisualFromOffset(text);
+  }
+
+  /**
    * Phase 3 offset model — derive `head` (and `anchor` unless `keepAnchor`) from
    * the current visual caret. Used at the boundary while navigation still
    * mutates `xLine`/`yLine` directly (before Tasks 3.2–3.5 migrate them).

--- a/packages/annotator/src/lib/Cursor.ts
+++ b/packages/annotator/src/lib/Cursor.ts
@@ -353,27 +353,6 @@ export default class Cursor
   }
 
   /**
-   * fixOutOfBounds moves the cursor to the next line if the current line is too short
-   * @param viewport
-   * @param text
-   */
-  fixOutOfBounds(viewport: Viewport, text: Text) {
-    let line = undefined;
-    do {
-      line = text.getCurrentLine(viewport, this);
-      if (line === null) {
-        this.reset();
-        return;
-      }
-
-      if (line.length < this.xLine) {
-        this.yLine++;
-        this.xLine = this.xLine - line.length;
-      }
-    } while (!line || line.length < this.xLine);
-  }
-
-  /**
    * move the cursor to start of the next line
    */
   moveToNewline() {

--- a/packages/annotator/src/lib/Highlighter.ts
+++ b/packages/annotator/src/lib/Highlighter.ts
@@ -138,7 +138,8 @@ export default class Highlighter {
     } else if (this.hlMode === "select") {
       ctx.globalCompositeOperation = "color";
       ctx.globalAlpha = 1;
-      ctx.fillRect(xStart * charWidth, y, width || 1, height);
+      // width === 0 means a collapsed caret; honor the configured caret width.
+      ctx.fillRect(xStart * charWidth, y, width || options.caretWidth || 1, height);
     }
   }
 

--- a/packages/annotator/src/lib/History.ts
+++ b/packages/annotator/src/lib/History.ts
@@ -1,0 +1,111 @@
+import { CaretAffinity } from "./Text";
+
+/**
+ * A full editor state: the raw document string plus the canonical caret/selection
+ * offsets (Phase 3 offset model). Restoring one is just assigning the string and
+ * the four offset fields — no fragile visual coordinates are stored.
+ */
+export interface HistorySnapshot {
+  value: string;
+  anchor: number;
+  head: number;
+  anchorAffinity: CaretAffinity;
+  headAffinity: CaretAffinity;
+}
+
+/**
+ * Phase 4 (#3086) — bounded undo/redo stack.
+ *
+ * Each `record` is given the state as it was *before* a mutation. Undo pushes the
+ * live ("present") state onto the redo stack and pops the previous before-state;
+ * redo is the mirror. A contiguous run of single-character typing collapses into
+ * one entry (see {@link record}); every other op is discrete.
+ */
+export default class History {
+  private undoStack: HistorySnapshot[] = [];
+  private redoStack: HistorySnapshot[] = [];
+  private readonly maxSize: number;
+
+  /** Whether the last recorded op may merge with a following typing op. */
+  private lastCoalescable = false;
+  /** Caret offset immediately after the last recorded op (contiguity check). */
+  private lastAfterHead = -1;
+
+  constructor(maxSize: number = 500) {
+    this.maxSize = Math.max(1, maxSize);
+  }
+
+  /**
+   * Record the pre-mutation state.
+   *
+   * @param before    state captured before the mutation was applied
+   * @param coalesce   true only for a single-character typing insert
+   * @param afterHead  caret offset after the mutation (for contiguity tracking)
+   *
+   * Merges into the current top entry (records nothing) iff the previous op was
+   * also coalescable and this op begins exactly where that one ended
+   * (`before.head === lastAfterHead`). Otherwise pushes `before` as a new undo
+   * entry, trims to `maxSize`, and clears the redo stack.
+   */
+  record(before: HistorySnapshot, coalesce: boolean, afterHead: number): void {
+    const merge =
+      coalesce && this.lastCoalescable && before.head === this.lastAfterHead;
+
+    if (!merge) {
+      this.undoStack.push({ ...before });
+      if (this.undoStack.length > this.maxSize) {
+        this.undoStack.shift();
+      }
+      this.redoStack = [];
+    }
+
+    this.lastCoalescable = coalesce;
+    this.lastAfterHead = afterHead;
+  }
+
+  /**
+   * Undo: stash the live state on the redo stack and return the previous
+   * before-state to restore, or null when there is nothing to undo.
+   */
+  undo(present: HistorySnapshot): HistorySnapshot | null {
+    const target = this.undoStack.pop();
+    if (target === undefined) {
+      return null;
+    }
+    this.redoStack.push({ ...present });
+    this.endCoalescing();
+    return target;
+  }
+
+  /** Redo: mirror of {@link undo}. */
+  redo(present: HistorySnapshot): HistorySnapshot | null {
+    const target = this.redoStack.pop();
+    if (target === undefined) {
+      return null;
+    }
+    this.undoStack.push({ ...present });
+    this.endCoalescing();
+    return target;
+  }
+
+  canUndo(): boolean {
+    return this.undoStack.length > 0;
+  }
+
+  canRedo(): boolean {
+    return this.redoStack.length > 0;
+  }
+
+  /** Break any in-progress typing run so the next typing op starts a new entry. */
+  endCoalescing(): void {
+    this.lastCoalescable = false;
+    this.lastAfterHead = -1;
+  }
+
+  /** Drop all history (e.g. when the document is reloaded from scratch). */
+  clear(): void {
+    this.undoStack = [];
+    this.redoStack = [];
+    this.endCoalescing();
+  }
+}

--- a/packages/annotator/src/lib/Keys.ts
+++ b/packages/annotator/src/lib/Keys.ts
@@ -1,5 +1,6 @@
 import { EditMode } from "./constants";
 import Cursor from "./Cursor";
+import { HistorySnapshot } from "./History";
 import Text from "./Text";
 import Viewport from "./Viewport";
 
@@ -44,6 +45,11 @@ export interface AnnotatorCallbacks {
   text: Text;
   element: HTMLCanvasElement;
   scrollExtentLineCount(): number;
+  // Phase 4 (#3086) — undo/redo
+  captureSnapshot(): HistorySnapshot;
+  recordHistory(before: HistorySnapshot, coalesce: boolean): void;
+  undo(): void;
+  redo(): void;
 }
 
 export default class Keys {
@@ -877,6 +883,12 @@ export default class Keys {
     // setMode) without updating the offsets.
     this.cursor.reconcileOffsetsFromVisual(this.text);
 
+    // Undo/redo: capture the pre-edit state, and whether this key is a
+    // coalescable single-character typing insert (a contiguous typing run is one
+    // undo step). Recorded at the very end iff the document actually changed.
+    const historyBefore = this.annotator.captureSnapshot();
+    const coalesceEdit = key.length === 1 && !e.ctrlKey && !e.metaKey;
+
     // Any key other than vertical movement drops the goal column; ArrowUp/Down
     // manage it themselves so the desired column survives short lines.
     if (e.key !== Key.ArrowUp && e.key !== Key.ArrowDown) {
@@ -977,6 +989,20 @@ export default class Keys {
               xLine: (this.text.getLine(lastLine) ?? "").length,
               yLine: lastLine,
             };
+          } else if ((e.key === "z" || e.key === "Z") && !e.shiftKey) {
+            // Undo (Ctrl/Cmd+Z). Self-contained: it restores + scrolls + fires
+            // the change callback + draws, so return before the generic
+            // end-of-key recorder runs (it must not record the undo as an edit).
+            this.annotator.undo();
+            return;
+          } else if (
+            ((e.key === "z" || e.key === "Z") && e.shiftKey) ||
+            e.key === "y" ||
+            e.key === "Y"
+          ) {
+            // Redo (Ctrl/Cmd+Shift+Z, or Ctrl+Y on Windows).
+            this.annotator.redo();
+            return;
           }
           break;
         }
@@ -1028,6 +1054,12 @@ export default class Keys {
     // keepAnchor while a selection is active so the fixed end is preserved.
     if (this.cursor.xLine >= 0 && this.cursor.yLine >= 0) {
       this.cursor.syncOffsetFromVisual(this.text, this.cursor.isSelected());
+    }
+
+    // Record the pre-edit state for undo when the document actually changed.
+    // Undo/redo keypresses returned earlier, so they are never recorded here.
+    if (this.text.value !== valueBefore) {
+      this.annotator.recordHistory(historyBefore, coalesceEdit);
     }
 
     this.annotator.draw();

--- a/packages/annotator/src/lib/Keys.ts
+++ b/packages/annotator/src/lib/Keys.ts
@@ -1,6 +1,6 @@
 import { EditMode } from "./constants";
 import Cursor, { DIRECTION } from "./Cursor";
-import Text, { CaretAffinity } from "./Text";
+import Text from "./Text";
 import Viewport from "./Viewport";
 
 /** Snapshot of caret before an arrow-key nudge (absolute line / column). */
@@ -100,55 +100,6 @@ export default class Keys {
   private compareDocPoints(a: CaretPoint, b: CaretPoint): number {
     if (a.yLine !== b.yLine) return a.yLine - b.yLine;
     return a.xLine - b.xLine;
-  }
-
-  /**
-   * Phase 3.2 — one document position to the RIGHT of `(offset, affinity)`,
-   * preserving soft-wrap caret affinity. At an UPSTREAM boundary the caret first
-   * steps DOWNSTREAM (same offset, start of the next visual line); otherwise it
-   * advances one offset, taking UPSTREAM affinity if it lands on a boundary.
-   */
-  private stepRightOffset(
-    offset: number,
-    affinity: CaretAffinity
-  ): { offset: number; affinity: CaretAffinity } {
-    if (
-      this.text.isWrapBoundary(offset) &&
-      affinity === CaretAffinity.UPSTREAM
-    ) {
-      return { offset, affinity: CaretAffinity.DOWNSTREAM };
-    }
-    if (offset >= this.text.value.length) {
-      return { offset, affinity };
-    }
-    const next = offset + 1;
-    return {
-      offset: next,
-      affinity: this.text.isWrapBoundary(next)
-        ? CaretAffinity.UPSTREAM
-        : CaretAffinity.DOWNSTREAM,
-    };
-  }
-
-  /**
-   * Phase 3.2 — one document position to the LEFT of `(offset, affinity)`. At a
-   * DOWNSTREAM boundary the caret first steps UPSTREAM (same offset, end of the
-   * previous visual line); otherwise it retreats one offset (DOWNSTREAM).
-   */
-  private stepLeftOffset(
-    offset: number,
-    affinity: CaretAffinity
-  ): { offset: number; affinity: CaretAffinity } {
-    if (
-      this.text.isWrapBoundary(offset) &&
-      affinity === CaretAffinity.DOWNSTREAM
-    ) {
-      return { offset, affinity: CaretAffinity.UPSTREAM };
-    }
-    if (offset <= 0) {
-      return { offset, affinity };
-    }
-    return { offset: offset - 1, affinity: CaretAffinity.DOWNSTREAM };
   }
 
   private docCaretMin(a: CaretPoint, b: CaretPoint): CaretPoint {
@@ -769,34 +720,17 @@ export default class Keys {
         }
       }
     } else if (!ctrlHandled) {
-      if (this.text.mode === EditMode.RAW) {
-        // RAW single-character left via the document-offset model (Phase 3.2).
-        const { offset, affinity } = this.text.offsetWithAffinityFromVisual(
-          originalXLine,
-          absY
-        );
-        if (offset >= 0) {
-          const prev = this.stepLeftOffset(offset, affinity);
-          const v = this.text.visualFromOffset(prev.offset, prev.affinity);
-          if (v) {
-            this.cursor.xLine = v.xLine;
-            this.cursor.yLine = v.yLine;
-            this.cursor.head = prev.offset;
-            this.cursor.headAffinity = prev.affinity;
-          }
-        }
-      } else {
-        // non-RAW: move by visual (parsed) column (skips hidden tag markup).
-        if (this.cursor.xLine <= 0) {
-          if (this.cursor.yLine > 0) {
-            this.cursor.yLine = Math.max(0, this.cursor.yLine - 1);
-            const line = this.text.getCurrentLine(this.viewport, this.cursor);
-            this.cursor.xLine = line?.length || 0;
-          }
-        } else {
-          this.cursor.move(offsetLeft, 0);
-        }
-      }
+      // Single visible column left, in any mode (see onArrowRight): step in
+      // visual space, then store the canonical raw offset.
+      const next = this.text.stepVisualLeft(originalXLine, absY);
+      this.cursor.xLine = next.xLine;
+      this.cursor.yLine = next.yLine;
+      const { offset, affinity } = this.text.offsetWithAffinityFromVisual(
+        next.xLine,
+        next.yLine
+      );
+      this.cursor.head = offset;
+      this.cursor.headAffinity = affinity;
     }
 
     if (shiftKey) {
@@ -978,49 +912,18 @@ export default class Keys {
         }
       }
     } else if (!ctrlKey && !ctrlRightHandled) {
-      if (this.text.mode === EditMode.RAW) {
-        // RAW single-character right via the document-offset model (Phase 3.2):
-        // advancing one offset naturally handles EOL->next-line, the soft-wrap
-        // affinity boundary, and the EOF clamp — replacing the old
-        // move/wrap/backtrack/clamp dance.
-        const { offset, affinity } = this.text.offsetWithAffinityFromVisual(
-          originalXLine,
-          absY
-        );
-        if (offset >= 0) {
-          const next = this.stepRightOffset(offset, affinity);
-          const v = this.text.visualFromOffset(next.offset, next.affinity);
-          if (v) {
-            this.cursor.xLine = v.xLine;
-            this.cursor.yLine = v.yLine;
-            this.cursor.head = next.offset;
-            this.cursor.headAffinity = next.affinity;
-          }
-        }
-      } else {
-        // non-RAW: move by visual (parsed) column so the caret skips hidden tag
-        // markup instead of stepping into it.
-        this.cursor.move(offsetRight, 0);
-
-        const line = this.text.getCurrentLine(this.viewport, this.cursor) || "";
-        let backupXLine = this.cursor.xLine;
-        let backupYLine = this.cursor.yLine;
-
-        if (line.length < this.cursor.xLine) {
-          if (this.cursor.yLine >= this.text.noLines - 1) {
-            // Already on the last visual line: clamp to EOL, never wrap past EOF.
-            this.cursor.xLine = line.length;
-          } else {
-            this.cursor.xLine = 0;
-            this.cursor.yLine++;
-          }
-        }
-
-        if (!this.text.cursorToIndex(this.viewport, this.cursor)) {
-          this.cursor.xLine = backupXLine - 1;
-          this.cursor.yLine = backupYLine;
-        }
-      }
+      // Single visible column right, in any mode: step in visual space (crosses
+      // line boundaries, honours the soft-wrap affinity, clamps at EOF) then
+      // store the canonical raw offset (which skips hidden markup in HIGHLIGHT).
+      const next = this.text.stepVisualRight(originalXLine, absY);
+      this.cursor.xLine = next.xLine;
+      this.cursor.yLine = next.yLine;
+      const { offset, affinity } = this.text.offsetWithAffinityFromVisual(
+        next.xLine,
+        next.yLine
+      );
+      this.cursor.head = offset;
+      this.cursor.headAffinity = affinity;
     }
 
     // Clamp cursor to document bounds.

--- a/packages/annotator/src/lib/Keys.ts
+++ b/packages/annotator/src/lib/Keys.ts
@@ -1,5 +1,5 @@
 import { EditMode } from "./constants";
-import Cursor, { DIRECTION } from "./Cursor";
+import Cursor from "./Cursor";
 import Text from "./Text";
 import Viewport from "./Viewport";
 
@@ -63,37 +63,28 @@ export default class Keys {
   }
 
   /**
-   * After shift+arrow, only the selection endpoint that was at the caret should
-   * move. Cmd+Shift+Left leaves the caret at line start while selectDirection is
-   * FORWARD (start before end on the same line), so updating selectEnd would drop
-   * the line-end anchor — match the pre-move caret to start or end instead.
+   * Phase 3 — after a navigation handler has moved the visual caret, make the
+   * canonical `head` offset follow it and either EXTEND the selection (shift:
+   * `anchor` stays fixed, selectStart/End are derived from anchor/head) or
+   * COLLAPSE it (anchor = head, selection cleared). Replaces the visual-anchor
+   * juggling of `extendShiftSelectionToCaret` — a stable anchor offset makes the
+   * anchor-crossing cases fall out for free.
    */
-  private extendShiftSelectionToCaret(prev: CaretPoint): void {
-    const s = this.cursor.selectStart;
-    const e = this.cursor.selectEnd;
-    if (!s || !e) {
-      return;
-    }
-
-    const next: CaretPoint = {
-      xLine: this.cursor.xLine,
-      yLine: this.cursor.yLine,
-    };
-
-    const atStart = prev.xLine === s.xLine && prev.yLine === s.yLine;
-    const atEnd = prev.xLine === e.xLine && prev.yLine === e.yLine;
-
-    if (atStart && !atEnd) {
-      this.cursor.selectStart = { ...next };
-    } else if (atEnd && !atStart) {
-      this.cursor.selectEnd = { ...next };
-    } else if (atStart && atEnd) {
-      this.cursor.selectStart = { xLine: prev.xLine, yLine: prev.yLine };
-      this.cursor.selectEnd = { ...next };
-    } else if (this.cursor.selectDirection === DIRECTION.BACKWARD) {
-      this.cursor.selectStart = { ...next };
+  private finishCaretMove(extendSelection: boolean): void {
+    const { offset, affinity } = this.text.offsetWithAffinityFromVisual(
+      this.cursor.xLine,
+      this.cursor.yLine
+    );
+    this.cursor.head = offset;
+    this.cursor.headAffinity = affinity;
+    if (extendSelection) {
+      this.cursor.syncVisualFromOffset(this.text);
     } else {
-      this.cursor.selectEnd = { ...next };
+      this.cursor.anchor = offset;
+      this.cursor.anchorAffinity = affinity;
+      this.cursor.selectStart = undefined;
+      this.cursor.selectEnd = undefined;
+      this.cursor.setTrueSelectionDirection();
     }
   }
 
@@ -128,9 +119,6 @@ export default class Keys {
   }
 
   onKeyHome({ ctrlKey, shiftKey }: { ctrlKey?: boolean; shiftKey?: boolean }) {
-    const originalXLine = this.cursor.xLine;
-    const originalAbsYLine = this.cursor.yLine;
-
     this.cursor.xLine = 0;
 
     if (ctrlKey) {
@@ -138,29 +126,10 @@ export default class Keys {
       this.viewport.lineStart = 0;
     }
 
-    if (shiftKey) {
-      if (this.cursor.selectDirection === undefined) {
-        this.cursor.selectStart = {
-          xLine: originalXLine,
-          yLine: originalAbsYLine,
-        };
-      }
-      this.cursor.selectEnd = {
-        xLine: 0,
-        yLine: this.cursor.yLine,
-      };
-    } else {
-      this.cursor.selectStart = undefined;
-      this.cursor.selectEnd = undefined;
-    }
-
-    this.cursor.setTrueSelectionDirection();
+    this.finishCaretMove(!!shiftKey);
   }
 
   onKeyEnd({ ctrlKey, shiftKey }: { ctrlKey?: boolean; shiftKey?: boolean }) {
-    const originalXLine = this.cursor.xLine;
-    const originalAbsYLine = this.cursor.yLine;
-
     if (ctrlKey) {
       const lastLine = this.text.noLines > 0 ? this.text.noLines - 1 : 0;
       this.cursor.yLine = lastLine;
@@ -171,23 +140,7 @@ export default class Keys {
     const line = this.text.getCurrentLine(this.viewport, this.cursor) || "";
     this.cursor.xLine = line.length;
 
-    if (shiftKey) {
-      if (this.cursor.selectDirection === undefined) {
-        this.cursor.selectStart = {
-          xLine: originalXLine,
-          yLine: originalAbsYLine,
-        };
-      }
-      this.cursor.selectEnd = {
-        xLine: this.cursor.xLine,
-        yLine: this.cursor.yLine,
-      };
-    } else {
-      this.cursor.selectStart = undefined;
-      this.cursor.selectEnd = undefined;
-    }
-
-    this.cursor.setTrueSelectionDirection();
+    this.finishCaretMove(!!shiftKey);
   }
 
   onKeyBackspace({
@@ -274,8 +227,7 @@ export default class Keys {
   }
 
   onKeyPgUp({ shiftKey }: { ctrlKey?: boolean; shiftKey?: boolean }) {
-    const originalXLine = this.cursor.xLine;
-    const originalAbsYLine = this.cursor.yLine;
+    this.cursor.reconcileOffsetsFromVisual(this.text);
     const pageStep = this.viewport.noLines;
 
     this.cursor.yLine = Math.max(0, this.cursor.yLine - pageStep);
@@ -288,29 +240,8 @@ export default class Keys {
       this.cursor.xLine = line.length;
     }
 
-    if (shiftKey) {
-      if (!this.cursor.selectStart || !this.cursor.selectEnd) {
-        this.cursor.selectStart = {
-          xLine: originalXLine,
-          yLine: originalAbsYLine,
-        };
-        this.cursor.selectEnd = {
-          xLine: this.cursor.xLine,
-          yLine: this.cursor.yLine,
-        };
-      } else {
-        this.extendShiftSelectionToCaret({
-          xLine: originalXLine,
-          yLine: originalAbsYLine,
-        });
-      }
-    } else {
-      this.cursor.selectStart = undefined;
-      this.cursor.selectEnd = undefined;
-    }
-
+    this.finishCaretMove(!!shiftKey);
     this.scrollCursorIntoView();
-    this.cursor.setTrueSelectionDirection();
   }
 
   onKeyPgDown({
@@ -319,8 +250,7 @@ export default class Keys {
     ctrlKey?: boolean;
     shiftKey?: boolean;
   }) {
-    const originalXLine = this.cursor.xLine;
-    const originalAbsYLine = this.cursor.yLine;
+    this.cursor.reconcileOffsetsFromVisual(this.text);
     const pageStep = this.viewport.noLines;
     const maxLine = Math.max(0, this.text.noLines - 1);
 
@@ -331,29 +261,8 @@ export default class Keys {
       this.cursor.xLine = line.length;
     }
 
-    if (shiftKey) {
-      if (!this.cursor.selectStart || !this.cursor.selectEnd) {
-        this.cursor.selectStart = {
-          xLine: originalXLine,
-          yLine: originalAbsYLine,
-        };
-        this.cursor.selectEnd = {
-          xLine: this.cursor.xLine,
-          yLine: this.cursor.yLine,
-        };
-      } else {
-        this.extendShiftSelectionToCaret({
-          xLine: originalXLine,
-          yLine: originalAbsYLine,
-        });
-      }
-    } else {
-      this.cursor.selectStart = undefined;
-      this.cursor.selectEnd = undefined;
-    }
-
+    this.finishCaretMove(!!shiftKey);
     this.scrollCursorIntoView();
-    this.cursor.setTrueSelectionDirection();
   }
 
   onKeyEnter() {
@@ -456,29 +365,8 @@ export default class Keys {
     const line = this.text.getCurrentLine(this.viewport, this.cursor) || "";
     this.cursor.xLine = Math.min(this.cursor.goalColumn, line.length);
 
-    if (shiftKey) {
-      if (!this.cursor.selectStart || !this.cursor.selectEnd) {
-        this.cursor.selectStart = {
-          xLine: originalXLine,
-          yLine: originalAbsYline,
-        };
-        this.cursor.selectEnd = {
-          xLine: this.cursor.xLine,
-          yLine: this.cursor.yLine,
-        };
-      } else {
-        this.extendShiftSelectionToCaret({
-          xLine: originalXLine,
-          yLine: originalAbsYline,
-        });
-      }
-    } else {
-      this.cursor.selectStart = undefined;
-      this.cursor.selectEnd = undefined;
-    }
-
+    this.finishCaretMove(!!shiftKey);
     this.scrollCursorIntoView();
-    this.cursor.setTrueSelectionDirection();
   }
 
   onArrowDown({
@@ -564,29 +452,8 @@ export default class Keys {
       this.cursor.xLine = Math.min(this.cursor.goalColumn, line.length);
     }
 
-    if (shiftKey) {
-      if (!this.cursor.selectStart || !this.cursor.selectEnd) {
-        this.cursor.selectStart = {
-          xLine: originalXLine,
-          yLine: originalAbsYline,
-        };
-        this.cursor.selectEnd = {
-          xLine: this.cursor.xLine,
-          yLine: this.cursor.yLine,
-        };
-      } else {
-        this.extendShiftSelectionToCaret({
-          xLine: originalXLine,
-          yLine: originalAbsYline,
-        });
-      }
-    } else {
-      this.cursor.selectStart = undefined;
-      this.cursor.selectEnd = undefined;
-    }
-
+    this.finishCaretMove(!!shiftKey);
     this.scrollCursorIntoView();
-    this.cursor.setTrueSelectionDirection();
   }
 
   /**
@@ -607,6 +474,9 @@ export default class Keys {
     shiftKey?: boolean;
     metaKey?: boolean;
   }) {
+    // Offsets may be stale when called directly (tests, onKeyBackspace) rather
+    // than via onKeyDown — reconcile so anchor/head reflect the current caret.
+    this.cursor.reconcileOffsetsFromVisual(this.text);
     const absY = this.cursor.yLine;
     if (metaKey && shiftKey) {
       const [hStart, hEnd] = this.cursor.getAbsBounds();
@@ -750,37 +620,20 @@ export default class Keys {
     }
 
     if (shiftKey) {
-      if (!this.cursor.selectStart || !this.cursor.selectEnd) {
-        this.cursor.selectStart = {
-          xLine: originalXLine,
-          yLine: absY,
-        };
-        this.cursor.selectEnd = {
-          xLine: this.cursor.xLine,
-          yLine: this.cursor.yLine,
-        };
-      } else {
-        this.extendShiftSelectionToCaret({
-          xLine: originalXLine,
-          yLine: absY,
-        });
-      }
+      this.finishCaretMove(true);
     } else {
+      // Non-shift word-jump with an active selection collapses to its left edge.
       if (this.cursor.isSelected()) {
         const [docStart] = this.cursor.getAbsBounds();
         if (docStart) {
           this.cursor.xLine = docStart.xLine;
           this.cursor.yLine = docStart.yLine;
         }
-        offsetLeft = 0;
       }
-
-      this.cursor.selectStart = undefined;
-      this.cursor.selectEnd = undefined;
+      this.finishCaretMove(false);
     }
 
     this.scrollCursorIntoView();
-    this.cursor.setTrueSelectionDirection();
   }
 
   /**
@@ -801,6 +654,8 @@ export default class Keys {
     shiftKey?: boolean;
     metaKey?: boolean;
   }) {
+    // See onArrowLeft: reconcile offsets for direct (non-onKeyDown) callers.
+    this.cursor.reconcileOffsetsFromVisual(this.text);
     const absY = this.cursor.yLine;
     const line = this.text.getLine(absY) ?? "";
     if (metaKey && shiftKey) {
@@ -972,37 +827,20 @@ export default class Keys {
     );
 
     if (shiftKey) {
-      if (!this.cursor.selectStart || !this.cursor.selectEnd) {
-        this.cursor.selectStart = {
-          xLine: originalXLine,
-          yLine: absY,
-        };
-        this.cursor.selectEnd = {
-          xLine: this.cursor.xLine,
-          yLine: this.cursor.yLine,
-        };
-      } else {
-        this.extendShiftSelectionToCaret({
-          xLine: originalXLine,
-          yLine: absY,
-        });
-      }
+      this.finishCaretMove(true);
     } else {
+      // Non-shift word-jump with an active selection collapses to its right edge.
       if (this.cursor.isSelected()) {
         const [, docEnd] = this.cursor.getAbsBounds();
         if (docEnd) {
           this.cursor.xLine = docEnd.xLine;
           this.cursor.yLine = docEnd.yLine;
         }
-        offsetRight = 0;
       }
-
-      this.cursor.selectStart = undefined;
-      this.cursor.selectEnd = undefined;
+      this.finishCaretMove(false);
     }
 
     this.scrollCursorIntoView();
-    this.cursor.setTrueSelectionDirection();
   }
 
   onKeyDown(e: KeyboardEvent) {

--- a/packages/annotator/src/lib/Keys.ts
+++ b/packages/annotator/src/lib/Keys.ts
@@ -1,6 +1,6 @@
 import { EditMode } from "./constants";
 import Cursor, { DIRECTION } from "./Cursor";
-import Text from "./Text";
+import Text, { CaretAffinity } from "./Text";
 import Viewport from "./Viewport";
 
 /** Snapshot of caret before an arrow-key nudge (absolute line / column). */
@@ -100,6 +100,55 @@ export default class Keys {
   private compareDocPoints(a: CaretPoint, b: CaretPoint): number {
     if (a.yLine !== b.yLine) return a.yLine - b.yLine;
     return a.xLine - b.xLine;
+  }
+
+  /**
+   * Phase 3.2 — one document position to the RIGHT of `(offset, affinity)`,
+   * preserving soft-wrap caret affinity. At an UPSTREAM boundary the caret first
+   * steps DOWNSTREAM (same offset, start of the next visual line); otherwise it
+   * advances one offset, taking UPSTREAM affinity if it lands on a boundary.
+   */
+  private stepRightOffset(
+    offset: number,
+    affinity: CaretAffinity
+  ): { offset: number; affinity: CaretAffinity } {
+    if (
+      this.text.isWrapBoundary(offset) &&
+      affinity === CaretAffinity.UPSTREAM
+    ) {
+      return { offset, affinity: CaretAffinity.DOWNSTREAM };
+    }
+    if (offset >= this.text.value.length) {
+      return { offset, affinity };
+    }
+    const next = offset + 1;
+    return {
+      offset: next,
+      affinity: this.text.isWrapBoundary(next)
+        ? CaretAffinity.UPSTREAM
+        : CaretAffinity.DOWNSTREAM,
+    };
+  }
+
+  /**
+   * Phase 3.2 — one document position to the LEFT of `(offset, affinity)`. At a
+   * DOWNSTREAM boundary the caret first steps UPSTREAM (same offset, end of the
+   * previous visual line); otherwise it retreats one offset (DOWNSTREAM).
+   */
+  private stepLeftOffset(
+    offset: number,
+    affinity: CaretAffinity
+  ): { offset: number; affinity: CaretAffinity } {
+    if (
+      this.text.isWrapBoundary(offset) &&
+      affinity === CaretAffinity.DOWNSTREAM
+    ) {
+      return { offset, affinity: CaretAffinity.UPSTREAM };
+    }
+    if (offset <= 0) {
+      return { offset, affinity };
+    }
+    return { offset: offset - 1, affinity: CaretAffinity.DOWNSTREAM };
   }
 
   private docCaretMin(a: CaretPoint, b: CaretPoint): CaretPoint {
@@ -708,15 +757,33 @@ export default class Keys {
         }
       }
     } else if (!ctrlHandled) {
-      // Single-character left movement (no ctrl/alt)
-      if (this.cursor.xLine <= 0) {
-        if (this.cursor.yLine > 0) {
-          this.cursor.yLine = Math.max(0, this.cursor.yLine - 1);
-          const line = this.text.getCurrentLine(this.viewport, this.cursor);
-          this.cursor.xLine = line?.length || 0;
+      if (this.text.mode === EditMode.RAW) {
+        // RAW single-character left via the document-offset model (Phase 3.2).
+        const { offset, affinity } = this.text.offsetWithAffinityFromVisual(
+          originalXLine,
+          absY
+        );
+        if (offset >= 0) {
+          const prev = this.stepLeftOffset(offset, affinity);
+          const v = this.text.visualFromOffset(prev.offset, prev.affinity);
+          if (v) {
+            this.cursor.xLine = v.xLine;
+            this.cursor.yLine = v.yLine;
+            this.cursor.head = prev.offset;
+            this.cursor.headAffinity = prev.affinity;
+          }
         }
       } else {
-        this.cursor.move(offsetLeft, 0);
+        // non-RAW: move by visual (parsed) column (skips hidden tag markup).
+        if (this.cursor.xLine <= 0) {
+          if (this.cursor.yLine > 0) {
+            this.cursor.yLine = Math.max(0, this.cursor.yLine - 1);
+            const line = this.text.getCurrentLine(this.viewport, this.cursor);
+            this.cursor.xLine = line?.length || 0;
+          }
+        } else {
+          this.cursor.move(offsetLeft, 0);
+        }
       }
     }
 
@@ -899,26 +966,48 @@ export default class Keys {
         }
       }
     } else if (!ctrlKey && !ctrlRightHandled) {
-      // Single-character right movement (no ctrl/alt)
-      this.cursor.move(offsetRight, 0);
-
-      const line = this.text.getCurrentLine(this.viewport, this.cursor) || "";
-      let backupXLine = this.cursor.xLine;
-      let backupYLine = this.cursor.yLine;
-
-      if (line.length < this.cursor.xLine) {
-        if (this.cursor.yLine >= this.text.noLines - 1) {
-          // Already on the last visual line: clamp to EOL, never wrap past EOF.
-          this.cursor.xLine = line.length;
-        } else {
-          this.cursor.xLine = 0;
-          this.cursor.yLine++;
+      if (this.text.mode === EditMode.RAW) {
+        // RAW single-character right via the document-offset model (Phase 3.2):
+        // advancing one offset naturally handles EOL->next-line, the soft-wrap
+        // affinity boundary, and the EOF clamp — replacing the old
+        // move/wrap/backtrack/clamp dance.
+        const { offset, affinity } = this.text.offsetWithAffinityFromVisual(
+          originalXLine,
+          absY
+        );
+        if (offset >= 0) {
+          const next = this.stepRightOffset(offset, affinity);
+          const v = this.text.visualFromOffset(next.offset, next.affinity);
+          if (v) {
+            this.cursor.xLine = v.xLine;
+            this.cursor.yLine = v.yLine;
+            this.cursor.head = next.offset;
+            this.cursor.headAffinity = next.affinity;
+          }
         }
-      }
+      } else {
+        // non-RAW: move by visual (parsed) column so the caret skips hidden tag
+        // markup instead of stepping into it.
+        this.cursor.move(offsetRight, 0);
 
-      if (!this.text.cursorToIndex(this.viewport, this.cursor)) {
-        this.cursor.xLine = backupXLine - 1;
-        this.cursor.yLine = backupYLine;
+        const line = this.text.getCurrentLine(this.viewport, this.cursor) || "";
+        let backupXLine = this.cursor.xLine;
+        let backupYLine = this.cursor.yLine;
+
+        if (line.length < this.cursor.xLine) {
+          if (this.cursor.yLine >= this.text.noLines - 1) {
+            // Already on the last visual line: clamp to EOL, never wrap past EOF.
+            this.cursor.xLine = line.length;
+          } else {
+            this.cursor.xLine = 0;
+            this.cursor.yLine++;
+          }
+        }
+
+        if (!this.text.cursorToIndex(this.viewport, this.cursor)) {
+          this.cursor.xLine = backupXLine - 1;
+          this.cursor.yLine = backupYLine;
+        }
       }
     }
 

--- a/packages/annotator/src/lib/Keys.ts
+++ b/packages/annotator/src/lib/Keys.ts
@@ -1153,6 +1153,16 @@ export default class Keys {
     ) {
       this.annotator.onTextChangeCb(this.text.value);
     }
+
+    // Keep the canonical document offset (head/anchor) in sync with the final
+    // visual caret after ANY key. Edits set head exactly via moveToOffset and
+    // re-deriving from the visual is idempotent; pure-visual navigation
+    // (vertical, Home/End, word-jump, page, mouse-independent) is captured here.
+    // keepAnchor while a selection is active so the fixed end is preserved.
+    if (this.cursor.xLine >= 0 && this.cursor.yLine >= 0) {
+      this.cursor.syncOffsetFromVisual(this.text, this.cursor.isSelected());
+    }
+
     this.annotator.draw();
   }
 }

--- a/packages/annotator/src/lib/Keys.ts
+++ b/packages/annotator/src/lib/Keys.ts
@@ -415,9 +415,21 @@ export default class Keys {
       this.cursor.reset();
       this.cursor.setPosition(area[0].xLine, area[0].yLine);
     }
-    this.text.insertNewline(this.viewport, this.cursor);
 
-    this.cursor.moveToNewline();
+    // The newline is inserted at the caret's raw offset; the caret follows it to
+    // offset+1. Deriving the visual position from that offset is always in
+    // bounds — unlike the old blind `moveToNewline` (yLine += 1), which
+    // overshoots when the split re-wraps the prefix into fewer visual lines.
+    const insertOffset = this.text.offsetFromVisual(
+      this.cursor.xLine,
+      this.cursor.yLine
+    );
+    this.text.insertNewline(this.viewport, this.cursor);
+    if (insertOffset >= 0) {
+      this.cursor.moveToOffset(this.text, insertOffset + 1);
+    } else {
+      this.cursor.moveToNewline();
+    }
     this.scrollCursorIntoView();
   }
 
@@ -1147,9 +1159,17 @@ export default class Keys {
             this.cursor.reset();
             this.cursor.setPosition(sel[0].xLine, sel[0].yLine);
           }
+          const tabOffset = this.text.offsetFromVisual(
+            this.cursor.xLine,
+            this.cursor.yLine
+          );
           this.text.insertText(this.viewport, this.cursor, "\t");
-          this.cursor.move(+1, 0);
-          this.cursor.fixOutOfBounds(this.viewport, this.text);
+          if (tabOffset >= 0) {
+            this.cursor.moveToOffset(this.text, tabOffset + 1);
+          } else {
+            this.cursor.move(+1, 0);
+            this.cursor.fixOutOfBounds(this.viewport, this.text);
+          }
           this.scrollCursorIntoView();
         }
         break;
@@ -1200,9 +1220,21 @@ export default class Keys {
             this.cursor.setPosition(area[0].xLine, area[0].yLine);
           }
 
+          // Insert at the caret's raw offset and move to offset + length via the
+          // offset model. This keeps the caret in bounds after a re-wrap and
+          // clears any stale (collapsed) selection — replacing move() +
+          // fixOutOfBounds, which left both to drift.
+          const insertOffset = this.text.offsetFromVisual(
+            this.cursor.xLine,
+            this.cursor.yLine
+          );
           this.text.insertText(this.viewport, this.cursor, key);
-          this.cursor.move(+1, 0);
-          this.cursor.fixOutOfBounds(this.viewport, this.text);
+          if (insertOffset >= 0) {
+            this.cursor.moveToOffset(this.text, insertOffset + key.length);
+          } else {
+            this.cursor.move(+1, 0);
+            this.cursor.fixOutOfBounds(this.viewport, this.text);
+          }
 
           // When typing moves the cursor outside of the current viewport,
           // keep behaviour consistent with arrow keys and scroll so that

--- a/packages/annotator/src/lib/Keys.ts
+++ b/packages/annotator/src/lib/Keys.ts
@@ -944,12 +944,8 @@ export default class Keys {
             this.cursor.yLine
           );
           this.text.insertText(this.viewport, this.cursor, "\t");
-          if (tabOffset >= 0) {
-            this.cursor.moveToOffset(this.text, tabOffset + 1);
-          } else {
-            this.cursor.move(+1, 0);
-            this.cursor.fixOutOfBounds(this.viewport, this.text);
-          }
+          const tabAt = tabOffset >= 0 ? tabOffset : this.cursor.head;
+          this.cursor.moveToOffset(this.text, tabAt + 1);
           this.scrollCursorIntoView();
         }
         break;
@@ -1009,12 +1005,9 @@ export default class Keys {
             this.cursor.yLine
           );
           this.text.insertText(this.viewport, this.cursor, key);
-          if (insertOffset >= 0) {
-            this.cursor.moveToOffset(this.text, insertOffset + key.length);
-          } else {
-            this.cursor.move(+1, 0);
-            this.cursor.fixOutOfBounds(this.viewport, this.text);
-          }
+          const insertAt =
+            insertOffset >= 0 ? insertOffset : this.cursor.head;
+          this.cursor.moveToOffset(this.text, insertAt + key.length);
 
           // When typing moves the cursor outside of the current viewport,
           // keep behaviour consistent with arrow keys and scroll so that

--- a/packages/annotator/src/lib/Keys.ts
+++ b/packages/annotator/src/lib/Keys.ts
@@ -720,17 +720,33 @@ export default class Keys {
         }
       }
     } else if (!ctrlHandled) {
-      // Single visible column left, in any mode (see onArrowRight): step in
-      // visual space, then store the canonical raw offset.
-      const next = this.text.stepVisualLeft(originalXLine, absY);
-      this.cursor.xLine = next.xLine;
-      this.cursor.yLine = next.yLine;
-      const { offset, affinity } = this.text.offsetWithAffinityFromVisual(
-        next.xLine,
-        next.yLine
-      );
-      this.cursor.head = offset;
-      this.cursor.headAffinity = affinity;
+      // Single visible column left via the anchor/head offset model (any mode).
+      const hadSelection = this.cursor.anchor !== this.cursor.head;
+      if (!shiftKey && hadSelection) {
+        // Collapse to the left edge of the selection (no further move).
+        this.cursor.moveToOffset(
+          this.text,
+          Math.min(this.cursor.anchor, this.cursor.head)
+        );
+      } else {
+        const next = this.text.stepVisualLeft(
+          this.cursor.xLine,
+          this.cursor.yLine
+        );
+        const { offset, affinity } = this.text.offsetWithAffinityFromVisual(
+          next.xLine,
+          next.yLine
+        );
+        this.cursor.head = offset;
+        this.cursor.headAffinity = affinity;
+        if (!shiftKey) {
+          this.cursor.anchor = offset;
+          this.cursor.anchorAffinity = affinity;
+        }
+        this.cursor.syncVisualFromOffset(this.text);
+      }
+      this.scrollCursorIntoView();
+      return;
     }
 
     if (shiftKey) {
@@ -912,18 +928,36 @@ export default class Keys {
         }
       }
     } else if (!ctrlKey && !ctrlRightHandled) {
-      // Single visible column right, in any mode: step in visual space (crosses
-      // line boundaries, honours the soft-wrap affinity, clamps at EOF) then
-      // store the canonical raw offset (which skips hidden markup in HIGHLIGHT).
-      const next = this.text.stepVisualRight(originalXLine, absY);
-      this.cursor.xLine = next.xLine;
-      this.cursor.yLine = next.yLine;
-      const { offset, affinity } = this.text.offsetWithAffinityFromVisual(
-        next.xLine,
-        next.yLine
-      );
-      this.cursor.head = offset;
-      this.cursor.headAffinity = affinity;
+      // Single visible column right via the anchor/head offset model (any mode).
+      const hadSelection = this.cursor.anchor !== this.cursor.head;
+      if (!shiftKey && hadSelection) {
+        // Collapse to the right edge of the selection (no further move).
+        this.cursor.moveToOffset(
+          this.text,
+          Math.max(this.cursor.anchor, this.cursor.head)
+        );
+      } else {
+        // Step one visible column right (crosses line boundaries, honours the
+        // soft-wrap affinity, clamps at EOF), then store the canonical offset.
+        const next = this.text.stepVisualRight(
+          this.cursor.xLine,
+          this.cursor.yLine
+        );
+        const { offset, affinity } = this.text.offsetWithAffinityFromVisual(
+          next.xLine,
+          next.yLine
+        );
+        this.cursor.head = offset;
+        this.cursor.headAffinity = affinity;
+        if (!shiftKey) {
+          this.cursor.anchor = offset;
+          this.cursor.anchorAffinity = affinity;
+        }
+        // Derive caret + selectStart/selectEnd from anchor/head.
+        this.cursor.syncVisualFromOffset(this.text);
+      }
+      this.scrollCursorIntoView();
+      return;
     }
 
     // Clamp cursor to document bounds.
@@ -1002,6 +1036,11 @@ export default class Keys {
     let key: Key = e.key as Key;
     // Snapshot to fire onTextChangeCb only when the document actually changes.
     const valueBefore = this.text.value;
+
+    // Make the canonical head/anchor offsets authoritative before handling the
+    // key — the caret/selection may have been set visually (setPosition, mouse,
+    // setMode) without updating the offsets.
+    this.cursor.reconcileOffsetsFromVisual(this.text);
 
     // Any key other than vertical movement drops the goal column; ArrowUp/Down
     // manage it themselves so the desired column survives short lines.

--- a/packages/annotator/src/lib/Keys.ts
+++ b/packages/annotator/src/lib/Keys.ts
@@ -285,11 +285,8 @@ export default class Keys {
       this.cursor.yLine
     );
     this.text.insertNewline(this.viewport, this.cursor);
-    if (insertOffset >= 0) {
-      this.cursor.moveToOffset(this.text, insertOffset + 1);
-    } else {
-      this.cursor.moveToNewline();
-    }
+    const newlineAt = insertOffset >= 0 ? insertOffset : this.cursor.head;
+    this.cursor.moveToOffset(this.text, newlineAt + 1);
     this.scrollCursorIntoView();
   }
 

--- a/packages/annotator/src/lib/SettingsOverlay.ts
+++ b/packages/annotator/src/lib/SettingsOverlay.ts
@@ -1,0 +1,307 @@
+/**
+ * Modal settings overlay for the annotator.
+ *
+ * Like ContextMenu, the editor renders to a canvas, so this builds a centered
+ * DOM box on top of a dimmed backdrop. It is self-contained (no host wiring) and
+ * closes on backdrop click, the × button, or Escape.
+ *
+ * Settings are passed in as a small declarative schema (currently just a
+ * segmented control); add new control types here as the options grow.
+ */
+
+/** A single-choice segmented control (e.g. caret width: 1px / 2px / 3px). */
+export interface SegmentedSetting {
+  type: "segmented";
+  label: string;
+  options: { label: string; value: number }[];
+  /** Currently-selected value (must match one of `options[].value`). */
+  value: number;
+  onChange: (value: number) => void;
+}
+
+/** A native color picker (`<input type="color">`). */
+export interface ColorSetting {
+  type: "color";
+  label: string;
+  /** Current color as a `#rrggbb` hex string. */
+  value: string;
+  onChange: (hex: string) => void;
+}
+
+export type SettingControl = SegmentedSetting | ColorSetting;
+
+/** A button rendered in the overlay footer (e.g. "Reset to defaults"). */
+export interface FooterAction {
+  label: string;
+  onClick: () => void;
+}
+
+export class SettingsOverlay {
+  private backdrop: HTMLDivElement | null = null;
+
+  /** Whether the overlay is currently shown. */
+  get isOpen(): boolean {
+    return this.backdrop !== null;
+  }
+
+  /**
+   * Show the overlay with the given settings. A previously-open instance is
+   * replaced. When `anchor` is given the backdrop covers only that element's
+   * box (e.g. the canvas) instead of the whole viewport.
+   */
+  open(
+    settings: SettingControl[] = [],
+    anchor?: HTMLElement,
+    footer: FooterAction[] = []
+  ): void {
+    this.close();
+
+    const backdrop = document.createElement("div");
+    Object.assign(backdrop.style, {
+      position: "fixed",
+      zIndex: "10001",
+      display: "flex",
+      alignItems: "center",
+      justifyContent: "center",
+      background: "rgba(0, 0, 0, 0.35)",
+    } as Partial<CSSStyleDeclaration>);
+
+    if (anchor) {
+      const rect = anchor.getBoundingClientRect();
+      Object.assign(backdrop.style, {
+        left: `${rect.left}px`,
+        top: `${rect.top}px`,
+        width: `${rect.width}px`,
+        height: `${rect.height}px`,
+        overflow: "hidden",
+      } as Partial<CSSStyleDeclaration>);
+    } else {
+      (backdrop.style as Partial<CSSStyleDeclaration>).inset = "0";
+    }
+
+    const box = document.createElement("div");
+    Object.assign(box.style, {
+      maxWidth: "90%",
+      maxHeight: "90%",
+      overflow: "auto",
+      background: "#ffffff",
+      border: "1px solid #d0d0d0",
+      borderRadius: "6px",
+      boxShadow: "0 6px 24px rgba(0, 0, 0, 0.25)",
+      font: '13px "Roboto Mono", monospace',
+      color: "#222",
+    } as Partial<CSSStyleDeclaration>);
+    // Clicks inside the box must not fall through to the backdrop dismiss.
+    box.addEventListener("mousedown", (e) => e.stopPropagation());
+
+    box.appendChild(this.buildHeader());
+
+    const body = document.createElement("div");
+    Object.assign(body.style, {
+      padding: "16px 14px",
+      display: "flex",
+      flexDirection: "column",
+      gap: "14px",
+    } as Partial<CSSStyleDeclaration>);
+
+    if (settings.length === 0) {
+      body.textContent = "No settings yet.";
+      (body.style as Partial<CSSStyleDeclaration>).color = "#888";
+    } else {
+      for (const setting of settings) {
+        body.appendChild(
+          setting.type === "color"
+            ? this.buildColor(setting)
+            : this.buildSegmented(setting)
+        );
+      }
+    }
+
+    box.appendChild(body);
+
+    if (footer.length > 0) {
+      box.appendChild(this.buildFooter(footer));
+    }
+
+    backdrop.appendChild(box);
+    backdrop.addEventListener("mousedown", () => this.close());
+
+    document.body.appendChild(backdrop);
+    this.backdrop = backdrop;
+
+    document.addEventListener("keydown", this.onKeyDown, true);
+  }
+
+  /** Remove the overlay and detach listeners. Safe to call when already closed. */
+  close(): void {
+    if (!this.backdrop) {
+      return;
+    }
+    this.backdrop.remove();
+    this.backdrop = null;
+    document.removeEventListener("keydown", this.onKeyDown, true);
+  }
+
+  private buildHeader(): HTMLDivElement {
+    const header = document.createElement("div");
+    Object.assign(header.style, {
+      display: "flex",
+      alignItems: "center",
+      justifyContent: "space-between",
+      padding: "10px 14px",
+      borderBottom: "1px solid #e0e0e0",
+      fontWeight: "bold",
+    } as Partial<CSSStyleDeclaration>);
+
+    const title = document.createElement("span");
+    title.textContent = "Options";
+
+    const closeBtn = document.createElement("span");
+    closeBtn.textContent = "×";
+    Object.assign(closeBtn.style, {
+      cursor: "pointer",
+      padding: "0 4px",
+      fontSize: "18px",
+      lineHeight: "1",
+    } as Partial<CSSStyleDeclaration>);
+    closeBtn.addEventListener("mousedown", (e) => {
+      e.preventDefault();
+      e.stopPropagation();
+      this.close();
+    });
+
+    header.appendChild(title);
+    header.appendChild(closeBtn);
+    return header;
+  }
+
+  /** Render the footer with action buttons (e.g. "Reset to defaults"). */
+  private buildFooter(actions: FooterAction[]): HTMLDivElement {
+    const footer = document.createElement("div");
+    Object.assign(footer.style, {
+      display: "flex",
+      justifyContent: "flex-end",
+      gap: "8px",
+      padding: "10px 14px",
+      borderTop: "1px solid #e0e0e0",
+    } as Partial<CSSStyleDeclaration>);
+
+    for (const action of actions) {
+      const btn = document.createElement("button");
+      btn.type = "button";
+      btn.textContent = action.label;
+      Object.assign(btn.style, {
+        font: "inherit",
+        padding: "5px 12px",
+        border: "1px solid #c0c0c0",
+        borderRadius: "4px",
+        background: "#f5f5f5",
+        cursor: "pointer",
+      } as Partial<CSSStyleDeclaration>);
+      btn.addEventListener("mousedown", (e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        action.onClick();
+      });
+      footer.appendChild(btn);
+    }
+
+    return footer;
+  }
+
+  /** A labelled setting row: `<label>` on the left, control on the right. */
+  private buildRow(labelText: string): { row: HTMLDivElement; label: HTMLSpanElement } {
+    const row = document.createElement("div");
+    Object.assign(row.style, {
+      display: "flex",
+      alignItems: "center",
+      justifyContent: "space-between",
+      gap: "12px",
+    } as Partial<CSSStyleDeclaration>);
+
+    const label = document.createElement("span");
+    label.textContent = labelText;
+    row.appendChild(label);
+    return { row, label };
+  }
+
+  /** Render a labelled native color picker; picking a color fires onChange. */
+  private buildColor(setting: ColorSetting): HTMLDivElement {
+    const { row } = this.buildRow(setting.label);
+
+    const input = document.createElement("input");
+    input.type = "color";
+    input.value = setting.value;
+    Object.assign(input.style, {
+      width: "40px",
+      height: "24px",
+      padding: "0",
+      border: "1px solid #c0c0c0",
+      borderRadius: "4px",
+      cursor: "pointer",
+      background: "none",
+    } as Partial<CSSStyleDeclaration>);
+    // Keep clicks inside the control from dismissing the backdrop.
+    input.addEventListener("mousedown", (e) => e.stopPropagation());
+    input.addEventListener("input", () => setting.onChange(input.value));
+
+    row.appendChild(input);
+    return row;
+  }
+
+  /** Render a labelled segmented control; clicking a segment fires onChange. */
+  private buildSegmented(setting: SegmentedSetting): HTMLDivElement {
+    const { row } = this.buildRow(setting.label);
+
+    const group = document.createElement("div");
+    Object.assign(group.style, {
+      display: "inline-flex",
+      border: "1px solid #c0c0c0",
+      borderRadius: "4px",
+      overflow: "hidden",
+    } as Partial<CSSStyleDeclaration>);
+
+    let selected = setting.value;
+    const segments: { value: number; el: HTMLElement }[] = [];
+
+    const restyle = () => {
+      for (const seg of segments) {
+        const active = seg.value === selected;
+        Object.assign(seg.el.style, {
+          background: active ? "#1971c2" : "#ffffff",
+          color: active ? "#ffffff" : "#222",
+        } as Partial<CSSStyleDeclaration>);
+      }
+    };
+
+    for (const opt of setting.options) {
+      const seg = document.createElement("div");
+      seg.textContent = opt.label;
+      Object.assign(seg.style, {
+        padding: "4px 12px",
+        cursor: "pointer",
+        borderLeft: segments.length ? "1px solid #c0c0c0" : "none",
+      } as Partial<CSSStyleDeclaration>);
+      seg.addEventListener("mousedown", (e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        selected = opt.value;
+        restyle();
+        setting.onChange(opt.value);
+      });
+      segments.push({ value: opt.value, el: seg });
+      group.appendChild(seg);
+    }
+
+    restyle();
+
+    row.appendChild(group);
+    return row;
+  }
+
+  private readonly onKeyDown = (e: KeyboardEvent) => {
+    if (e.key === "Escape") {
+      this.close();
+    }
+  };
+}

--- a/packages/annotator/src/lib/Text.ts
+++ b/packages/annotator/src/lib/Text.ts
@@ -200,8 +200,9 @@ export class Tag {
  * A segment is a portion of text that gets processed and displayed as lines.
  */
 export class Segment {
-  lineStart: number = -1; // incl.
-  lineEnd: number = -1; // incl.
+  lineStart: number = -1; // inclusive — first visual line index of this segment
+  /** Exclusive — one past the last visual line index of this segment (`lineStart + lines.length`). */
+  lineEndExclusive: number = -1;
   raw: string;
   parsed: string = "";
   openingTags: Tag[] = [];
@@ -341,7 +342,7 @@ class Text {
   getLine(lineIndex: number): string {
     // Find the segment that contains the line
     const segmentIndex = this.segments.findIndex(
-      (s) => s.lineStart <= lineIndex && s.lineEnd > lineIndex
+      (s) => s.lineStart <= lineIndex && s.lineEndExclusive > lineIndex
     );
 
     if (segmentIndex === -1) {
@@ -422,7 +423,9 @@ class Text {
       }
 */
       segment.lineStart =
-        segmentIndex === 0 ? 0 : this.segments[segmentIndex - 1].lineEnd;
+        segmentIndex === 0
+          ? 0
+          : this.segments[segmentIndex - 1].lineEndExclusive;
       segment.lines = [];
 
       let text = segment.raw;
@@ -538,7 +541,8 @@ class Text {
       }
       if (currentLine.length > 0) pushLine();
 
-      segment.lineEnd = segment.lineStart + (segment.lines.length || 1);
+      segment.lineEndExclusive =
+        segment.lineStart + (segment.lines.length || 1);
 
       if (!segment.lines.length) {
         segment.lines = [""];
@@ -845,7 +849,7 @@ class Text {
     }
 
     const segmentIndex = this.segments.findLastIndex(
-      (s) => s.lineStart <= absLineIndex && s.lineEnd > absLineIndex
+      (s) => s.lineStart <= absLineIndex && s.lineEndExclusive > absLineIndex
     );
 
     if (segmentIndex === -1) {
@@ -931,7 +935,10 @@ class Text {
       const segment = this.segments[i];
 
       // Skip segments that don't contain any of the requested lines
-      if (segment.lineEnd <= startLine || segment.lineStart >= endLine) {
+      if (
+        segment.lineEndExclusive <= startLine ||
+        segment.lineStart >= endLine
+      ) {
         continue;
       }
 

--- a/packages/annotator/src/lib/Text.ts
+++ b/packages/annotator/src/lib/Text.ts
@@ -854,6 +854,46 @@ class Text {
   }
 
   /**
+   * Phase 3 offset model — one VISIBLE column to the right of an absolute visual
+   * position, crossing visual line boundaries. Works in every mode (a "visible
+   * column" is a parsed column in HIGHLIGHT/SEMI, a raw column in RAW); the
+   * caller converts the result back to a raw offset, which skips hidden markup.
+   * At end-of-document the position is unchanged.
+   */
+  stepVisualRight(
+    xLine: number,
+    yLine: number
+  ): { xLine: number; yLine: number } {
+    const lineLen = (this.getLine(yLine) ?? "").length;
+    if (xLine < lineLen) {
+      return { xLine: xLine + 1, yLine };
+    }
+    // At end of the visual line: drop to the start of the next one, or stay at EOF.
+    if (yLine >= this.noLines - 1) {
+      return { xLine: lineLen, yLine };
+    }
+    return { xLine: 0, yLine: yLine + 1 };
+  }
+
+  /**
+   * Phase 3 offset model — one VISIBLE column to the left of an absolute visual
+   * position, crossing visual line boundaries. At document start it is unchanged.
+   */
+  stepVisualLeft(
+    xLine: number,
+    yLine: number
+  ): { xLine: number; yLine: number } {
+    if (xLine > 0) {
+      return { xLine: xLine - 1, yLine };
+    }
+    if (yLine <= 0) {
+      return { xLine: 0, yLine: 0 };
+    }
+    const prevLen = (this.getLine(yLine - 1) ?? "").length;
+    return { xLine: prevLen, yLine: yLine - 1 };
+  }
+
+  /**
    * Phase 3 offset model — is `offset` a soft-wrap boundary, i.e. the start of a
    * continuation visual line WITHIN a segment (not a hard `\n` boundary, which
    * begins a new segment at lineIndex 0)? Such offsets have two visual caret

--- a/packages/annotator/src/lib/Text.ts
+++ b/packages/annotator/src/lib/Text.ts
@@ -791,6 +791,44 @@ class Text {
   }
 
   /**
+   * Phase 3 offset model — raw document offset (index into {@link value}) to
+   * ABSOLUTE visual coordinates (`yLine` is an absolute line index, not
+   * viewport-relative). The offset is clamped into `[0, value.length]`. The
+   * returned `xLine` is the visual column in the current edit mode (tags are
+   * stripped in HIGHLIGHT/SEMI). Returns `null` only for an empty document.
+   */
+  visualFromOffset(
+    offset: number
+  ): { xLine: number; yLine: number } | null {
+    const clamped = Math.max(0, Math.min(offset, this.value.length));
+    const pos = this.getSegmentFromAbsTextIndex(clamped);
+    if (!pos) {
+      return null;
+    }
+    const segment = this.segments[pos.segmentIndex];
+    if (!segment) {
+      return null;
+    }
+    // An offset that lands inside hidden tag markup (HIGHLIGHT/SEMI) can yield a
+    // negative parsed column; snap it to the line start so the caret never sits
+    // at a negative column.
+    return {
+      xLine: Math.max(0, pos.charInLineIndex),
+      yLine: segment.lineStart + pos.lineIndex,
+    };
+  }
+
+  /**
+   * Phase 3 offset model — ABSOLUTE visual coordinates to a raw document offset.
+   * Returns `-1` when the line index is out of bounds (uses the non-clamping
+   * {@link getSegmentPositionOrNull}). Inverse of {@link visualFromOffset}.
+   */
+  offsetFromVisual(xLine: number, yLine: number): number {
+    const pos = this.getSegmentPositionOrNull(yLine, xLine);
+    return pos ? this.getAbsTextIndexFromPosition(pos) : -1;
+  }
+
+  /**
    * Non-clamping variant of {@link getSegmentPosition}: returns `null` when
    * `absLineIndex` falls outside `[0, noLines - 1]` instead of clamping it into
    * range. Use this when a `null` return is meant to signal "invalid position"

--- a/packages/annotator/src/lib/Text.ts
+++ b/packages/annotator/src/lib/Text.ts
@@ -787,6 +787,37 @@ class Text {
   }
 
   /**
+   * Non-clamping variant of {@link getSegmentPosition}: returns `null` when
+   * `absLineIndex` falls outside `[0, noLines - 1]` instead of clamping it into
+   * range. Use this when a `null` return is meant to signal "invalid position"
+   * (the offset-model code in Phase 3 relies on this); the clamping variant
+   * stays for existing callers that depend on the old behavior.
+   *
+   * @param absLineIndex - The absolute line index
+   * @param charInLineIndex - Character position within the line (default: 0)
+   * @param ignoreLastClosingTag - Whether to ignore the last closing tag (default: false)
+   * @returns Segment position, or `null` if the line index is out of bounds
+   */
+  getSegmentPositionOrNull(
+    absLineIndex: number,
+    charInLineIndex: number = 0,
+    ignoreLastClosingTag: boolean = false
+  ): SegmentPosition | null {
+    if (
+      this.noLines <= 0 ||
+      absLineIndex < 0 ||
+      absLineIndex >= this.noLines
+    ) {
+      return null;
+    }
+    return this.getSegmentPosition(
+      absLineIndex,
+      charInLineIndex,
+      ignoreLastClosingTag
+    );
+  }
+
+  /**
    * Converts absolute line index to segment position.
    *
    * This method finds the segment containing the given line and calculates

--- a/packages/annotator/src/lib/Text.ts
+++ b/packages/annotator/src/lib/Text.ts
@@ -667,18 +667,34 @@ class Text {
       if (absTextIndex < currentIndex + segmentLength) {
         const rawTextIndex = absTextIndex - currentIndex;
 
-        // Calculate parsed text index by accounting for tags
+        // Calculate parsed text index by counting the characters that tag
+        // removal strips from the raw text up to this index. We derive this
+        // from `tagRemovalRegex` — the exact pattern used to build `parsed`
+        // (`raw.replace(tagRemovalRegex, "")`) — so the two stay consistent
+        // even for malformed tags. A closing tag carrying attributes
+        // (`</first elvl="1">`) is stripped from `parsed` by tagRemovalRegex
+        // but matches neither the strict opening nor closing regex, so it
+        // never lands in `openingTags`/`closingTags`; reconstructing the
+        // removed length from those lists both misses such tags and uses the
+        // canonical (attribute-stripped) tag length, drifting the caret.
         let parsedTextIndex = rawTextIndex;
         if (this.mode !== EditMode.RAW) {
-          const tags = segment.openingTags
-            .concat(segment.closingTags)
-            .sort((a, b) => a.position - b.position);
-
-          for (const tag of tags) {
-            if (tag.position <= rawTextIndex) {
-              parsedTextIndex -= tag.getTag().length;
+          const removalRegex = new RegExp(
+            tagRemovalRegex.source,
+            tagRemovalRegex.flags
+          );
+          let removalMatch: RegExpExecArray | null;
+          while ((removalMatch = removalRegex.exec(segment.raw)) !== null) {
+            if (removalMatch.index > rawTextIndex) {
+              break;
             }
+            parsedTextIndex -= removalMatch[0].length;
           }
+          // Note: parsedTextIndex may go negative when rawTextIndex sits on a
+          // leading tag (the `<= rawTextIndex` boundary subtracts a tag that
+          // starts exactly there); the return value clamps it, matching the
+          // previous tracked-tag computation. Only the malformed-tag accounting
+          // differs from before.
         }
 
         // Find line index and character position within the line

--- a/packages/annotator/src/lib/Text.ts
+++ b/packages/annotator/src/lib/Text.ts
@@ -9,6 +9,18 @@ import {
 } from "./Annotator";
 
 /**
+ * Caret affinity at a soft-wrap boundary, where a single document offset maps to
+ * two visual positions (Phase 3 offset model):
+ * - `UPSTREAM`   — render at the END of the wrapped visual line.
+ * - `DOWNSTREAM` — render at the START of the following visual line.
+ * Irrelevant for any offset that is not a soft-wrap boundary.
+ */
+export enum CaretAffinity {
+  UPSTREAM = "UPSTREAM",
+  DOWNSTREAM = "DOWNSTREAM",
+}
+
+/**
  * Represents an XML-like tag within a text segment.
  * Tags can be opening or closing tags and may contain attributes.
  */
@@ -798,7 +810,8 @@ class Text {
    * stripped in HIGHLIGHT/SEMI). Returns `null` only for an empty document.
    */
   visualFromOffset(
-    offset: number
+    offset: number,
+    affinity: CaretAffinity = CaretAffinity.DOWNSTREAM
   ): { xLine: number; yLine: number } | null {
     const clamped = Math.max(0, Math.min(offset, this.value.length));
     const pos = this.getSegmentFromAbsTextIndex(clamped);
@@ -809,12 +822,24 @@ class Text {
     if (!segment) {
       return null;
     }
+    let lineIndex = pos.lineIndex;
     // An offset that lands inside hidden tag markup (HIGHLIGHT/SEMI) can yield a
     // negative parsed column; snap it to the line start so the caret never sits
     // at a negative column.
+    let charInLineIndex = Math.max(0, pos.charInLineIndex);
+    // At a soft-wrap boundary (start of a continuation line) UPSTREAM affinity
+    // renders the caret at the end of the previous visual line instead.
+    if (
+      affinity === CaretAffinity.UPSTREAM &&
+      lineIndex > 0 &&
+      charInLineIndex === 0
+    ) {
+      lineIndex -= 1;
+      charInLineIndex = segment.lines[lineIndex].length;
+    }
     return {
-      xLine: Math.max(0, pos.charInLineIndex),
-      yLine: segment.lineStart + pos.lineIndex,
+      xLine: charInLineIndex,
+      yLine: segment.lineStart + lineIndex,
     };
   }
 
@@ -826,6 +851,48 @@ class Text {
   offsetFromVisual(xLine: number, yLine: number): number {
     const pos = this.getSegmentPositionOrNull(yLine, xLine);
     return pos ? this.getAbsTextIndexFromPosition(pos) : -1;
+  }
+
+  /**
+   * Phase 3 offset model — is `offset` a soft-wrap boundary, i.e. the start of a
+   * continuation visual line WITHIN a segment (not a hard `\n` boundary, which
+   * begins a new segment at lineIndex 0)? Such offsets have two visual caret
+   * positions distinguished by {@link CaretAffinity}.
+   */
+  isWrapBoundary(offset: number): boolean {
+    const clamped = Math.max(0, Math.min(offset, this.value.length));
+    const pos = this.getSegmentFromAbsTextIndex(clamped);
+    if (!pos) {
+      return false;
+    }
+    return pos.lineIndex > 0 && pos.charInLineIndex === 0;
+  }
+
+  /**
+   * Phase 3 offset model — ABSOLUTE visual coordinates to a document offset PLUS
+   * the affinity that visual position implies: the end of a wrapped (non-last)
+   * visual line is UPSTREAM, everything else DOWNSTREAM. Inverse companion of
+   * {@link visualFromOffset} that recovers the affinity bit lost by a bare offset.
+   */
+  offsetWithAffinityFromVisual(
+    xLine: number,
+    yLine: number
+  ): { offset: number; affinity: CaretAffinity } {
+    const offset = this.offsetFromVisual(xLine, yLine);
+    if (offset < 0) {
+      return { offset, affinity: CaretAffinity.DOWNSTREAM };
+    }
+    const pos = this.getSegmentPositionOrNull(yLine, xLine);
+    if (pos) {
+      const segment = this.segments[pos.segmentIndex];
+      const lineLen = segment?.lines[pos.lineIndex]?.length ?? 0;
+      const isLastVisualLineOfSegment =
+        !segment || pos.lineIndex >= segment.lines.length - 1;
+      if (xLine >= lineLen && !isLastVisualLineOfSegment) {
+        return { offset, affinity: CaretAffinity.UPSTREAM };
+      }
+    }
+    return { offset, affinity: CaretAffinity.DOWNSTREAM };
   }
 
   /**

--- a/packages/annotator/src/lib/Text.ts
+++ b/packages/annotator/src/lib/Text.ts
@@ -1237,12 +1237,19 @@ class Text {
       textToInsert +
       this.value.slice(indexPosition);
 
-    segment.raw =
-      segment.raw.slice(0, segmentPosition.rawTextIndex) +
-      textToInsert +
-      segment.raw.slice(segmentPosition.rawTextIndex);
-
-    segment.parseText();
+    if (textToInsert.includes("\n")) {
+      // Multi-line insert (e.g. pasting text with newlines): re-split the whole
+      // document from the updated value so the newlines become real segment
+      // boundaries — a targeted single-segment splice would leave a stray "\n"
+      // embedded in one segment's raw.
+      this.prepareSegments();
+    } else {
+      segment.raw =
+        segment.raw.slice(0, segmentPosition.rawTextIndex) +
+        textToInsert +
+        segment.raw.slice(segmentPosition.rawTextIndex);
+      segment.parseText();
+    }
     this.calculateLines();
   }
 

--- a/packages/annotator/src/lib/index.ts
+++ b/packages/annotator/src/lib/index.ts
@@ -3,6 +3,8 @@ export * from "./Highlighter";
 export * from "./Viewport";
 export * from "./Text";
 export * from "./Annotator";
+export * from "./ContextMenu";
+export * from "./SettingsOverlay";
 export * from "./warnings";
 
 import { LoremIpsum } from "lorem-ipsum";

--- a/packages/annotator/src/malformedTagOffset.test.ts
+++ b/packages/annotator/src/malformedTagOffset.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Regression: raw→parsed offset mapping must stay consistent with how `parsed`
+ * is actually built (`raw.replace(tagRemovalRegex, "")`), including for
+ * malformed tags that the strict opening/closing regexes never track.
+ *
+ * `</first elvl="1">` is a closing tag carrying attributes. tagRemovalRegex
+ * strips it from `parsed`, but it matches neither `openingTagRegex` nor
+ * `closingTagRegex`, so it lands in neither `openingTags` nor `closingTags`.
+ * The old converter reconstructed the removed length from those lists and so
+ * (a) missed this tag entirely and (b) would have used the attribute-stripped
+ * `</first>` length even if it had tracked it — overshooting parsedTextIndex
+ * past the end of `parsed`. See getSegmentFromAbsTextIndex in Text.ts.
+ */
+import Text from "./lib/Text";
+import { EditMode } from "./lib/constants";
+
+const RAW = 'ad asdadas<first><test>fdsds </test></first elvl="1"> dfsd  ';
+
+describe("raw→parsed offset mapping with a malformed (attribute-bearing) closing tag", () => {
+  test("a raw offset after the malformed tag maps onto the matching parsed text", () => {
+    // Wide line so each segment stays on one line (no wrapping noise).
+    const text = new Text(RAW, 1000);
+    text.mode = EditMode.HIGHLIGHT;
+    text.prepareSegments();
+    text.calculateLines();
+
+    const parsed = text.segments[0].parsed;
+    // The malformed closing tag is stripped from parsed just like a normal tag.
+    expect(parsed).toBe("ad asdadasfdsds  dfsd  ");
+
+    // Raw index of the space immediately before "dfsd" (just past the "> ").
+    const rawIndex = RAW.indexOf("> ") + 1;
+    const pos = text.getSegmentFromAbsTextIndex(rawIndex);
+    expect(pos).not.toBeNull();
+
+    // Must land on the " dfsd" run in parsed, not past the end of it.
+    expect(parsed.slice(pos!.parsedTextIndex, pos!.parsedTextIndex + 5)).toBe(
+      " dfsd"
+    );
+  });
+
+  test("well-formed tags map identically (no behavior change for the common case)", () => {
+    const wellFormed = "<p>Hello world</p>";
+    const text = new Text(wellFormed, 1000);
+    text.mode = EditMode.HIGHLIGHT;
+    text.prepareSegments();
+    text.calculateLines();
+
+    // Raw index of 'w' in "world" (after "<p>Hello ").
+    const rawIndex = wellFormed.indexOf("world");
+    const pos = text.getSegmentFromAbsTextIndex(rawIndex);
+    expect(pos).not.toBeNull();
+    expect(text.segments[0].parsed.slice(pos!.parsedTextIndex)).toBe("world");
+  });
+});

--- a/packages/annotator/src/textBounds.test.ts
+++ b/packages/annotator/src/textBounds.test.ts
@@ -1,0 +1,49 @@
+/**
+ * Phase 3 prerequisite — explicit out-of-bounds handling for line→position lookup.
+ *
+ * `getSegmentPosition` CLAMPS an out-of-range line index into [0, noLines-1],
+ * which silently hides invalid positions from callers that test validity via a
+ * null return. `getSegmentPositionOrNull` is the non-clamping variant the
+ * offset-model refactor (Phase 3) relies on; the clamping variant stays for
+ * existing callers.
+ */
+import Text from "./lib/Text";
+
+const DOC = "abcde\nfghij\nklmno"; // 3 lines, no wrapping at width 100
+
+describe("Text.getSegmentPositionOrNull", () => {
+  test("returns null for a negative line index", () => {
+    const t = new Text(DOC, 100);
+    expect(t.getSegmentPositionOrNull(-1, 0)).toBeNull();
+  });
+
+  test("returns null for a line index at or past noLines", () => {
+    const t = new Text(DOC, 100);
+    expect(t.noLines).toBe(3);
+    expect(t.getSegmentPositionOrNull(3, 0)).toBeNull();
+    expect(t.getSegmentPositionOrNull(99, 0)).toBeNull();
+  });
+
+  test("returns the same position as getSegmentPosition for valid lines", () => {
+    const t = new Text(DOC, 100);
+    for (let y = 0; y < t.noLines; y++) {
+      for (let x = 0; x <= 5; x++) {
+        expect(t.getSegmentPositionOrNull(y, x)).toEqual(
+          t.getSegmentPosition(y, x)
+        );
+      }
+    }
+  });
+
+  test("does NOT clamp where getSegmentPosition silently would", () => {
+    const t = new Text(DOC, 100);
+    // getSegmentPosition clamps line 5 -> line 2; the OrNull variant must not.
+    expect(t.getSegmentPosition(5, 0)).not.toBeNull();
+    expect(t.getSegmentPositionOrNull(5, 0)).toBeNull();
+  });
+
+  test("returns null on an empty document for any non-zero line", () => {
+    const t = new Text("", 100);
+    expect(t.getSegmentPositionOrNull(1, 0)).toBeNull();
+  });
+});

--- a/packages/annotator/src/textBounds.test.ts
+++ b/packages/annotator/src/textBounds.test.ts
@@ -47,3 +47,28 @@ describe("Text.getSegmentPositionOrNull", () => {
     expect(t.getSegmentPositionOrNull(1, 0)).toBeNull();
   });
 });
+
+describe("Segment.lineEndExclusive", () => {
+  test("is exclusive: equals lineStart + number of visual lines", () => {
+    const t = new Text("abcde\nfghij\nklmno", 100); // 3 unwrapped segments
+    expect(t.segments).toHaveLength(3);
+    t.segments.forEach((s) => {
+      expect(s.lineEndExclusive).toBe(s.lineStart + s.lines.length);
+    });
+    // contiguous: each segment starts where the previous one ended.
+    expect(t.segments[0].lineStart).toBe(0);
+    expect(t.segments[0].lineEndExclusive).toBe(1);
+    expect(t.segments[1].lineStart).toBe(1);
+    expect(t.segments[2].lineEndExclusive).toBe(3);
+    // last exclusive end equals the total line count.
+    expect(t.segments[t.segments.length - 1].lineEndExclusive).toBe(t.noLines);
+  });
+
+  test("accounts for wrapped (multi-visual-line) segments", () => {
+    const t = new Text("supercalifragilistic", 10); // 1 segment, 2 visual lines
+    expect(t.segments).toHaveLength(1);
+    expect(t.segments[0].lines).toHaveLength(2);
+    expect(t.segments[0].lineStart).toBe(0);
+    expect(t.segments[0].lineEndExclusive).toBe(2);
+  });
+});

--- a/packages/annotator/src/undoRedo.test.ts
+++ b/packages/annotator/src/undoRedo.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Phase 4 (#3086) — undo/redo end-to-end through the keyboard + public API.
+ *
+ * Snapshots are document string + offsets (Phase 3), so undo restores both the
+ * text and the caret. Coalescing: a contiguous run of single-char typing is one
+ * undo step; Enter / Backspace / Delete / paste / replace are discrete steps.
+ */
+import { Annotator } from "./lib/Annotator";
+import { EditMode } from "./lib/constants";
+
+const mk = (text: string, mode: EditMode = EditMode.RAW): Annotator => {
+  const c = document.createElement("canvas");
+  c.style.width = "800px";
+  c.style.height = "600px";
+  document.body.appendChild(c);
+  const a = new Annotator(c, text);
+  a.setMode(mode);
+  return a;
+};
+const key = (a: Annotator, k: string, mods: Partial<KeyboardEvent> = {}) =>
+  a.keys.onKeyDown({
+    key: k,
+    ctrlKey: false,
+    metaKey: false,
+    altKey: false,
+    shiftKey: false,
+    code: "",
+    preventDefault: () => {},
+    ...mods,
+  } as KeyboardEvent);
+const flush = () => new Promise((r) => setTimeout(r, 0));
+const type = (a: Annotator, s: string) => {
+  for (const ch of s) key(a, ch);
+};
+
+describe("undo/redo: typing", () => {
+  test("a typing run is a single undo step, and redo restores it", () => {
+    const a = mk("");
+    type(a, "abc");
+    expect(a.text.value).toBe("abc");
+
+    a.undo();
+    expect(a.text.value).toBe("");
+    expect(a.canUndo()).toBe(false);
+
+    a.redo();
+    expect(a.text.value).toBe("abc");
+    expect(a.cursor.head).toBe(3);
+  });
+
+  test("Ctrl+Z / Ctrl+Y from the keyboard drive undo/redo", () => {
+    const a = mk("");
+    type(a, "hi");
+    key(a, "z", { ctrlKey: true });
+    expect(a.text.value).toBe("");
+    key(a, "y", { ctrlKey: true });
+    expect(a.text.value).toBe("hi");
+  });
+
+  test("Cmd+Z / Cmd+Shift+Z (mac) drive undo/redo", () => {
+    const a = mk("");
+    type(a, "hi");
+    key(a, "z", { metaKey: true });
+    expect(a.text.value).toBe("");
+    key(a, "Z", { metaKey: true, shiftKey: true });
+    expect(a.text.value).toBe("hi");
+  });
+
+  test("undo restores the caret to where it was before the edit", () => {
+    const a = mk("hello world");
+    a.cursor.setPosition(5, 0); // between "hello" and " world"
+    key(a, "X");
+    expect(a.text.value).toBe("helloX world");
+    expect(a.cursor.head).toBe(6);
+
+    a.undo();
+    expect(a.text.value).toBe("hello world");
+    expect(a.cursor.head).toBe(5);
+  });
+});
+
+describe("undo/redo: discrete steps", () => {
+  test("a delete is undone separately from the preceding typing run", () => {
+    const a = mk("");
+    type(a, "ab");
+    key(a, "Backspace"); // -> "a"
+    expect(a.text.value).toBe("a");
+
+    a.undo(); // undoes the backspace
+    expect(a.text.value).toBe("ab");
+
+    a.undo(); // undoes the typing run
+    expect(a.text.value).toBe("");
+  });
+
+  test("Enter is its own undo step", () => {
+    const a = mk("ab");
+    a.cursor.setPosition(1, 0);
+    key(a, "Enter"); // -> "a\nb"
+    expect(a.text.value).toBe("a\nb");
+    a.undo();
+    expect(a.text.value).toBe("ab");
+  });
+
+  test("a paste is a single undo step", async () => {
+    const a = mk("hello");
+    a.cursor.setPosition(5, 0);
+    (window.navigator.clipboard as any) = {
+      readText: () => Promise.resolve("XYZ"),
+      writeText: () => Promise.resolve(),
+    };
+    a.onPasteText();
+    await flush();
+    expect(a.text.value).toBe("helloXYZ");
+
+    a.undo();
+    expect(a.text.value).toBe("hello");
+  });
+
+  test("onReplaceText is a single undo step", () => {
+    const a = mk("abc");
+    a.cursor.setPosition(3, 0);
+    a.onReplaceText("XY");
+    expect(a.text.value).toBe("abcXY");
+    a.undo();
+    expect(a.text.value).toBe("abc");
+  });
+});
+
+describe("undo/redo: edges", () => {
+  test("undo with empty history is a no-op", () => {
+    const a = mk("abc");
+    expect(a.canUndo()).toBe(false);
+    a.undo();
+    expect(a.text.value).toBe("abc");
+  });
+
+  test("redo with empty history is a no-op", () => {
+    const a = mk("abc");
+    expect(a.canRedo()).toBe(false);
+    a.redo();
+    expect(a.text.value).toBe("abc");
+  });
+
+  test("a new edit after undo clears the redo path", () => {
+    const a = mk("");
+    type(a, "abc");
+    a.undo(); // -> ""
+    expect(a.canRedo()).toBe(true);
+    type(a, "x"); // fresh edit
+    expect(a.canRedo()).toBe(false);
+    expect(a.text.value).toBe("x");
+  });
+
+  test("pure navigation does not create an undo step", () => {
+    const a = mk("abc");
+    a.cursor.setPosition(0, 0);
+    key(a, "ArrowRight");
+    key(a, "ArrowRight");
+    key(a, "End");
+    expect(a.canUndo()).toBe(false);
+  });
+});

--- a/packages/annotator/src/undoRedo.test.ts
+++ b/packages/annotator/src/undoRedo.test.ts
@@ -160,4 +160,26 @@ describe("undo/redo: edges", () => {
     key(a, "End");
     expect(a.canUndo()).toBe(false);
   });
+
+  test("undo/redo are no-ops in HIGHLIGHT mode (editing is disabled)", () => {
+    // History built in RAW survives a mode switch (setMode keeps the stack).
+    const a = mk("", EditMode.RAW);
+    type(a, "abc");
+    expect(a.text.value).toBe("abc");
+
+    a.setMode(EditMode.HIGHLIGHT);
+
+    // HIGHLIGHT disables all editing; undo/redo must not mutate the document.
+    // Otherwise text.value would change while onTextChangeCb is suppressed,
+    // silently desyncing the editor from the host app.
+    key(a, "z", { ctrlKey: true });
+    expect(a.text.value).toBe("abc");
+    expect(a.canUndo()).toBe(true); // stack left untouched
+
+    a.undo(); // public API is gated too
+    expect(a.text.value).toBe("abc");
+
+    a.redo();
+    expect(a.text.value).toBe("abc");
+  });
 });


### PR DESCRIPTION
## Accomplishments

- [x] Fixed cursor & selection bugs at the root (rebuilt how the editor tracks the cursor)
- [x] Added undo / redo (Ctrl+Z / Ctrl+Y, ⌘ on Mac)
- [x] Fixed scroll jump on view-mode switch and cursor mapping over malformed tags
- [x] Added right-click settings menu: cursor width, highlight color, FPS counter
- [x] Settings saved in the browser and restored on reload (+ reset to defaults)
- [x] Backed by maaany automated tests, all passing

close #3086 
close #2642 - word-wrap keeps inter-word spaces at the end of the previous line so wrapped lines start with the word (never indented whitespace) 