### PR TITLE
Dedupe Document.findByEntityId results

### DIFF
--- a/packages/server/src/models/document/document.ts
+++ b/packages/server/src/models/document/document.ts
@@ -402,6 +402,13 @@ export default class Document implements IDocument, IDbModel {
       .table(Document.table)
       .getAll(entityId, { index: DbEnums.Indexes.DocumentEntityIds })
       .without("content")
+      // getAll on a multi-index yields one row per matching index key, so a
+      // document that lists the same id more than once (a legacy flat array
+      // with duplicates, or an id bucketed under multiple classes) would come
+      // back multiple times. distinct() restores the single-occurrence
+      // semantics of the previous contains() filter (same approach as
+      // Relation.findForEntities).
+      .distinct()
       .run(db);
 
     return entries && entries.length ? (entries as IDocumentMeta[]) : [];


### PR DESCRIPTION
Follow-up to #3132 (already merged).

`getAll` on the `documents.entityIds` multi-index returns one row per matching index key, so a document that lists the same entity id more than once (a legacy flat array with duplicates, or an id bucketed under multiple classes) is returned multiple times — a regression vs the `contains()` filter it replaced.

- Adds `.distinct()` to `Document.findByEntityId`, restoring single-occurrence semantics (same approach as `Relation.findForEntities`).

Verified against a live RethinkDB: documents with a duplicated id returned 2 rows via the bare `getAll`, 1 row with `.distinct()` — matching the old filter exactly.