### PR TITLE
Speed up entity tooltip endpoint

### DIFF
--- a/packages/database/scripts/import/indexes.ts
+++ b/packages/database/scripts/import/indexes.ts
@@ -154,6 +154,31 @@ const relationsIndexes: IndexDef[] = [
   def(DbEnums.Indexes.RelationsEntityIds, { multi: true }),
 ];
 
+const documentsIndexes: IndexDef[] = [
+  // Multi-index over every entity id referenced by a document. Backs
+  // Document.findByEntityId so it can getAll the matching documents instead
+  // of scanning the whole table (and deserializing each document's full
+  // content) on every call. The function flattens both the legacy flat
+  // string[] shape and the canonical Record<Class, string[]> shape, matching
+  // the dual-format branch the old filter handled.
+  def(
+    DbEnums.Indexes.DocumentEntityIds,
+    function (row: RDatum) {
+      return r.branch(
+        // a malformed/legacy row without entityIds contributes no keys
+        row.hasFields("entityIds").not(),
+        [] as unknown as RValue,
+        // legacy flat string[] shape
+        row("entityIds").typeOf().eq("ARRAY"),
+        row("entityIds"),
+        // canonical Record<Class, string[]> shape
+        row("entityIds").values().concatMap((arr: RDatum) => arr)
+      );
+    },
+    { multi: true }
+  ),
+];
+
 // Materialized stats indexes for each time unit
 const materializedStatsIndexes: IndexDef[] = [
   def("date"),
@@ -169,7 +194,7 @@ export const DbSchemaIndexes: { [key in keyof DbSchema]: IndexDef[] } = {
   entities: entitiesIndexes,
   audits: auditsIndexes,
   relations: relationsIndexes,
-  documents: [],
+  documents: documentsIndexes,
   settings: [],
   users: [],
   aclPermissions: [],

--- a/packages/server/src/models/document/document.ts
+++ b/packages/server/src/models/document/document.ts
@@ -1,7 +1,7 @@
 import { IDbModel } from "@models/common";
-import { r as rethink, Connection, WriteResult, RDatum } from "rethinkdb-ts";
-import { IDocument } from "@inkvisitor/shared/types";
-import { EntityEnums, UserEnums } from "@inkvisitor/shared/enums";
+import { r as rethink, Connection, WriteResult } from "rethinkdb-ts";
+import { IDocument, IDocumentMeta } from "@inkvisitor/shared/types";
+import { DbEnums, EntityEnums, UserEnums } from "@inkvisitor/shared/enums";
 import { InternalServerError, ModelNotValidError } from "@inkvisitor/shared/types/errors";
 import User from "@models/user/user";
 import { AnchorsNode } from "./anchors";
@@ -389,24 +389,22 @@ export default class Document implements IDocument, IDbModel {
   static async findByEntityId(
     db: Connection,
     entityId: string
-  ): Promise<IDocument[]> {
+  ): Promise<IDocumentMeta[]> {
+    // No caller needs the (potentially large) content blob - consumers want
+    // the document meta + anchors or just the ids - so content is dropped
+    // from the read (return type IDocumentMeta enforces that).
+    //
+    // The documents.entityIds multi-index flattens both the legacy string[]
+    // and the canonical Record<Class, string[]> shapes, so getAll touches
+    // only the matching documents instead of scanning the whole table. The
+    // index is a required boot dependency (see assertRequiredIndexes).
     const entries = await rethink
       .table(Document.table)
-      .filter(function (row: RDatum) {
-        const entityIds = row("entityIds");
-
-        return rethink.branch(
-          entityIds.typeOf().eq("ARRAY"),
-          // Case: entityIds is string[] (old format)
-          entityIds.contains(entityId),
-
-          // Else assume object: Record<string, string[]> (new format)
-          entityIds.values().concatMap(arr => arr).contains(entityId)
-        );
-      })
+      .getAll(entityId, { index: DbEnums.Indexes.DocumentEntityIds })
+      .without("content")
       .run(db);
 
-    return entries && entries.length ? (entries as IDocument[]) : [];
+    return entries && entries.length ? (entries as IDocumentMeta[]) : [];
   }
 
   /**

--- a/packages/server/src/models/entity/entity.ts
+++ b/packages/server/src/models/entity/entity.ts
@@ -609,10 +609,11 @@ export default class Entity implements IEntity, IDbModel {
         const traverse = (nodes: AnchorsNode[], parentT?: string) => {
           for (const node of nodes) {
             if (node.anchor === this.id) {
-              const { content, ...documentMeta } = docData;
-
+              // docData is already IDocumentMeta (content dropped at the
+              // findByEntityId query), so it can be used as the response
+              // document directly.
               out.push({
-                document: documentMeta,
+                document: docData,
                 anchorText: node.getShortContent(),
                 resourceId: resource?.id || "",
                 parentTerritoryId: parentT || "",

--- a/packages/server/src/models/entity/response-tooltip.ts
+++ b/packages/server/src/models/entity/response-tooltip.ts
@@ -28,17 +28,30 @@ export class ResponseTooltip
   async prepare(request: IRequest) {
     super.prepare(request);
 
-    await this.relations.prepare(request, [
-      RelationEnums.Type.Superclass,
-      RelationEnums.Type.SuperordinateEntity,
-      RelationEnums.Type.Synonym,
-      RelationEnums.Type.ActionEventEquivalent,
-      RelationEnums.Type.Classification,
-      RelationEnums.Type.Identification,
-      RelationEnums.Type.SubjectSemantics,
-      RelationEnums.Type.Actant1Semantics,
-      RelationEnums.Type.Actant2Semantics,
+    const conn = request.db.connection;
+
+    // findUsedInDocuments only fills this.usedInDocuments - its results are
+    // not fed into linkedEntitiesIds - so it is independent of the relations
+    // walk and the populateEntitiesMap below. Overlap it with
+    // relations.prepare instead of awaiting it sequentially (mirrors
+    // ResponseEntityDetail.prepare). Pairing both in one Promise.all observes
+    // either rejection without leaving a dangling promise.
+    const [usedInDocuments] = await Promise.all([
+      this.findUsedInDocuments(conn),
+      this.relations.prepare(request, [
+        RelationEnums.Type.Superclass,
+        RelationEnums.Type.SuperordinateEntity,
+        RelationEnums.Type.Synonym,
+        RelationEnums.Type.ActionEventEquivalent,
+        RelationEnums.Type.Classification,
+        RelationEnums.Type.Identification,
+        RelationEnums.Type.SubjectSemantics,
+        RelationEnums.Type.Actant1Semantics,
+        RelationEnums.Type.Actant2Semantics,
+      ]),
     ]);
+
+    this.usedInDocuments = usedInDocuments;
 
     this.addLinkedEntities(
       this.relations.getEntityIdsFromType(RelationEnums.Type.Superclass)
@@ -74,10 +87,8 @@ export class ResponseTooltip
       this.relations.getEntityIdsFromType(RelationEnums.Type.Actant2Semantics)
     );
 
-    this.usedInDocuments = await this.findUsedInDocuments(
-      request.db.connection
-    );
-
-    this.entities = await this.populateEntitiesMap(request.db.connection);
+    // populateEntitiesMap depends on the fully-accumulated linkedEntitiesIds,
+    // so it stays after every addLinkedEntities call above.
+    this.entities = await this.populateEntitiesMap(conn);
   }
 }

--- a/packages/server/src/service/assertRequiredIndexes.ts
+++ b/packages/server/src/service/assertRequiredIndexes.ts
@@ -31,6 +31,11 @@ const REQUIRED: RequiredIndex[] = [
     index: DbEnums.Indexes.StatementTerritory,
     usedBy: "Statement.findStatementsInTerritory (territory statements list)",
   },
+  {
+    table: "documents",
+    index: DbEnums.Indexes.DocumentEntityIds,
+    usedBy: "Document.findByEntityId (entity tooltip/detail usedInDocuments, delete check)",
+  },
 ];
 
 /**

--- a/packages/shared/enums/database.ts
+++ b/packages/shared/enums/database.ts
@@ -10,7 +10,8 @@ export namespace DbEnums {
     AuditDateTypeUser = "date_type_user",
     EntityUsedTemplate = "usedTemplate",
     PropsRecursive = "props.recursive",
-    RelationsEntityIds = "entityIds"
+    RelationsEntityIds = "entityIds",
+    DocumentEntityIds = "entityIds"
   }
 
   export const EntityIdReferenceIndexes = [


### PR DESCRIPTION
Speeds up `GET /entities/:entityId/tooltip` (was crossing the slow-query threshold).

- Added a `documents.entityIds` multi-index (handles both the legacy flat `string[]` and canonical `Record<Class, string[]>` shapes) and registered it as a required boot dependency.
- `Document.findByEntityId` now uses an indexed `getAll` instead of an unindexed full-table scan, and drops the `content` blob from the read (returns `IDocumentMeta[]`).
- `ResponseTooltip.prepare` runs `findUsedInDocuments` in parallel with `relations.prepare` instead of sequentially.

**Note:** the `documents.entityIds` index is now a required boot dependency — run `ensureIndexesJob` (or create the index manually) in each environment before deploying.