### PR TITLE
feat(client): capture HTML-instead-of-JSON API - catchable on frontend

### DIFF
--- a/packages/client/src/api.tsx
+++ b/packages/client/src/api.tsx
@@ -36,6 +36,7 @@ import { defaultPing } from "Theme/constants";
 import axios, { AxiosError, AxiosInstance, AxiosRequestConfig, AxiosResponse } from "axios";
 import { toast } from "react-toastify";
 import io, { Socket } from "socket.io-client";
+import { v4 as uuidv4 } from "uuid";
 import {
   EntitiesDeleteErrorResponse,
   EntitiesDeleteSuccessResponse,
@@ -88,6 +89,15 @@ const parseJwt = (token: string) => {
     return false;
   }
 };
+
+/**
+ * Diagnostic capture of the intermittent "Server returned HTML instead of JSON"
+ * response. Shared between the api interceptor (writer, see captureHtmlResponse)
+ * and the PageHeader UI (reader). The event lets the header react instantly in the
+ * same tab, where the native "storage" event does not fire.
+ */
+export const HTML_CAPTURE_STORAGE_KEY = "inkvisitor:htmlResponseCaptures";
+export const HTML_CAPTURE_EVENT = "inkvisitor:html-capture";
 
 class Api {
   private baseUrl: string;
@@ -181,8 +191,82 @@ class Api {
     // each request to api will be by default authorized
     this.connection.interceptors.request.use((config) => {
       config.headers.Authorization = `Bearer ${this.token}`;
+      // Per-request correlation id. Lets us match a client-observed bad response
+      // (see rejectIfNonJsonApiBody) against front-proxy / server access logs and
+      // confirm whether the request ever reached Node at all.
+      if (!config.headers["x-inkvisitor-request-id"]) {
+        config.headers["x-inkvisitor-request-id"] = uuidv4();
+      }
       return config;
     });
+  }
+
+  /**
+   * Diagnostics for the intermittent "Server returned HTML instead of JSON".
+   * The bug is not reproducible, so we capture the offending response the moment
+   * it is detected. The header fingerprint (server/via/x-cache/cf-ray/...) tells us
+   * WHICH layer produced the HTML, and `containsAppConfigMarker` distinguishes our
+   * own index.html (served by the SPA fallback) from a foreign proxy/CDN page.
+   *
+   * Records go to the console AND a capped localStorage ring buffer so an occurrence
+   * can be inspected after the fact, even if the console was not open:
+   *   JSON.parse(localStorage.getItem("inkvisitor:htmlResponseCaptures"))
+   * Must never throw — logging cannot be allowed to break the interceptor.
+   */
+  private captureHtmlResponse(response: AxiosResponse): void {
+    try {
+      const data = typeof response.data === "string" ? response.data : "";
+      const headers: Record<string, any> =
+        response.headers && typeof (response.headers as any).toJSON === "function"
+          ? (response.headers as any).toJSON()
+          : { ...(response.headers as any) };
+
+      const record = {
+        ts: new Date().toISOString(),
+        requestId: (response.config?.headers as any)?.["x-inkvisitor-request-id"],
+        method: response.config?.method,
+        url: (response.config?.baseURL || "") + (response.config?.url || ""),
+        finalUrl: (response.request as any)?.responseURL,
+        status: response.status,
+        statusText: response.statusText,
+        contentType: headers["content-type"] ?? headers["Content-Type"],
+        // header fingerprint — identifies the layer that produced the HTML
+        server: headers["server"],
+        via: headers["via"],
+        xCache: headers["x-cache"],
+        age: headers["age"],
+        cfRay: headers["cf-ray"],
+        xVercelCache: headers["x-vercel-cache"],
+        xServedBy: headers["x-served-by"],
+        allHeaders: headers,
+        // our SPA fallback injects `window.appConfig`; a foreign page won't have it
+        containsAppConfigMarker: data.includes("window.appConfig"),
+        bodyPrefix: data.slice(0, 200),
+      };
+
+      // eslint-disable-next-line no-console
+      console.error(
+        "[html-instead-of-json] non-JSON API response captured:",
+        record
+      );
+
+      try {
+        const prev = JSON.parse(
+          localStorage.getItem(HTML_CAPTURE_STORAGE_KEY) || "[]"
+        );
+        prev.push(record);
+        localStorage.setItem(
+          HTML_CAPTURE_STORAGE_KEY,
+          JSON.stringify(prev.slice(-20))
+        );
+        // notify the header (same-tab; native "storage" event only fires cross-tab)
+        window.dispatchEvent(new Event(HTML_CAPTURE_EVENT));
+      } catch {
+        // localStorage unavailable / quota exceeded — console.error still fired
+      }
+    } catch {
+      // capture must never break the response interceptor
+    }
   }
 
   /**
@@ -212,6 +296,7 @@ class Api {
       lowerHead.startsWith("<body") ||
       lowerHead.startsWith("<div")
     ) {
+      this.captureHtmlResponse(response);
       toast.error(
         <div>
           Server returned HTML instead of JSON

--- a/packages/client/src/components/advanced/PageHeader/PageHeader.tsx
+++ b/packages/client/src/components/advanced/PageHeader/PageHeader.tsx
@@ -2,7 +2,11 @@ import { InterfaceEnums, UserEnums } from "@inkvisitor/shared/enums";
 import { useQueryClient } from "@tanstack/react-query";
 import { heightHeader } from "Theme/constants";
 import { PingColor } from "Theme/theme";
-import api, { IDbStats } from "api";
+import api, {
+  HTML_CAPTURE_EVENT,
+  HTML_CAPTURE_STORAGE_KEY,
+  IDbStats,
+} from "api";
 import LogoInkvisitor from "assets/logos/inkvisitor.svg";
 import { Button, Loader } from "components";
 import React, { useEffect, useRef, useState } from "react";
@@ -23,6 +27,12 @@ import {
   StyledHeader,
   StyledHeaderLogo,
   StyledHeaderTag,
+  StyledHtmlCaptureActions,
+  StyledHtmlCaptureIcon,
+  StyledHtmlCapturePanel,
+  StyledHtmlCapturePre,
+  StyledHtmlCaptureText,
+  StyledHtmlCaptureWrap,
   StyledLoggedAsWrap,
   StyledMenu,
   StyledPingColor,
@@ -65,6 +75,12 @@ export const LeftHeader: React.FC<LeftHeader> = React.memo(({ tempLocation }) =>
   const [dbStats, setDbStats] = useState<IDbStats | null>(api.getDbStats());
   const statsWrapRef = useRef<HTMLDivElement | null>(null);
 
+  // Diagnostic captures of "Server returned HTML instead of JSON" (written by the
+  // api response interceptor). The warning icon below only renders when present.
+  const [htmlCaptures, setHtmlCaptures] = useState<any[] | null>(null);
+  const [htmlCapturesOpen, setHtmlCapturesOpen] = useState(false);
+  const htmlCapturesWrapRef = useRef<HTMLDivElement | null>(null);
+
   // Poll lightly until the first sample arrives (only privileged sockets ever
   // receive one). Until it does, the popup trigger stays inert.
   useEffect(() => {
@@ -92,6 +108,57 @@ export const LeftHeader: React.FC<LeftHeader> = React.memo(({ tempLocation }) =>
       document.removeEventListener("mousedown", onDocClick);
     };
   }, [statsOpen]);
+
+  // Load captured diagnostics on mount and whenever one is written (same-tab
+  // custom event) or changed in another tab (native "storage" event).
+  useEffect(() => {
+    const refresh = () => {
+      try {
+        const raw = localStorage.getItem(HTML_CAPTURE_STORAGE_KEY);
+        const parsed = raw ? JSON.parse(raw) : null;
+        setHtmlCaptures(Array.isArray(parsed) && parsed.length ? parsed : null);
+      } catch {
+        setHtmlCaptures(null);
+      }
+    };
+    refresh();
+    window.addEventListener(HTML_CAPTURE_EVENT, refresh);
+    window.addEventListener("storage", refresh);
+    return () => {
+      window.removeEventListener(HTML_CAPTURE_EVENT, refresh);
+      window.removeEventListener("storage", refresh);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!htmlCapturesOpen) return;
+    const onDocClick = (e: MouseEvent) => {
+      if (!htmlCapturesWrapRef.current?.contains(e.target as Node)) {
+        setHtmlCapturesOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", onDocClick);
+    return () => document.removeEventListener("mousedown", onDocClick);
+  }, [htmlCapturesOpen]);
+
+  const handleCopyHtmlCaptures = async () => {
+    try {
+      await navigator.clipboard.writeText(JSON.stringify(htmlCaptures, null, 2));
+      toast.info("Diagnostic copied — please send it to support");
+    } catch {
+      toast.error("Could not copy to clipboard");
+    }
+  };
+
+  const handleClearHtmlCaptures = () => {
+    try {
+      localStorage.removeItem(HTML_CAPTURE_STORAGE_KEY);
+    } catch {
+      // ignore — clearing state below is what matters for the UI
+    }
+    setHtmlCaptures(null);
+    setHtmlCapturesOpen(false);
+  };
 
   useEffect(() => {
     if ((ping === -1 || ping === -2) && !waitingForServerRestart) {
@@ -212,6 +279,42 @@ export const LeftHeader: React.FC<LeftHeader> = React.memo(({ tempLocation }) =>
             </StyledStatsWrap>
           )}
           {ping >= 0 && <StyledPingText>{ping}ms</StyledPingText>}
+
+          {htmlCaptures && (
+            <StyledHtmlCaptureWrap ref={htmlCapturesWrapRef}>
+              <StyledHtmlCaptureIcon
+                size={18}
+                title="A server response error was captured — click for details"
+                onClick={() => setHtmlCapturesOpen((v) => !v)}
+              />
+              {htmlCapturesOpen && (
+                <StyledHtmlCapturePanel>
+                  <StyledHtmlCaptureText>
+                    <strong>{htmlCaptures.length}</strong> server response
+                    problem{htmlCaptures.length > 1 ? "s were" : " was"} captured
+                    (the server returned HTML instead of JSON). Please{" "}
+                    <strong>copy the details below and send them to support</strong>{" "}
+                    so the issue can be diagnosed.
+                  </StyledHtmlCaptureText>
+                  <StyledHtmlCapturePre>
+                    {JSON.stringify(htmlCaptures, null, 2)}
+                  </StyledHtmlCapturePre>
+                  <StyledHtmlCaptureActions>
+                    <Button
+                      label="Copy"
+                      color="primary"
+                      onClick={handleCopyHtmlCaptures}
+                    />
+                    <Button
+                      label="Clear"
+                      color="danger"
+                      onClick={handleClearHtmlCaptures}
+                    />
+                  </StyledHtmlCaptureActions>
+                </StyledHtmlCapturePanel>
+              )}
+            </StyledHtmlCaptureWrap>
+          )}
         </StyledFlexRow>
       </StyledFlexColumn>
     </StyledHeader>

--- a/packages/client/src/components/advanced/PageHeader/PageHeaderStyles.tsx
+++ b/packages/client/src/components/advanced/PageHeader/PageHeaderStyles.tsx
@@ -1,4 +1,5 @@
 import { PingColor } from "Theme/theme";
+import { AiOutlineWarning } from "react-icons/ai";
 import { FaUserAlt } from "react-icons/fa";
 import styled from "styled-components";
 
@@ -124,6 +125,65 @@ export const StyledStatsHeading = styled.div`
   &:first-child {
     margin-top: 0;
   }
+`;
+
+/* --- "HTML instead of JSON" diagnostic capture indicator + popup --- */
+export const StyledHtmlCaptureWrap = styled.div`
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  margin-left: 0.5rem;
+`;
+
+export const StyledHtmlCaptureIcon = styled(AiOutlineWarning)`
+  cursor: pointer;
+  color: ${({ theme }) => theme.color["warning"]};
+  vertical-align: middle;
+`;
+
+export const StyledHtmlCapturePanel = styled.div`
+  position: absolute;
+  top: 1.6rem;
+  left: 0;
+  z-index: 100;
+  width: 26rem;
+  max-width: 80vw;
+  padding: 0.6rem 0.75rem;
+  background-color: ${({ theme }) => theme.color["white"]};
+  color: ${({ theme }) => theme.color["black"]};
+  border: 1px solid ${({ theme }) => theme.color["gray"][400]};
+  border-radius: 0.25rem;
+  box-shadow: 2px 2px 6px rgba(0, 0, 0, 0.25);
+  font-size: 0.8rem;
+  line-height: 1.4;
+`;
+
+export const StyledHtmlCaptureText = styled.div`
+  margin-bottom: 0.5rem;
+  & strong {
+    font-weight: bold;
+  }
+`;
+
+export const StyledHtmlCapturePre = styled.pre`
+  margin: 0 0 0.5rem 0;
+  padding: 0.4rem 0.5rem;
+  max-height: 16rem;
+  overflow: auto;
+  background-color: ${({ theme }) => theme.color["gray"][200]};
+  border: 1px solid ${({ theme }) => theme.color["gray"][400]};
+  border-radius: 0.2rem;
+  font-family: monospace;
+  font-size: 0.7rem;
+  line-height: 1.35;
+  white-space: pre-wrap;
+  word-break: break-word;
+`;
+
+export const StyledHtmlCaptureActions = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
 `;
 
 export const StyledStatsRow = styled.div`


### PR DESCRIPTION
Can be tested/reproduced:
- use NODE_ENV=development for client/server (both)
- click on user profile in top-right corner
- click on simulate html error
- warning glyph should be displayed next to websocket indicator

close #3138 