### PR TITLE
Fix entity restore (#3039)

### DIFF
--- a/packages/client/src/pages/Main/containers/EntityDetailBox/EntityDetail/EntityDetail.tsx
+++ b/packages/client/src/pages/Main/containers/EntityDetailBox/EntityDetail/EntityDetail.tsx
@@ -18,6 +18,7 @@ import { rootTerritoryId } from "Theme/constants";
 import { DraggedPropRowCategory } from "types";
 import { DropdownItem } from "@inkvisitor/shared/types";
 import { getEntityLabel, getEntityRelationRules, getShortLabelByLetterCount } from "utils/utils";
+import { handleDeleteEntityError } from "utils/deleteEntityConflict";
 import { EntityReferenceTable } from "../../EntityReferenceTable/EntityReferenceTable";
 import { PropGroup } from "../../PropGroup/PropGroup";
 import { EntityDetailCreateTemplateModal } from "./EntityDetailCreateTemplateModal/EntityDetailCreateTemplateModal";
@@ -347,16 +348,8 @@ export const EntityDetail: React.FC<EntityDetail> = ({ detailId, entity, error, 
 
       removeDetailId(entityId);
     },
-    onError: async (error: any) => {
-      if (error.error === "InvalidDeleteError" && error.data && error.data.length > 0) {
-        const { data } = error;
-        toast.info("Click to open conflicting entity in detail", {
-          autoClose: 6000,
-          onClick: () => {
-            appendDetailId(data[0]);
-          },
-        });
-      }
+    onError: (error, entityId) => {
+      handleDeleteEntityError(error, entityId, appendDetailId);
     },
   });
 

--- a/packages/client/src/pages/Main/containers/EntityDetailBox/EntityDetail/EntityDetail.tsx
+++ b/packages/client/src/pages/Main/containers/EntityDetailBox/EntityDetail/EntityDetail.tsx
@@ -18,7 +18,12 @@ import { rootTerritoryId } from "Theme/constants";
 import { DraggedPropRowCategory } from "types";
 import { DropdownItem } from "@inkvisitor/shared/types";
 import { getEntityLabel, getEntityRelationRules, getShortLabelByLetterCount } from "utils/utils";
-import { handleDeleteEntityError } from "utils/deleteEntityConflict";
+import {
+  ENTITY_DETAIL_SCROLLBAR_ID,
+  ENTITY_DETAIL_SCROLL_CONTAINER_ID,
+  handleDeleteEntityError,
+  usedInSectionId,
+} from "utils/deleteEntityConflict";
 import { openRestoredEntity } from "utils/openRestoredEntity";
 import { EntityReferenceTable } from "../../EntityReferenceTable/EntityReferenceTable";
 import { PropGroup } from "../../PropGroup/PropGroup";
@@ -616,6 +621,8 @@ export const EntityDetail: React.FC<EntityDetail> = ({ detailId, entity, error, 
     <>
       {entity && (
         <CustomScrollbar
+          scrollerId={ENTITY_DETAIL_SCROLLBAR_ID}
+          elementId={ENTITY_DETAIL_SCROLL_CONTAINER_ID}
           customStyle={{
             // necessary to scroll until the bottom of the page
             height: "calc(100% - 2.5rem)",
@@ -900,7 +907,7 @@ export const EntityDetail: React.FC<EntityDetail> = ({ detailId, entity, error, 
                 )}
               </StyledDetailSection>
 
-              <StyledDetailSection>
+              <StyledDetailSection id={usedInSectionId(entity.id)}>
                 <StyledDetailSectionHeader
                   onClick={() => toggleSection(EntityDetailSection.UsedIn)}
                 >

--- a/packages/client/src/pages/Main/containers/EntityDetailBox/EntityDetail/EntityDetail.tsx
+++ b/packages/client/src/pages/Main/containers/EntityDetailBox/EntityDetail/EntityDetail.tsx
@@ -19,6 +19,7 @@ import { DraggedPropRowCategory } from "types";
 import { DropdownItem } from "@inkvisitor/shared/types";
 import { getEntityLabel, getEntityRelationRules, getShortLabelByLetterCount } from "utils/utils";
 import { handleDeleteEntityError } from "utils/deleteEntityConflict";
+import { openRestoredEntity } from "utils/openRestoredEntity";
 import { EntityReferenceTable } from "../../EntityReferenceTable/EntityReferenceTable";
 import { PropGroup } from "../../PropGroup/PropGroup";
 import { EntityDetailCreateTemplateModal } from "./EntityDetailCreateTemplateModal/EntityDetailCreateTemplateModal";
@@ -312,7 +313,11 @@ export const EntityDetail: React.FC<EntityDetail> = ({ detailId, entity, error, 
           onLinkClick={async () => {
             const response = await api.entityRestore(entityId);
             toast.info("Entity restored");
-            appendDetailId(entityId);
+            openRestoredEntity(response.data.data as IEntity, {
+              setTerritoryId,
+              setStatementId,
+              appendDetailId,
+            });
             queryClient.invalidateQueries({ queryKey: ["entity"] });
             queryClient.invalidateQueries({ queryKey: ["statement"] });
             if (entity?.class === EntityEnums.Class.Territory) {

--- a/packages/client/src/pages/Main/containers/StatementsListBox/StatementListBox.tsx
+++ b/packages/client/src/pages/Main/containers/StatementsListBox/StatementListBox.tsx
@@ -38,6 +38,7 @@ import {
 } from "types";
 import { collectStatementAnchors, getStatementOrderByIndex, searchTree } from "utils/utils";
 import { handleDeleteEntityError } from "utils/deleteEntityConflict";
+import { openRestoredEntity } from "utils/openRestoredEntity";
 import {
   StyledContentWrapper,
   StyledEmptyState,
@@ -371,6 +372,11 @@ export const StatementListBox: React.FC = () => {
           onLinkClick={async () => {
             const response = await api.entityRestore(sId);
             toast.info("Statement restored");
+            openRestoredEntity(response.data.data as IEntity, {
+              setTerritoryId,
+              setStatementId,
+              appendDetailId,
+            });
             queryClient.invalidateQueries({
               queryKey: ["detail-tab-entities"],
             });

--- a/packages/client/src/pages/Main/containers/StatementsListBox/StatementListBox.tsx
+++ b/packages/client/src/pages/Main/containers/StatementsListBox/StatementListBox.tsx
@@ -37,6 +37,7 @@ import {
   StatementOrderCorrection,
 } from "types";
 import { collectStatementAnchors, getStatementOrderByIndex, searchTree } from "utils/utils";
+import { handleDeleteEntityError } from "utils/deleteEntityConflict";
 import {
   StyledContentWrapper,
   StyledEmptyState,
@@ -393,23 +394,8 @@ export const StatementListBox: React.FC = () => {
       });
       setSelectedRows(selectedRows.filter((r) => r !== sId));
     },
-    onError: (error) => {
-      if (
-        (error as any).error === "InvalidDeleteError" &&
-        (error as any).data &&
-        (error as any).data.length > 0
-      ) {
-        const { data } = error as any;
-        toast.warning(
-          "Statement cannot be deleted, click to open the conflicting entity in detail",
-          {
-            autoClose: 6000,
-            onClick: () => {
-              appendDetailId(data[0]);
-            },
-          }
-        );
-      } else {
+    onError: (error, sId) => {
+      if (!handleDeleteEntityError(error, sId, appendDetailId, "warning")) {
         toast.error((error as any).message);
       }
     },

--- a/packages/client/src/pages/Main/containers/TerritoryTreeBox/ContextMenuSubmitDelete/ContextMenuSubmitDelete.tsx
+++ b/packages/client/src/pages/Main/containers/TerritoryTreeBox/ContextMenuSubmitDelete/ContextMenuSubmitDelete.tsx
@@ -6,6 +6,7 @@ import { useSearchParams } from "hooks";
 import React, { useEffect, useState } from "react";
 import { toast } from "react-toastify";
 import { getShortLabelByLetterCount } from "utils/utils";
+import { handleDeleteEntityError } from "utils/deleteEntityConflict";
 
 interface ContextMenuSubmitDelete {
   territoryActant: IEntity;
@@ -66,18 +67,7 @@ export const ContextMenuSubmitDelete: React.FC<ContextMenuSubmitDelete> = ({
       onClose();
     },
     onError: (error) => {
-      if (
-        (error as any).error === "InvalidDeleteError" &&
-        (error as any).data &&
-        (error as any).data.length > 0
-      ) {
-        const { data } = error as any;
-        toast.info("Click to open conflicting entity in detail", {
-          autoClose: 6000,
-          onClick: () => {
-            appendDetailId(data[0]);
-          },
-        });
+      if (handleDeleteEntityError(error, territoryActant.id, appendDetailId)) {
         onClose();
       }
     },

--- a/packages/client/src/pages/Main/containers/TerritoryTreeBox/ContextMenuSubmitDelete/ContextMenuSubmitDelete.tsx
+++ b/packages/client/src/pages/Main/containers/TerritoryTreeBox/ContextMenuSubmitDelete/ContextMenuSubmitDelete.tsx
@@ -7,6 +7,7 @@ import React, { useEffect, useState } from "react";
 import { toast } from "react-toastify";
 import { getShortLabelByLetterCount } from "utils/utils";
 import { handleDeleteEntityError } from "utils/deleteEntityConflict";
+import { openRestoredEntity } from "utils/openRestoredEntity";
 
 interface ContextMenuSubmitDelete {
   territoryActant: IEntity;
@@ -26,6 +27,7 @@ export const ContextMenuSubmitDelete: React.FC<ContextMenuSubmitDelete> = ({
   const {
     territoryId,
     setTerritoryId,
+    setStatementId,
     detailIdArray,
     removeDetailId,
     appendDetailId,
@@ -44,6 +46,11 @@ export const ContextMenuSubmitDelete: React.FC<ContextMenuSubmitDelete> = ({
           onLinkClick={async () => {
             const response = await api.entityRestore(territoryActant.id);
             toast.info("Entity restored");
+            openRestoredEntity(response.data.data as IEntity, {
+              setTerritoryId,
+              setStatementId,
+              appendDetailId,
+            });
             queryClient.invalidateQueries({ queryKey: ["tree"] });
             queryClient.invalidateQueries({
               queryKey: ["detail-tab-entities"],

--- a/packages/client/src/utils/deleteEntityConflict.test.ts
+++ b/packages/client/src/utils/deleteEntityConflict.test.ts
@@ -1,8 +1,33 @@
 import { IInvalidDeleteErrorData } from "@inkvisitor/shared/types/errors";
+
+vi.mock("react-toastify", () => ({
+  toast: { info: vi.fn(), warning: vi.fn() },
+}));
+
+import { toast } from "react-toastify";
 import {
+  ENTITY_DETAIL_SCROLL_CONTAINER_ID,
   getInvalidDeleteErrorData,
+  handleDeleteEntityError,
   resolveDeleteEntityConflict,
+  scrollToUsedInSection,
+  usedInSectionId,
 } from "./deleteEntityConflict";
+
+const addScrollContainer = () => {
+  const container = document.createElement("div");
+  container.id = ENTITY_DETAIL_SCROLL_CONTAINER_ID;
+  const scrollTo = vi.fn();
+  (container as unknown as { scrollTo: typeof scrollTo }).scrollTo = scrollTo;
+  document.body.append(container);
+  return scrollTo;
+};
+
+const addUsedInSection = (entityId: string) => {
+  const section = document.createElement("div");
+  section.id = usedInSectionId(entityId);
+  document.body.append(section);
+};
 
 const deletedEntityId = "entity-being-deleted";
 
@@ -77,5 +102,105 @@ describe("resolveDeleteEntityConflict", () => {
       deletedEntityId
     );
     expect(result.message).toContain("3 documents");
+  });
+});
+
+describe("usedInSectionId", () => {
+  it("builds a per-entity section id", () => {
+    expect(usedInSectionId("abc")).toBe("entity-detail-used-in-section-abc");
+  });
+});
+
+describe("scrollToUsedInSection", () => {
+  // fake timers so the poll's recursive setTimeout can be discarded after each test
+  beforeEach(() => {
+    vi.useFakeTimers();
+    document.body.innerHTML = "";
+  });
+  afterEach(() => {
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  });
+
+  it("scrolls the container once the entity's section is present", () => {
+    const scrollTo = addScrollContainer();
+    addUsedInSection("e1");
+    scrollToUsedInSection("e1");
+    // jsdom reports offsetTop as 0; asserting the scroll happened is the point
+    expect(scrollTo).toHaveBeenCalledWith({ behavior: "smooth", top: 0 });
+  });
+
+  it("does not scroll while a different entity's section is shown", () => {
+    const scrollTo = addScrollContainer();
+    addUsedInSection("other");
+    scrollToUsedInSection("e1");
+    vi.runAllTimers(); // drain the poll; e1 never appears
+    expect(scrollTo).not.toHaveBeenCalled();
+  });
+
+  it("does not throw when nothing is rendered", () => {
+    expect(() => {
+      scrollToUsedInSection("e1");
+      vi.runAllTimers();
+    }).not.toThrow();
+  });
+});
+
+describe("handleDeleteEntityError", () => {
+  const documentError = {
+    error: "InvalidDeleteError",
+    data: { type: "document", ids: ["doc-1"] } as IInvalidDeleteErrorData,
+  };
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    (toast.info as ReturnType<typeof vi.fn>).mockClear();
+    (toast.warning as ReturnType<typeof vi.fn>).mockClear();
+    document.body.innerHTML = "";
+  });
+  afterEach(() => {
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  });
+
+  const getOnClick = (toastFn: typeof toast.info) =>
+    (toastFn as ReturnType<typeof vi.fn>).mock.calls[0][1].onClick as () => void;
+
+  it("returns false and shows no toast for a non-delete error", () => {
+    expect(handleDeleteEntityError({ error: "Other" }, "e1", vi.fn())).toBe(false);
+    expect(toast.info).not.toHaveBeenCalled();
+    expect(toast.warning).not.toHaveBeenCalled();
+  });
+
+  it("on click opens the entity being deleted and scrolls it to used-in for a document conflict", () => {
+    const scrollTo = addScrollContainer();
+    addUsedInSection("entity-1");
+    const appendDetailId = vi.fn();
+
+    const handled = handleDeleteEntityError(documentError, "entity-1", appendDetailId);
+    expect(handled).toBe(true);
+    expect(toast.info).toHaveBeenCalledTimes(1);
+    expect(appendDetailId).not.toHaveBeenCalled(); // nothing until clicked
+
+    getOnClick(toast.info)();
+
+    // document conflict opens the entity being deleted, not the document id
+    expect(appendDetailId).toHaveBeenCalledWith("entity-1");
+    expect(scrollTo).toHaveBeenCalled();
+  });
+
+  it("on click opens the first conflicting entity for an entity conflict (warning variant)", () => {
+    addScrollContainer();
+    const appendDetailId = vi.fn();
+    handleDeleteEntityError(
+      { error: "InvalidDeleteError", data: { type: "entity", ids: ["e2", "e3"] } },
+      "entity-1",
+      appendDetailId,
+      "warning"
+    );
+
+    expect(toast.warning).toHaveBeenCalledTimes(1);
+    expect(() => getOnClick(toast.warning)()).not.toThrow();
+    expect(appendDetailId).toHaveBeenCalledWith("e2");
   });
 });

--- a/packages/client/src/utils/deleteEntityConflict.test.ts
+++ b/packages/client/src/utils/deleteEntityConflict.test.ts
@@ -1,0 +1,81 @@
+import { IInvalidDeleteErrorData } from "@inkvisitor/shared/types/errors";
+import {
+  getInvalidDeleteErrorData,
+  resolveDeleteEntityConflict,
+} from "./deleteEntityConflict";
+
+const deletedEntityId = "entity-being-deleted";
+
+describe("getInvalidDeleteErrorData", () => {
+  it("returns the typed data for a valid InvalidDeleteError", () => {
+    const error = {
+      error: "InvalidDeleteError",
+      message: "nope",
+      data: { type: "document", ids: ["doc-1"] } as IInvalidDeleteErrorData,
+    };
+    expect(getInvalidDeleteErrorData(error)).toEqual({
+      type: "document",
+      ids: ["doc-1"],
+    });
+  });
+
+  it("returns null for a different error", () => {
+    expect(
+      getInvalidDeleteErrorData({ error: "SomethingElse", data: { type: "entity", ids: ["e"] } })
+    ).toBeNull();
+  });
+
+  it("returns null when data is missing or has no ids", () => {
+    expect(getInvalidDeleteErrorData({ error: "InvalidDeleteError" })).toBeNull();
+    expect(
+      getInvalidDeleteErrorData({ error: "InvalidDeleteError", data: { type: "entity", ids: [] } })
+    ).toBeNull();
+  });
+
+  it("returns null for null/undefined/non-object input", () => {
+    expect(getInvalidDeleteErrorData(null)).toBeNull();
+    expect(getInvalidDeleteErrorData(undefined)).toBeNull();
+    expect(getInvalidDeleteErrorData("oops")).toBeNull();
+  });
+});
+
+describe("resolveDeleteEntityConflict", () => {
+  it("opens the first conflicting entity for an entity conflict", () => {
+    const data: IInvalidDeleteErrorData = {
+      type: "entity",
+      ids: ["other-entity-1", "other-entity-2"],
+    };
+    const result = resolveDeleteEntityConflict(data, deletedEntityId);
+    expect(result.targetId).toBe("other-entity-1");
+    expect(result.message.toLowerCase()).toContain("entity");
+  });
+
+  it("opens the entity being deleted (not the document) for a document conflict", () => {
+    const data: IInvalidDeleteErrorData = {
+      type: "document",
+      ids: ["doc-1", "doc-2"],
+    };
+    const result = resolveDeleteEntityConflict(data, deletedEntityId);
+    // must NOT navigate to a document id - documents are not entities
+    expect(result.targetId).toBe(deletedEntityId);
+    expect(result.targetId).not.toBe("doc-1");
+    expect(result.message.toLowerCase()).toContain("document");
+  });
+
+  it("uses singular wording for a single document", () => {
+    const result = resolveDeleteEntityConflict(
+      { type: "document", ids: ["doc-1"] },
+      deletedEntityId
+    );
+    expect(result.message).toContain("1 document");
+    expect(result.message).not.toContain("documents");
+  });
+
+  it("uses plural wording for multiple documents", () => {
+    const result = resolveDeleteEntityConflict(
+      { type: "document", ids: ["doc-1", "doc-2", "doc-3"] },
+      deletedEntityId
+    );
+    expect(result.message).toContain("3 documents");
+  });
+});

--- a/packages/client/src/utils/deleteEntityConflict.ts
+++ b/packages/client/src/utils/deleteEntityConflict.ts
@@ -35,6 +35,33 @@ export interface DeleteEntityConflict {
   message: string;
 }
 
+/** CustomScrollbar wrapper id of the entity detail (`scrollerId`). */
+export const ENTITY_DETAIL_SCROLLBAR_ID = "entity-detail-scrollbar";
+/** Scrollable entity-detail container id (CustomScrollbar `elementId`). */
+export const ENTITY_DETAIL_SCROLL_CONTAINER_ID = "entity-detail-box-content";
+/** Id of an entity's "Used in" section — per entity so a scroll waits for the right detail. */
+export const usedInSectionId = (entityId: string) =>
+  `entity-detail-used-in-section-${entityId}`;
+
+/**
+ * Scrolls the entity detail to `entityId`'s "Used in" section. Opening the detail
+ * is asynchronous, so this polls (up to ~3s) until that entity's section is
+ * rendered, then scrolls its container into view. No-op if it never appears.
+ */
+export const scrollToUsedInSection = (entityId: string): void => {
+  let attempts = 0;
+  const tick = () => {
+    const container = document.getElementById(ENTITY_DETAIL_SCROLL_CONTAINER_ID);
+    const section = document.getElementById(usedInSectionId(entityId));
+    if (container && section) {
+      container.scrollTo({ behavior: "smooth", top: section.offsetTop });
+    } else if (attempts++ < 30) {
+      setTimeout(tick, 100);
+    }
+  };
+  tick();
+};
+
 /**
  * Decides what to surface when an entity delete is blocked by an
  * InvalidDeleteError:
@@ -65,9 +92,10 @@ export const resolveDeleteEntityConflict = (
 
 /**
  * Shows the appropriate toast for a blocked entity deletion and wires its click
- * to open the right id in entity detail. Returns true when the error was a
- * handled InvalidDeleteError, false otherwise (so callers can fall back to a
- * generic error toast).
+ * to open the right entity in detail and scroll it to its "Used in" section
+ * (where the blocking anchors/references can be removed). Returns true when the
+ * error was a handled InvalidDeleteError, false otherwise (so callers can fall
+ * back to a generic error toast).
  */
 export const handleDeleteEntityError = (
   error: unknown,
@@ -82,7 +110,10 @@ export const handleDeleteEntityError = (
   const { targetId, message } = resolveDeleteEntityConflict(data, deletedEntityId);
   const options: ToastOptions = {
     autoClose: 6000,
-    onClick: () => appendDetailId(targetId),
+    onClick: () => {
+      appendDetailId(targetId);
+      scrollToUsedInSection(targetId);
+    },
   };
   if (variant === "warning") {
     toast.warning(message, options);

--- a/packages/client/src/utils/deleteEntityConflict.ts
+++ b/packages/client/src/utils/deleteEntityConflict.ts
@@ -1,0 +1,93 @@
+import { IInvalidDeleteErrorData } from "@inkvisitor/shared/types/errors";
+import { toast, ToastOptions } from "react-toastify";
+
+/**
+ * Narrows an unknown delete-mutation error to the typed payload carried by an
+ * InvalidDeleteError, or returns null when the error is not a (usable) delete
+ * conflict. The server stuffs entity ids OR document ids into `data.ids`, and
+ * `data.type` discriminates between them.
+ */
+export const getInvalidDeleteErrorData = (
+  error: unknown
+): IInvalidDeleteErrorData | null => {
+  if (!error || typeof error !== "object") {
+    return null;
+  }
+  const { error: errorName, data } = error as {
+    error?: string;
+    data?: Partial<IInvalidDeleteErrorData>;
+  };
+  if (
+    errorName !== "InvalidDeleteError" ||
+    !data ||
+    !Array.isArray(data.ids) ||
+    data.ids.length === 0
+  ) {
+    return null;
+  }
+  return { type: data.type === "document" ? "document" : "entity", ids: data.ids };
+};
+
+export interface DeleteEntityConflict {
+  /** id to open in the entity detail panel when the toast is clicked */
+  targetId: string;
+  /** message describing why the deletion was blocked */
+  message: string;
+}
+
+/**
+ * Decides what to surface when an entity delete is blocked by an
+ * InvalidDeleteError:
+ * - "entity" conflicts -> open the first conflicting entity in detail.
+ * - "document" conflicts -> open the entity the user tried to delete; its
+ *   detail "Used in documents" table is where the blocking anchors can be
+ *   removed. Document ids are NOT entities and cannot be opened in entity
+ *   detail (doing so was the original bug).
+ */
+export const resolveDeleteEntityConflict = (
+  data: IInvalidDeleteErrorData,
+  deletedEntityId: string
+): DeleteEntityConflict => {
+  if (data.type === "document") {
+    const count = data.ids.length;
+    return {
+      targetId: deletedEntityId,
+      message: `Cannot delete — anchored to ${count} document${
+        count === 1 ? "" : "s"
+      }. Click to review anchors in detail.`,
+    };
+  }
+  return {
+    targetId: data.ids[0],
+    message: "Click to open the conflicting entity in detail",
+  };
+};
+
+/**
+ * Shows the appropriate toast for a blocked entity deletion and wires its click
+ * to open the right id in entity detail. Returns true when the error was a
+ * handled InvalidDeleteError, false otherwise (so callers can fall back to a
+ * generic error toast).
+ */
+export const handleDeleteEntityError = (
+  error: unknown,
+  deletedEntityId: string,
+  appendDetailId: (id: string) => void,
+  variant: "info" | "warning" = "info"
+): boolean => {
+  const data = getInvalidDeleteErrorData(error);
+  if (!data) {
+    return false;
+  }
+  const { targetId, message } = resolveDeleteEntityConflict(data, deletedEntityId);
+  const options: ToastOptions = {
+    autoClose: 6000,
+    onClick: () => appendDetailId(targetId),
+  };
+  if (variant === "warning") {
+    toast.warning(message, options);
+  } else {
+    toast.info(message, options);
+  }
+  return true;
+};

--- a/packages/client/src/utils/openRestoredEntity.test.ts
+++ b/packages/client/src/utils/openRestoredEntity.test.ts
@@ -1,0 +1,100 @@
+import { EntityEnums } from "@inkvisitor/shared/enums";
+import { IEntity } from "@inkvisitor/shared/types";
+import { openRestoredEntity, resolveRestoreTarget } from "./openRestoredEntity";
+
+const asEntity = (o: object): IEntity => o as unknown as IEntity;
+
+describe("resolveRestoreTarget", () => {
+  it("routes a territory to the tree", () => {
+    expect(
+      resolveRestoreTarget(asEntity({ id: "T1", class: EntityEnums.Class.Territory }))
+    ).toEqual({ kind: "territory", id: "T1" });
+  });
+
+  it("routes a statement to its parent territory editor", () => {
+    expect(
+      resolveRestoreTarget(
+        asEntity({
+          id: "S1",
+          class: EntityEnums.Class.Statement,
+          data: { territory: { territoryId: "T9" } },
+        })
+      )
+    ).toEqual({ kind: "statement", id: "S1", territoryId: "T9" });
+  });
+
+  it("routes a statement with no parent territory to the editor without a territory", () => {
+    expect(
+      resolveRestoreTarget(
+        asEntity({ id: "S2", class: EntityEnums.Class.Statement, data: {} })
+      )
+    ).toEqual({ kind: "statement", id: "S2", territoryId: undefined });
+  });
+
+  it("routes any other entity class to a detail tab", () => {
+    expect(
+      resolveRestoreTarget(asEntity({ id: "P1", class: EntityEnums.Class.Person }))
+    ).toEqual({ kind: "detail", id: "P1" });
+  });
+
+  it("returns null for missing entity data", () => {
+    expect(resolveRestoreTarget(undefined)).toBeNull();
+    expect(resolveRestoreTarget(asEntity({ class: EntityEnums.Class.Person }))).toBeNull();
+  });
+});
+
+describe("openRestoredEntity", () => {
+  const makeNav = () => {
+    const calls = {
+      setTerritoryId: [] as string[],
+      setStatementId: [] as string[],
+      appendDetailId: [] as string[],
+    };
+    return {
+      calls,
+      nav: {
+        setTerritoryId: (id: string) => calls.setTerritoryId.push(id),
+        setStatementId: (id: string) => calls.setStatementId.push(id),
+        appendDetailId: (id: string) => calls.appendDetailId.push(id),
+      },
+    };
+  };
+
+  const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+  it("navigates a restored statement to its territory + editor (deferred)", async () => {
+    const { calls, nav } = makeNav();
+    openRestoredEntity(
+      asEntity({
+        id: "S1",
+        class: EntityEnums.Class.Statement,
+        data: { territory: { territoryId: "T9" } },
+      }),
+      nav
+    );
+    // deferred: nothing happens synchronously
+    expect(calls.setStatementId).toEqual([]);
+    await flush();
+    expect(calls.setTerritoryId).toEqual(["T9"]);
+    expect(calls.setStatementId).toEqual(["S1"]);
+  });
+
+  it("navigates a restored territory and other classes appropriately", async () => {
+    const t = makeNav();
+    openRestoredEntity(asEntity({ id: "T1", class: EntityEnums.Class.Territory }), t.nav);
+    const p = makeNav();
+    openRestoredEntity(asEntity({ id: "P1", class: EntityEnums.Class.Person }), p.nav);
+    await flush();
+    expect(t.calls.setTerritoryId).toEqual(["T1"]);
+    expect(p.calls.appendDetailId).toEqual(["P1"]);
+  });
+
+  it("does nothing for missing entity", async () => {
+    const { calls, nav } = makeNav();
+    openRestoredEntity(undefined, nav);
+    await flush();
+    expect(calls.setTerritoryId).toEqual([]);
+    expect(calls.setStatementId).toEqual([]);
+    expect(calls.appendDetailId).toEqual([]);
+  });
+});

--- a/packages/client/src/utils/openRestoredEntity.ts
+++ b/packages/client/src/utils/openRestoredEntity.ts
@@ -1,0 +1,73 @@
+import { EntityEnums } from "@inkvisitor/shared/enums";
+import { IEntity, IStatement } from "@inkvisitor/shared/types";
+
+interface RestoreNavigators {
+  setTerritoryId: (id: string) => void;
+  setStatementId: (id: string) => void;
+  appendDetailId: (id: string) => void;
+}
+
+export type RestoreTarget =
+  | { kind: "territory"; id: string }
+  | { kind: "statement"; id: string; territoryId?: string }
+  | { kind: "detail"; id: string };
+
+/**
+ * Pure decision: where should the UI land for a restored entity?
+ * Territories open in the tree, statements in their parent territory's editor,
+ * every other class in a detail tab.
+ */
+export const resolveRestoreTarget = (
+  entity: IEntity | undefined
+): RestoreTarget | null => {
+  if (!entity?.id) {
+    return null;
+  }
+  switch (entity.class) {
+    case EntityEnums.Class.Territory:
+      return { kind: "territory", id: entity.id };
+    case EntityEnums.Class.Statement:
+      return {
+        kind: "statement",
+        id: entity.id,
+        territoryId: (entity as IStatement).data?.territory?.territoryId,
+      };
+    default:
+      return { kind: "detail", id: entity.id };
+  }
+};
+
+/**
+ * Navigates the UI to a freshly restored entity so the user lands on it instead
+ * of an empty view.
+ *
+ * The navigation is deferred to a fresh macrotask on purpose: restore runs in an
+ * async toast callback, and setting territory/statement synchronously there
+ * races the search-params <-> URL sync, so the hash push gets swallowed and the
+ * URL stays unchanged. Deferring lets the URL actually update (this mirrors how
+ * appendDetailId defers its own selection).
+ */
+export const openRestoredEntity = (
+  entity: IEntity | undefined,
+  nav: RestoreNavigators
+): void => {
+  const target = resolveRestoreTarget(entity);
+  if (!target) {
+    return;
+  }
+  setTimeout(() => {
+    switch (target.kind) {
+      case "territory":
+        nav.setTerritoryId(target.id);
+        break;
+      case "statement":
+        if (target.territoryId) {
+          nav.setTerritoryId(target.territoryId);
+        }
+        nav.setStatementId(target.id);
+        break;
+      default:
+        nav.appendDetailId(target.id);
+    }
+  }, 0);
+};

--- a/packages/server/src/models/audit/audit.ts
+++ b/packages/server/src/models/audit/audit.ts
@@ -169,25 +169,28 @@ export default class Audit implements IAudit, IDbModel {
   }
 
   /**
-   * Records the single, minimal audit written when an entity or document is
-   * deleted: a deletion marker with empty changes, typed per scope via
-   * deletionEventType.
+   * Records the single audit written when an entity or document is deleted,
+   * typed per scope via deletionEventType. The optional snapshot holds the full
+   * data of the deleted model so it can later be restored (see the entity
+   * restore route); when omitted it defaults to empty changes.
    * @param db rethinkdb Connection
    * @param modelId id of the deleted entity/document
    * @param userId id of the user performing the deletion
    * @param scope audit scope (entity or document)
+   * @param snapshot full snapshot of the deleted model (used for restore)
    */
   static async createDeletionAudit(
     db: Connection | undefined,
     modelId: string,
     userId: string,
-    scope: AuditScope
+    scope: AuditScope,
+    snapshot: object = {}
   ): Promise<void> {
     await new Audit({
       modelId,
       auditScope: scope,
       user: userId,
-      changes: {},
+      changes: snapshot,
       type: Audit.deletionEventType(scope),
     }).save(db);
   }

--- a/packages/server/src/models/audit/deletion.test.ts
+++ b/packages/server/src/models/audit/deletion.test.ts
@@ -37,6 +37,34 @@ describe("Audit.createDeletionAudit", function () {
     });
   });
 
+  describe("entity scope with snapshot", () => {
+    const db = new Db();
+    const entityId = `entity-${Math.random().toString()}`;
+    const userId = `user-${Math.random().toString()}`;
+    const snapshot = { id: entityId, class: "P", labels: ["snapshot"] };
+
+    beforeAll(async () => {
+      await db.initDb();
+      await Audit.createDeletionAudit(
+        db.connection,
+        entityId,
+        userId,
+        AuditScope.Entity,
+        snapshot
+      );
+    });
+
+    afterAll(async () => await clean(db));
+
+    it("stores the provided entity snapshot so it can be restored", async () => {
+      const audits = await Audit.getLastNForEntity(db.connection, entityId, 10);
+
+      expect(audits).toHaveLength(1);
+      expect(audits[0].type).toBe(EventType.DELETE);
+      expect(audits[0].changes).toEqual(snapshot);
+    });
+  });
+
   describe("document scope", () => {
     const db = new Db();
     const documentId = `document-${Math.random().toString()}`;

--- a/packages/server/src/modules/entities/index.ts
+++ b/packages/server/src/modules/entities/index.ts
@@ -31,6 +31,7 @@ import {
   BadParams,
   CustomError,
   EntityDoesNotExist,
+  IInvalidDeleteErrorData,
   InternalServerError,
   InvalidDeleteError,
   ModelNotValidError,
@@ -501,7 +502,7 @@ export default Router()
               `Cannot be deleted while linked to relations (${
                 relIds[0] + (relIds.length > 1 ? " + " + (relIds.length - 1) + " others" : "")
               })`
-            ).withData(linkIds);
+            ).withData<IInvalidDeleteErrorData>({ type: "entity", ids: linkIds });
             continue;
           }
 
@@ -512,7 +513,10 @@ export default Router()
               `Cannot be deleted while anchored to documents (${
                 docs[0].id + (docs.length > 1 ? " + " + (docs.length - 1) + " others" : "")
               })`
-            ).withData(docs.map((d) => d.id));
+            ).withData<IInvalidDeleteErrorData>({
+              type: "document",
+              ids: docs.map((d) => d.id),
+            });
             continue;
           }
 
@@ -531,9 +535,12 @@ export default Router()
           const usedBy = await model.getUsedByEntity(req.db.connection);
           if (usedBy.length) {
             out.result = false;
-            out.data[entity.id] = new InvalidDeleteError(`Referenced by other entities`).withData(
-              usedBy.map((e) => e.id)
-            );
+            out.data[entity.id] = new InvalidDeleteError(
+              `Referenced by other entities`
+            ).withData<IInvalidDeleteErrorData>({
+              type: "entity",
+              ids: usedBy.map((e) => e.id),
+            });
             dependencyMap[entity.id] = usedBy.map((e) => e.id);
             continue;
           }

--- a/packages/server/src/modules/entities/index.ts
+++ b/packages/server/src/modules/entities/index.ts
@@ -314,8 +314,28 @@ export default Router()
           throw new AuditDoesNotExist("cannot restore entity - audit does not exist", entityId);
         }
 
+        // The deletion audit carries the full snapshot of the deleted entity.
+        // Entities deleted before snapshots were stored have empty changes, so
+        // fall back to the create audit, whose changes always hold the full
+        // entity (create requests submit the whole entity).
+        let snapshot = audit.changes as Partial<IEntity>;
+        if (!snapshot || !snapshot.class) {
+          const createAudit = await Audit.getFirstForEntity(
+            request.db.connection,
+            entityId
+          );
+          if (createAudit && (createAudit.changes as Partial<IEntity>)?.class) {
+            snapshot = createAudit.changes as Partial<IEntity>;
+          }
+        }
+        if (!snapshot || !snapshot.class) {
+          throw new ModelNotValidError(
+            "cannot restore entity - no snapshot available to restore from"
+          );
+        }
+
         const restoration = getEntityClass({
-          ...audit.changes,
+          ...snapshot,
         } as Partial<IEntity>);
         if (!restoration.isValid()) {
           throw new ModelNotValidError("");
@@ -335,7 +355,7 @@ export default Router()
         return {
           result: true,
           message: "Entity restored",
-          data: audit.changes,
+          data: snapshot,
         };
       }
     )
@@ -552,7 +572,8 @@ export default Router()
           for (const entityId of Object.keys(dependencyMap)) {
             if (dependencyMap[entityId].length === 0) {
               try {
-                const model = getEntityClass(existing.find((e) => e.id === entityId));
+                const deletedEntity = existing.find((e) => e.id === entityId);
+                const model = getEntityClass(deletedEntity);
                 if ((await model.delete(req.db.connection)).deleted !== 1) {
                   throw new InternalServerError(`cannot delete entity ${entityId}`);
                 }
@@ -561,7 +582,9 @@ export default Router()
                   req.db.connection,
                   entityId,
                   req.getUserOrFail().id,
-                  AuditScope.Entity
+                  AuditScope.Entity,
+                  // store the full entity snapshot so it can be restored later
+                  deletedEntity ? { ...deletedEntity } : {}
                 );
                 removeDependency(entityId);
                 removedCount++;

--- a/packages/shared/types/errors.ts
+++ b/packages/shared/types/errors.ts
@@ -34,7 +34,7 @@ export class CustomError extends Error {
     return this.loggable;
   }
 
-  withData(data: any): CustomError {
+  withData<T = any>(data: T): CustomError {
     this.data = data;
     return this;
   }
@@ -317,6 +317,23 @@ class InvalidDeleteError extends CustomError {
   public static title = "Invalid delete";
   public static message = "Model cannot be deleted";
   loggable = true;
+}
+
+/**
+ * Discriminates what kind of resource blocks an entity deletion, so the client
+ * can tell whether the ids carried in InvalidDeleteError.data point to entities
+ * or to documents (which are not entities and cannot be opened in entity detail).
+ */
+export type InvalidDeleteConflictType = "entity" | "document";
+
+/**
+ * Shape carried by InvalidDeleteError.withData() when an entity cannot be
+ * deleted because it is still referenced. `ids` are entity ids when
+ * type === "entity" and document ids when type === "document".
+ */
+export interface IInvalidDeleteErrorData {
+  type: InvalidDeleteConflictType;
+  ids: string[];
 }
 
 /**


### PR DESCRIPTION
Fixes restore of deleted entities (close #3039), plus the related delete-conflict toaster that tried to open a document id as an entity.

 Changes
- Restore (server): deletion audit stores the full entity snapshot, with a create-audit fallback for entities deleted before this change; clearer error when nothing is restorable.
- Restore (client): after restoring, navigate to the entity 
- Added unit tests for restore-target routing, deletion snapshot, and delete-conflict resolution.

- The "URL hash not updating" fix addresses a search-params URL sync race inferred from the code

Close #3096