### PR TITLE
feat(client): implement cache-busting for HTML responses in API calls

### DIFF
--- a/packages/client/src/api.tsx
+++ b/packages/client/src/api.tsx
@@ -114,6 +114,11 @@ class Api {
   private lastError: any = null;
   private errorTimeout: any;
 
+  // URLs that recently returned HTML instead of JSON — subsequent requests
+  // to these paths get cache-busting headers so stale proxy/browser cache
+  // doesn't keep serving the bad response after the server recovers.
+  private poisonedPaths = new Set<string>();
+
   constructor() {
     this.baseUrl = process.env.APIURL || window.location.origin;
     this.apiUrl = this.baseUrl + "/api/v1";
@@ -197,6 +202,16 @@ class Api {
       if (!config.headers["x-inkvisitor-request-id"]) {
         config.headers["x-inkvisitor-request-id"] = uuidv4();
       }
+
+      // Bust browser/proxy cache for URLs that previously returned HTML
+      const path = config.url || "";
+      if (this.poisonedPaths.has(path)) {
+        config.headers["Cache-Control"] = "no-cache";
+        config.headers["Pragma"] = "no-cache";
+        const separator = path.includes("?") ? "&" : "?";
+        config.url = `${path}${separator}_cb=${Date.now()}`;
+      }
+
       return config;
     });
   }
@@ -281,6 +296,7 @@ class Api {
     }
 
     if (typeof response.data !== "string") {
+      this.poisonedPaths.delete(response.config?.url || "");
       return response;
     }
 
@@ -297,6 +313,7 @@ class Api {
       lowerHead.startsWith("<div")
     ) {
       this.captureHtmlResponse(response);
+      this.poisonedPaths.add(response.config?.url || "");
       toast.error(
         <div>
           Server returned HTML instead of JSON


### PR DESCRIPTION
Added a mechanism to track URLs that return HTML instead of JSON, allowing subsequent requests to these paths to include cache-busting headers. This ensures that stale responses are not served after the server recovers. The implementation includes a Set to manage poisoned paths and updates to the request and response handling logic to add or remove paths as necessary.

When the server (or a front proxy/SPA fallback) returns a 2xx HTML response, the browser caches it according to default HTTP caching rules. Since no Cache-Control: no-store headers are being set, the browser may serve the stale HTML from disk cache on subsequent requests to the same URL.