### PR TITLE
Client/batch of fixes afte migration of Annotator to separate box

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,5 +16,5 @@
 - Always use styled-components instead of inline `style={}` props. Prefer creating
   new styled components in the corresponding `*Styles.tsx` file.
 - Always use theme values for colors (including black text: `theme.color["black"]`),
-  font sizes, spacing, etc. Never hardcode color values — the app supports dark mode
+  font sizes, etc. Never hardcode color values — the app supports dark mode
   and hardcoded colors break it.

--- a/packages/client/src/components/advanced/Annotator/Annotator.tsx
+++ b/packages/client/src/components/advanced/Annotator/Annotator.tsx
@@ -257,6 +257,14 @@ export const TextAnnotator = ({
       queryClient.invalidateQueries({ queryKey: ["statement"] });
       queryClient.invalidateQueries({ queryKey: ["entity"] });
     },
+    onError: () => {
+      // The instant anchor save failed, so the cache was never merged and now
+      // trails the live canvas. Surface the failure (otherwise silent in quiet
+      // mode) and refetch so the canvas reconciles to true server state instead
+      // of a later dep change clobbering it with stale content.
+      toast.error("Failed to save document changes");
+      queryClient.invalidateQueries({ queryKey: ["document"] });
+    },
     onSettled: () => {
       setIsSaving(false);
       setIsSavingWithoutRefresh(false);

--- a/packages/client/src/components/advanced/Annotator/Annotator.tsx
+++ b/packages/client/src/components/advanced/Annotator/Annotator.tsx
@@ -816,20 +816,26 @@ export const TextAnnotator = ({
     // rebuild — so the constructor runs once per document instead of on every
     // render (which recreated the canvas and snapped scroll back to the top) (#3092).
     if (annotator && annotatorLoadedForDocIdRef.current === documentId) {
-      // Props lag behind the live canvas (e.g. after anchor + save before the
-      // refetch lands): keep the live instance and sync the query cache instead
-      // of rebuilding from the stale dataDocument.
       if (
         currentContent !== undefined &&
         currentContent !== newContent &&
         documentId &&
         dataDocument?.id === documentId
       ) {
-        queryClient.setQueryData<IDocument | undefined>(["document", documentId], (old) => {
-          if (!old || old.id !== documentId) return old;
-          return { ...old, content: currentContent };
-        });
-        reuseExistingInstance(currentContent);
+        if (isChangeMade) {
+          // Local edit in progress — keep the live canvas and sync the query
+          // cache so the save won't clobber local changes with the stale fetch.
+          queryClient.setQueryData<IDocument | undefined>(["document", documentId], (old) => {
+            if (!old || old.id !== documentId) return old;
+            return { ...old, content: currentContent };
+          });
+          reuseExistingInstance(currentContent);
+        } else {
+          // Server content is newer (e.g. another user added anchors) — update
+          // the annotator's text in place, preserving scroll position.
+          annotator.updateText(newContent);
+          reuseExistingInstance(newContent);
+        }
       } else {
         reuseExistingInstance();
       }

--- a/packages/client/src/components/advanced/Menu/MenuStyles.tsx
+++ b/packages/client/src/components/advanced/Menu/MenuStyles.tsx
@@ -10,7 +10,7 @@ export const StyledMenuGroupWrapper = styled.div`
   margin-top: ${({ theme }) => theme.space[1]};
   padding-top: 2.7rem;
 
-  z-index: 500;
+  z-index: 10001;
   min-width: 200px;
 `;
 

--- a/packages/client/src/components/basic/Message/MessageStyles.tsx
+++ b/packages/client/src/components/basic/Message/MessageStyles.tsx
@@ -1,6 +1,6 @@
 import styled from "styled-components";
 
-interface StyledMessage { }
+interface StyledMessage {}
 export const StyledMessage = styled.div<StyledMessage>`
   display: flex;
   align-items: center;
@@ -17,7 +17,10 @@ export const StyledMessage = styled.div<StyledMessage>`
 `;
 
 export const StyledMessageTValidationContent = styled.div`
-  display: inline;
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 1px;
+  align-items: center;
 `;
 
 export const StyledMessageDetailList = styled.div`

--- a/packages/client/src/components/basic/Suggester/SuggesterStyles.tsx
+++ b/packages/client/src/components/basic/Suggester/SuggesterStyles.tsx
@@ -45,7 +45,10 @@ export const StyledSuggesterButton = styled.div`
 `;
 
 export const StyledSuggesterList = styled.div`
-  z-index: 160;
+  /* Rendered in a #page-content portal that forms no stacking context, so this
+     competes at the body level with the modal wrap (z 500). Match the other
+     floating portal menus (Tooltip, DatePicker) so the dropdown clears modals. */
+  z-index: 10000;
 `;
 interface StyledRelativePosition {
   $width?: number;

--- a/packages/client/src/hooks/useSearchParamsContext.tsx
+++ b/packages/client/src/hooks/useSearchParamsContext.tsx
@@ -154,7 +154,7 @@ export const SearchParamsProvider = ({
       }
       setDetailId(newDetailIdArray.join(arrJoinChar));
     }
-    setTimeout(() => setSelectedDetailId(id), 100);
+    setSelectedDetailId(id);
   };
 
   const appendMultipleDetailIds = (ids: string[], maxCount: number = maxTabCount) => {
@@ -182,7 +182,7 @@ export const SearchParamsProvider = ({
     }
 
     setDetailId(newDetailIdArray.join(arrJoinChar));
-    setTimeout(() => setSelectedDetailId(ids[0]), 100);
+    setSelectedDetailId(ids[0]);
   };
 
   const replaceDetailIds = (ids: string[]) => {

--- a/packages/client/src/pages/Main/MainPage.tsx
+++ b/packages/client/src/pages/Main/MainPage.tsx
@@ -265,7 +265,14 @@ const MainPage: React.FC<MainPage> = ({}) => {
     />
   );
 
-  const reverseThirdPanelIcon = !secondPanelExpanded;
+  const reverseThirdPanelIcon =
+    !firstPanelExpanded ||
+    !secondPanelExpanded ||
+    !thirdPanelExpanded ||
+    (firstPanelExpanded &&
+      secondPanelExpanded &&
+      thirdPanelExpanded &&
+      fourthPanelExpanded);
 
   const thirdPanelButton = () => (
     <Button

--- a/packages/client/src/pages/Main/containers/AnnotatorBox/AnnotatorBox.tsx
+++ b/packages/client/src/pages/Main/containers/AnnotatorBox/AnnotatorBox.tsx
@@ -99,11 +99,12 @@ export const AnnotatorBox: React.FC<AnnotatorBox> = ({ height, width }) => {
   // Set once the user manually picks a resource so auto-load stops overriding it.
   const userPickedRef = useRef(false);
 
-  // On territory change: reset selection once, and let auto-load run again.
+  // On territory change: let auto-load re-evaluate which resource to use.
+  // Don't clear selectedResourceId — if auto-load resolves to the same resource,
+  // the annotator stays alive instead of unmounting and remounting (#3092 follow-up).
   useEffect(() => {
     setIsInitialized(false);
     userPickedRef.current = false;
-    dispatch(setSelectedResourceId(false));
   }, [territoryId, dispatch]);
 
   // Auto-load the resource whose document anchors this territory (or an ancestor).
@@ -149,6 +150,16 @@ export const AnnotatorBox: React.FC<AnnotatorBox> = ({ height, width }) => {
   const selectedDocumentId = useMemo<string | undefined>(() => {
     return selectedResource ? selectedResource.data.documentId : undefined;
   }, [selectedResource]);
+
+  // Refetch the active document when territory changes so anchors are fresh.
+  // Uses a ref to only fire on actual territory change, not on other dep updates.
+  const prevTerritoryIdForRefetchRef = useRef<string | undefined>(undefined);
+  useEffect(() => {
+    if (prevTerritoryIdForRefetchRef.current !== territoryId && selectedDocumentId) {
+      queryClient.invalidateQueries({ queryKey: ["document", selectedDocumentId] });
+    }
+    prevTerritoryIdForRefetchRef.current = territoryId;
+  }, [territoryId, selectedDocumentId, queryClient]);
 
   const {
     data: selectedDocument,

--- a/packages/client/src/pages/Main/containers/AnnotatorBox/AnnotatorBox.tsx
+++ b/packages/client/src/pages/Main/containers/AnnotatorBox/AnnotatorBox.tsx
@@ -17,6 +17,7 @@ import { setSelectedResourceId } from "redux/features/statementAnnotator/selecte
 import { setHoveredStatementId } from "redux/features/statementAnnotator/hoveredStatementIdSlice";
 import { useAppDispatch, useAppSelector } from "redux/hooks";
 import { StatementListTextAnnotator } from "./AnnotatorContent";
+import { resolveAnnotatorResourceId } from "./resolveAnnotatorResourceId";
 
 interface AnnotatorBox {
   height: number;
@@ -95,50 +96,45 @@ export const AnnotatorBox: React.FC<AnnotatorBox> = ({ height, width }) => {
     enabled: api.isLoggedIn(),
   });
 
-  const [isInitialized, setIsInitialized] = useState(false);
   // Set once the user manually picks a resource so auto-load stops overriding it.
   const userPickedRef = useRef(false);
 
   // On territory change: let auto-load re-evaluate which resource to use.
-  // Don't clear selectedResourceId — if auto-load resolves to the same resource,
-  // the annotator stays alive instead of unmounting and remounting (#3092 follow-up).
   useEffect(() => {
-    setIsInitialized(false);
     userPickedRef.current = false;
-  }, [territoryId, dispatch]);
+  }, [territoryId]);
 
-  // Auto-load the resource whose document anchors this territory (or an ancestor).
-  // Only ever SETS a found resource (latching on success); when nothing is found
-  // it neither dispatches nor latches, so it retries as resources / documents /
-  // the territory path arrive — without overriding a manual selection.
+  // Reconcile selectedResourceId with the resource whose document anchors this
+  // territory (or an ancestor). SETS when one is found and CLEARS (false) when
+  // none is — so switching to a territory without a document drops the stale
+  // resource, document and warnings. Re-selecting the same id is a no-op, so the
+  // annotator stays alive across territory switches that keep the same resource
+  // instead of unmounting and remounting (#3092 follow-up). Skipped while the
+  // user has manually picked a resource, until the next territory change resets
+  // userPickedRef. Reruns as resources / documents / the territory path arrive.
   useEffect(() => {
-    if (!resources || !documents || isInitialized || userPickedRef.current) {
+    if (!resources || !documents || userPickedRef.current) {
       return;
     }
 
-    let resourceWithAnchor = resources.find((resource) => {
-      if (!resource.data.documentId) return false;
-      const document = documents.find((d) => d.id === resource.data.documentId);
-      return document?.entityIds.T.includes(territoryId) ?? false;
-    });
+    const resolvedId = resolveAnnotatorResourceId(
+      territoryId,
+      selectedTerritoryPath,
+      resources,
+      documents,
+    );
 
-    if (!resourceWithAnchor) {
-      for (let i = selectedTerritoryPath.length - 1; i > 0; i--) {
-        const territoryInPath = selectedTerritoryPath[i];
-        resourceWithAnchor = resources.find((resource) => {
-          if (!resource.data.documentId) return false;
-          const document = documents.find((d) => d.id === resource.data.documentId);
-          return document?.entityIds.T.includes(territoryInPath) ?? false;
-        });
-        if (resourceWithAnchor) break;
-      }
+    if (resolvedId !== selectedResourceId) {
+      dispatch(setSelectedResourceId(resolvedId));
     }
-
-    if (resourceWithAnchor) {
-      dispatch(setSelectedResourceId(resourceWithAnchor.id));
-      setIsInitialized(true);
-    }
-  }, [resources, documents, isInitialized, territoryId, selectedTerritoryPath, dispatch]);
+  }, [
+    resources,
+    documents,
+    territoryId,
+    selectedTerritoryPath,
+    selectedResourceId,
+    dispatch,
+  ]);
 
   const selectedResource = useMemo<IResponseEntity | false>(() => {
     if (selectedResourceId && resources) {
@@ -306,7 +302,6 @@ export const AnnotatorBox: React.FC<AnnotatorBox> = ({ height, width }) => {
       resources={resources}
       setSelectedResourceId={(id) => {
         userPickedRef.current = true;
-        setIsInitialized(true);
         dispatch(setSelectedResourceId(id));
       }}
       showStatementList={false}

--- a/packages/client/src/pages/Main/containers/AnnotatorBox/AnnotatorBoxStyles.tsx
+++ b/packages/client/src/pages/Main/containers/AnnotatorBox/AnnotatorBoxStyles.tsx
@@ -26,6 +26,25 @@ export const StyledLoadingDocument = styled.div`
   padding: 0 0.25rem;
 `;
 
+export const StyledHighlightTooltipTitle = styled.div`
+  margin-bottom: ${({ theme }) => theme.space[2]};
+  font-weight: ${({ theme }) => theme.fontWeight["bold"]};
+`;
+
+export const StyledHighlightTooltipRow = styled.span`
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+`;
+
+export const StyledHighlightTooltipDot = styled.span<{ $color: string }>`
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background-color: ${({ $color }) => $color};
+  flex-shrink: 0;
+`;
+
 export const StyledInfoText = styled.div`
   font-size: ${({ theme }) => theme.fontSize["sm"]};
   font-weight: ${({ theme }) => theme.fontWeight["normal"]};

--- a/packages/client/src/pages/Main/containers/AnnotatorBox/AnnotatorBoxStyles.tsx
+++ b/packages/client/src/pages/Main/containers/AnnotatorBox/AnnotatorBoxStyles.tsx
@@ -1,4 +1,5 @@
 import styled from "styled-components";
+import { EntityColors } from "types";
 
 export const StyledWarningsListHeader = styled.div`
   font-size: ${({ theme }) => theme.fontSize["xs"]};
@@ -37,11 +38,14 @@ export const StyledHighlightTooltipRow = styled.span`
   gap: 0.4rem;
 `;
 
-export const StyledHighlightTooltipDot = styled.span<{ $color: string }>`
+export const StyledHighlightTooltipDot = styled.span<{ $entityClass: string }>`
   width: 8px;
   height: 8px;
   border-radius: 50%;
-  background-color: ${({ $color }) => $color};
+  background-color: ${({ theme, $entityClass }) =>
+    EntityColors[$entityClass]
+      ? (theme.color[EntityColors[$entityClass].color] as string)
+      : "transparent"};
   flex-shrink: 0;
 `;
 

--- a/packages/client/src/pages/Main/containers/AnnotatorBox/AnnotatorBoxStyles.tsx
+++ b/packages/client/src/pages/Main/containers/AnnotatorBox/AnnotatorBoxStyles.tsx
@@ -17,3 +17,20 @@ export const StyledWarningWrapper = styled.div`
   display: inline-flex;
   flex-shrink: 0;
 `;
+
+export const StyledLoadingDocument = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 0.3rem;
+  position: relative;
+  padding: 0 0.25rem;
+`;
+
+export const StyledInfoText = styled.div`
+  font-size: ${({ theme }) => theme.fontSize["sm"]};
+  font-weight: ${({ theme }) => theme.fontWeight["normal"]};
+  display: flex;
+  align-items: center;
+  color: ${({ theme }) => theme.color["info"]};
+  margin-left: 0.3rem;
+`;

--- a/packages/client/src/pages/Main/containers/AnnotatorBox/AnnotatorBoxStyles.tsx
+++ b/packages/client/src/pages/Main/containers/AnnotatorBox/AnnotatorBoxStyles.tsx
@@ -54,7 +54,7 @@ export const StyledHighlightTooltipDot = styled.span<{ $entityClass: string }>`
 
 export const StyledInfoText = styled.div`
   display: flex;
-  font-size: ${({ theme }) => theme.fontSize["xs"]};
+  font-size: 1.3rem;
   font-weight: ${({ theme }) => theme.fontWeight["normal"]};
   color: ${({ theme }) => theme.color["info"]};
 `;

--- a/packages/client/src/pages/Main/containers/AnnotatorBox/AnnotatorBoxStyles.tsx
+++ b/packages/client/src/pages/Main/containers/AnnotatorBox/AnnotatorBoxStyles.tsx
@@ -22,9 +22,12 @@ export const StyledWarningWrapper = styled.div`
 export const StyledLoadingDocument = styled.div`
   display: flex;
   align-items: center;
-  gap: 0.3rem;
+  justify-content: center;
   position: relative;
-  padding: 0 0.25rem;
+  padding: 0.25rem 1rem;
+  border-radius: 2rem;
+  overflow: hidden;
+  width: 100%;
 `;
 
 export const StyledHighlightTooltipTitle = styled.div`
@@ -50,10 +53,8 @@ export const StyledHighlightTooltipDot = styled.span<{ $entityClass: string }>`
 `;
 
 export const StyledInfoText = styled.div`
-  font-size: ${({ theme }) => theme.fontSize["sm"]};
-  font-weight: ${({ theme }) => theme.fontWeight["normal"]};
   display: flex;
-  align-items: center;
+  font-size: ${({ theme }) => theme.fontSize["xs"]};
+  font-weight: ${({ theme }) => theme.fontWeight["normal"]};
   color: ${({ theme }) => theme.color["info"]};
-  margin-left: 0.3rem;
 `;

--- a/packages/client/src/pages/Main/containers/AnnotatorBox/AnnotatorContent.tsx
+++ b/packages/client/src/pages/Main/containers/AnnotatorBox/AnnotatorContent.tsx
@@ -191,7 +191,7 @@ export const StatementListTextAnnotator: React.FC<StatementListTextAnnotator> = 
         lastScrolledAnnotatorRef.current = annotator;
       }
     }
-  }, [selectedDocument, statementId, annotator, territory]);
+  }, [selectedDocument, statementId, annotator, territory, territoryId]);
 
   return (
     <>

--- a/packages/client/src/pages/Main/containers/AnnotatorBox/AnnotatorContent.tsx
+++ b/packages/client/src/pages/Main/containers/AnnotatorBox/AnnotatorContent.tsx
@@ -126,6 +126,11 @@ export const StatementListTextAnnotator: React.FC<StatementListTextAnnotator> = 
   const [warningsModalOpen, setWarningsModalOpen] = useState(false);
   const [warningAnchorCount, setWarningAnchorCount] = useState(0);
 
+  useEffect(() => {
+    setWarningAnchorCount(0);
+    setWarningsModalOpen(false);
+  }, [selectedDocumentId]);
+
   const activeTHasAnchor = useMemo<boolean>(() => {
     if (selectedDocument && territoryId) {
       return selectedDocument?.entityIds.T.includes(territoryId);

--- a/packages/client/src/pages/Main/containers/AnnotatorBox/AnnotatorDocumentLine.tsx
+++ b/packages/client/src/pages/Main/containers/AnnotatorBox/AnnotatorDocumentLine.tsx
@@ -268,7 +268,6 @@ const StatementListDocumentLine: React.FC<StatementListDocumentLine> = ({
                   options={entitiesDict}
                   disableEmpty
                   isClearable
-                  disableAny
                   closeMenuOnSelect={false}
                   onChange={setHlEntities}
                   value={hlEntities}
@@ -312,7 +311,6 @@ const StatementListDocumentLine: React.FC<StatementListDocumentLine> = ({
             options={entitiesDict}
             disableEmpty
             isClearable
-            disableAny
             closeMenuOnSelect={false}
             onChange={setHlEntities}
             value={hlEntities}

--- a/packages/client/src/pages/Main/containers/AnnotatorBox/AnnotatorDocumentLine.tsx
+++ b/packages/client/src/pages/Main/containers/AnnotatorBox/AnnotatorDocumentLine.tsx
@@ -24,9 +24,10 @@ import {
   StyledNoDocumentMessage,
   StyledSearchNavigation,
 } from "../StatementsListBox/StatementListBoxStyles";
-import { StyledInfoText } from "../StatementsListBox/StatementListHeader/StatementListHeaderStyles";
 import {
   StyledDocumentContainer,
+  StyledInfoText,
+  StyledLoadingDocument,
   StyledWarningsListHeader,
   StyledWarningWrapper,
 } from "./AnnotatorBoxStyles";
@@ -174,10 +175,10 @@ const StatementListDocumentLine: React.FC<StatementListDocumentLine> = ({
               />
             )}
             {selectedDocumentIsFetching && (
-              <div style={{ display: "flex", alignItems: "center", gap: "0.3rem" }}>
+              <StyledLoadingDocument>
                 <Loader show size={16} />
                 <StyledInfoText>Loading document</StyledInfoText>
-              </div>
+              </StyledLoadingDocument>
             )}
           </StyledDocumentTitleContainer>
 

--- a/packages/client/src/pages/Main/containers/AnnotatorBox/AnnotatorDocumentLine.tsx
+++ b/packages/client/src/pages/Main/containers/AnnotatorBox/AnnotatorDocumentLine.tsx
@@ -195,7 +195,7 @@ const StatementListDocumentLine: React.FC<StatementListDocumentLine> = ({
               </StyledWarningWrapper>
             )}
 
-          {!selectedDocumentIsFetching &&
+          {!selectedDocument && !selectedDocumentIsFetching &&
             selectedResource !== false &&
             selectedResource.data.documentId === undefined && (
               <StyledNoDocumentMessage>
@@ -204,8 +204,7 @@ const StatementListDocumentLine: React.FC<StatementListDocumentLine> = ({
               </StyledNoDocumentMessage>
             )}
 
-          {!selectedDocumentIsFetching &&
-            selectedResource !== false &&
+          {selectedResource !== false &&
             selectedResource?.data?.documentId && (
               <StyledAnnotatorMenuBar>
                 {activeTHasAnchor ? (

--- a/packages/client/src/pages/Main/containers/AnnotatorBox/AnnotatorDocumentLine.tsx
+++ b/packages/client/src/pages/Main/containers/AnnotatorBox/AnnotatorDocumentLine.tsx
@@ -10,7 +10,6 @@ import Dropdown, {
 } from "components/advanced";
 import { WarningsChip } from "components/advanced/Annotator/AnnotatorWarningsModal";
 import React, { useMemo, useState } from "react";
-import { useTheme } from "styled-components";
 import { FaDownload, FaHighlighter, FaLongArrowAltRight } from "react-icons/fa";
 import { GrDocumentMissing } from "react-icons/gr";
 import { TbAnchor, TbAnchorOff } from "react-icons/tb";
@@ -37,21 +36,18 @@ import {
 } from "./AnnotatorBoxStyles";
 
 const HighlightTooltipContent: React.FC<{ hlEntities: EntityEnums.Class[] }> = ({ hlEntities }) => {
-  const theme = useTheme();
-  const selected = entitiesDict.filter((e) => hlEntities.includes(e.value));
+  const selectedEntityClasses = entitiesDict.filter((e) => hlEntities.includes(e.value));
 
-  if (selected.length === 0) {
+  if (selectedEntityClasses.length === 0) {
     return <StyledHighlightTooltipTitle>No highlights</StyledHighlightTooltipTitle>;
   }
 
   return (
     <>
       <StyledHighlightTooltipTitle>Highlight</StyledHighlightTooltipTitle>
-      {selected.map((e) => (
+      {selectedEntityClasses.map((e) => (
         <StyledHighlightTooltipRow key={e.value}>
-          <StyledHighlightTooltipDot
-            $color={theme.color[`entity${e.value}` as keyof typeof theme.color] as string}
-          />
+          <StyledHighlightTooltipDot $entityClass={e.value} />
           {e.label}
         </StyledHighlightTooltipRow>
       ))}

--- a/packages/client/src/pages/Main/containers/AnnotatorBox/AnnotatorDocumentLine.tsx
+++ b/packages/client/src/pages/Main/containers/AnnotatorBox/AnnotatorDocumentLine.tsx
@@ -27,6 +27,9 @@ import {
 } from "../StatementsListBox/StatementListBoxStyles";
 import {
   StyledDocumentContainer,
+  StyledHighlightTooltipDot,
+  StyledHighlightTooltipRow,
+  StyledHighlightTooltipTitle,
   StyledInfoText,
   StyledLoadingDocument,
   StyledWarningsListHeader,
@@ -43,24 +46,14 @@ const HighlightTooltipContent: React.FC<{ hlEntities: EntityEnums.Class[] }> = (
 
   return (
     <>
-      <div style={{ marginBottom: "0.5rem" }}>
-        <b>Highlight</b>
-      </div>
+      <StyledHighlightTooltipTitle>Highlight</StyledHighlightTooltipTitle>
       {selected.map((e) => (
-        <span key={e.value} style={{ display: "flex", alignItems: "center", gap: "0.4rem" }}>
-          <span
-            style={{
-              width: 8,
-              height: 8,
-              borderRadius: "50%",
-              backgroundColor: theme.color[
-                `entity${e.value}` as keyof typeof theme.color
-              ] as string,
-              flexShrink: 0,
-            }}
+        <StyledHighlightTooltipRow key={e.value}>
+          <StyledHighlightTooltipDot
+            $color={theme.color[`entity${e.value}` as keyof typeof theme.color] as string}
           />
           {e.label}
-        </span>
+        </StyledHighlightTooltipRow>
       ))}
     </>
   );

--- a/packages/client/src/pages/Main/containers/AnnotatorBox/AnnotatorDocumentLine.tsx
+++ b/packages/client/src/pages/Main/containers/AnnotatorBox/AnnotatorDocumentLine.tsx
@@ -41,7 +41,7 @@ const HighlightTooltipContent: React.FC<{ hlEntities: EntityEnums.Class[] }> = (
   const selected = entitiesDict.filter((e) => hlEntities.includes(e.value));
 
   if (selected.length === 0) {
-    return <span>No highlights</span>;
+    return <StyledHighlightTooltipTitle>No highlights</StyledHighlightTooltipTitle>;
   }
 
   return (

--- a/packages/client/src/pages/Main/containers/AnnotatorBox/AnnotatorDocumentLine.tsx
+++ b/packages/client/src/pages/Main/containers/AnnotatorBox/AnnotatorDocumentLine.tsx
@@ -167,17 +167,17 @@ const StatementListDocumentLine: React.FC<StatementListDocumentLine> = ({
               minWidth: "2rem",
             }}
           >
-            {selectedDocument && !selectedDocumentIsFetching && (
+            {selectedDocument && (
               <DocumentTitle
                 title={selectedDocument.title}
                 width={annotatorWidthTooNarrow ? 80 : "full"}
                 noMargin
               />
             )}
-            {selectedDocumentIsFetching && (
+            {selectedDocumentIsFetching && !selectedDocument && (
               <StyledLoadingDocument>
                 <Loader show size={16} />
-                <StyledInfoText>Loading document</StyledInfoText>
+                <StyledInfoText>Loading</StyledInfoText>
               </StyledLoadingDocument>
             )}
           </StyledDocumentTitleContainer>

--- a/packages/client/src/pages/Main/containers/AnnotatorBox/AnnotatorDocumentLine.tsx
+++ b/packages/client/src/pages/Main/containers/AnnotatorBox/AnnotatorDocumentLine.tsx
@@ -10,6 +10,7 @@ import Dropdown, {
 } from "components/advanced";
 import { WarningsChip } from "components/advanced/Annotator/AnnotatorWarningsModal";
 import React, { useMemo, useState } from "react";
+import { useTheme } from "styled-components";
 import { FaDownload, FaHighlighter, FaLongArrowAltRight } from "react-icons/fa";
 import { GrDocumentMissing } from "react-icons/gr";
 import { TbAnchor, TbAnchorOff } from "react-icons/tb";
@@ -31,6 +32,39 @@ import {
   StyledWarningsListHeader,
   StyledWarningWrapper,
 } from "./AnnotatorBoxStyles";
+
+const HighlightTooltipContent: React.FC<{ hlEntities: EntityEnums.Class[] }> = ({ hlEntities }) => {
+  const theme = useTheme();
+  const selected = entitiesDict.filter((e) => hlEntities.includes(e.value));
+
+  if (selected.length === 0) {
+    return <span>No highlights</span>;
+  }
+
+  return (
+    <>
+      <div style={{ marginBottom: "0.5rem" }}>
+        <b>Highlight</b>
+      </div>
+      {selected.map((e) => (
+        <span key={e.value} style={{ display: "flex", alignItems: "center", gap: "0.4rem" }}>
+          <span
+            style={{
+              width: 8,
+              height: 8,
+              borderRadius: "50%",
+              backgroundColor: theme.color[
+                `entity${e.value}` as keyof typeof theme.color
+              ] as string,
+              flexShrink: 0,
+            }}
+          />
+          {e.label}
+        </span>
+      ))}
+    </>
+  );
+};
 
 // icon + margin + gap in StyledHighlightContainer when highlight label is shown
 const HIGHLIGHT_ICON_RESERVED_WIDTH = 10;
@@ -97,13 +131,6 @@ const StatementListDocumentLine: React.FC<StatementListDocumentLine> = ({
     const baseWidth = annotatorWidthTooNarrow ? contentWidth / 3.3 : contentWidth / 2.6;
     return isUndersized ? baseWidth + HIGHLIGHT_ICON_RESERVED_WIDTH : baseWidth;
   }, [contentWidth, annotatorWidthTooNarrow, isUndersized]);
-
-  const highlightTooltip = useMemo(() => {
-    const labels = entitiesDict.filter((e) => hlEntities.includes(e.value)).map((e) => e.label);
-    if (labels.length === 0) return "No highlights";
-    if (labels.length === entitiesDict.length) return "All classes highlighted";
-    return `Highlighted Entity classes: ${labels.join(", ")}`;
-  }, [hlEntities]);
 
   const highlightDropdownLimitSelectedItems = useMemo(
     () =>
@@ -265,7 +292,7 @@ const StatementListDocumentLine: React.FC<StatementListDocumentLine> = ({
             {isUndersized && (
               <Button
                 icon={<FaHighlighter />}
-                tooltipLabel={highlightTooltip}
+                tooltipContent={<HighlightTooltipContent hlEntities={hlEntities} />}
                 onClick={() => setShowHighlightModal(true)}
               />
             )}

--- a/packages/client/src/pages/Main/containers/AnnotatorBox/AnnotatorDocumentLine.tsx
+++ b/packages/client/src/pages/Main/containers/AnnotatorBox/AnnotatorDocumentLine.tsx
@@ -98,6 +98,13 @@ const StatementListDocumentLine: React.FC<StatementListDocumentLine> = ({
     return isUndersized ? baseWidth + HIGHLIGHT_ICON_RESERVED_WIDTH : baseWidth;
   }, [contentWidth, annotatorWidthTooNarrow, isUndersized]);
 
+  const highlightTooltip = useMemo(() => {
+    const labels = entitiesDict.filter((e) => hlEntities.includes(e.value)).map((e) => e.label);
+    if (labels.length === 0) return "No highlights";
+    if (labels.length === entitiesDict.length) return "All classes highlighted";
+    return `Highlighted Entity classes: ${labels.join(", ")}`;
+  }, [hlEntities]);
+
   const highlightDropdownLimitSelectedItems = useMemo(
     () =>
       Math.floor(
@@ -195,7 +202,8 @@ const StatementListDocumentLine: React.FC<StatementListDocumentLine> = ({
               </StyledWarningWrapper>
             )}
 
-          {!selectedDocument && !selectedDocumentIsFetching &&
+          {!selectedDocument &&
+            !selectedDocumentIsFetching &&
             selectedResource !== false &&
             selectedResource.data.documentId === undefined && (
               <StyledNoDocumentMessage>
@@ -204,32 +212,31 @@ const StatementListDocumentLine: React.FC<StatementListDocumentLine> = ({
               </StyledNoDocumentMessage>
             )}
 
-          {selectedResource !== false &&
-            selectedResource?.data?.documentId && (
-              <StyledAnnotatorMenuBar>
-                {activeTHasAnchor ? (
-                  <Button
-                    label=""
-                    iconRight={
-                      <div style={{ display: "flex", alignItems: "center" }}>
-                        <TbAnchor />
-                        <FaLongArrowAltRight />
-                      </div>
-                    }
-                    tooltipLabel="locate anchor"
-                    inverted
-                    onClick={() => {
-                      annotator?.scrollToAnchor(territoryId);
-                    }}
-                    color="warning"
-                  />
-                ) : (
-                  <StyledSearchNavigation>
-                    <TbAnchorOff title="no anchor for T" />
-                  </StyledSearchNavigation>
-                )}
-              </StyledAnnotatorMenuBar>
-            )}
+          {selectedResource !== false && selectedResource?.data?.documentId && (
+            <StyledAnnotatorMenuBar>
+              {activeTHasAnchor ? (
+                <Button
+                  label=""
+                  iconRight={
+                    <div style={{ display: "flex", alignItems: "center" }}>
+                      <TbAnchor />
+                      <FaLongArrowAltRight />
+                    </div>
+                  }
+                  tooltipLabel="locate anchor"
+                  inverted
+                  onClick={() => {
+                    annotator?.scrollToAnchor(territoryId);
+                  }}
+                  color="warning"
+                />
+              ) : (
+                <StyledSearchNavigation>
+                  <TbAnchorOff title="no anchor for T" />
+                </StyledSearchNavigation>
+              )}
+            </StyledAnnotatorMenuBar>
+          )}
         </StyledDocumentContainer>
 
         {/* Class selector - HIGHLIGHT */}
@@ -258,7 +265,7 @@ const StatementListDocumentLine: React.FC<StatementListDocumentLine> = ({
             {isUndersized && (
               <Button
                 icon={<FaHighlighter />}
-                tooltipLabel="Highlight settings"
+                tooltipLabel={highlightTooltip}
                 onClick={() => setShowHighlightModal(true)}
               />
             )}

--- a/packages/client/src/pages/Main/containers/AnnotatorBox/resolveAnnotatorResourceId.test.ts
+++ b/packages/client/src/pages/Main/containers/AnnotatorBox/resolveAnnotatorResourceId.test.ts
@@ -1,0 +1,63 @@
+import { EntityEnums } from "@inkvisitor/shared/enums";
+import { IDocument, IResponseEntity } from "@inkvisitor/shared/types";
+import { describe, expect, it } from "vitest";
+import { resolveAnnotatorResourceId } from "./resolveAnnotatorResourceId";
+
+const makeResource = (id: string, documentId?: string): IResponseEntity =>
+  ({ id, data: { documentId } } as unknown as IResponseEntity);
+
+const makeDocument = (id: string, territoryIds: string[]): IDocument =>
+  ({
+    id,
+    entityIds: { [EntityEnums.Class.Territory]: territoryIds },
+  } as unknown as IDocument);
+
+describe("resolveAnnotatorResourceId", () => {
+  it("resolves a resource whose document anchors the territory directly", () => {
+    const resources = [makeResource("res-1", "doc-1")];
+    const documents = [makeDocument("doc-1", ["T1"])];
+    expect(resolveAnnotatorResourceId("T1", [], resources, documents)).toBe(
+      "res-1"
+    );
+  });
+
+  it("resolves a resource anchored on an ancestor in the territory path", () => {
+    const resources = [makeResource("res-1", "doc-1")];
+    const documents = [makeDocument("doc-1", ["Tparent"])];
+    // path = [root, ...ancestors] (excludes the territory itself); the root at
+    // index 0 is intentionally not consulted.
+    expect(
+      resolveAnnotatorResourceId("T2", ["Troot", "Tparent"], resources, documents)
+    ).toBe("res-1");
+  });
+
+  it("returns false when no document anchors the territory or its ancestors", () => {
+    const resources = [makeResource("res-1", "doc-1")];
+    const documents = [makeDocument("doc-1", ["T1"])];
+    expect(
+      resolveAnnotatorResourceId("T2", ["Troot", "Tparent"], resources, documents)
+    ).toBe(false);
+  });
+
+  it("ignores resources without a documentId", () => {
+    const resources = [makeResource("res-1", undefined)];
+    const documents = [makeDocument("doc-1", ["T1"])];
+    expect(resolveAnnotatorResourceId("T1", [], resources, documents)).toBe(
+      false
+    );
+  });
+
+  it("prefers a direct anchor over an ancestor anchor", () => {
+    const resources = [
+      makeResource("res-ancestor", "doc-ancestor"),
+      makeResource("res-direct", "doc-direct"),
+    ];
+    const documents = [
+      makeDocument("doc-ancestor", ["Tparent"]),
+      makeDocument("doc-direct", ["T2"]),
+    ];
+    expect(
+      resolveAnnotatorResourceId("T2", ["Troot", "Tparent"], resources, documents)
+    ).toBe("res-direct");
+  });
+});

--- a/packages/client/src/pages/Main/containers/AnnotatorBox/resolveAnnotatorResourceId.ts
+++ b/packages/client/src/pages/Main/containers/AnnotatorBox/resolveAnnotatorResourceId.ts
@@ -1,0 +1,33 @@
+import { IDocument, IResponseEntity } from "@inkvisitor/shared/types";
+
+/**
+ * Resolve which resource's document anchors the given territory. Prefers a
+ * resource whose document anchors the territory directly; otherwise walks the
+ * territory path from the closest ancestor outward. Returns `false` when no
+ * resource anchors the territory or any of its ancestors — the caller uses this
+ * to clear a stale selection when switching to a territory without a document.
+ */
+export const resolveAnnotatorResourceId = (
+  territoryId: string,
+  selectedTerritoryPath: string[],
+  resources: IResponseEntity[],
+  documents: IDocument[]
+): string | false => {
+  const findAnchoringResource = (tId: string) =>
+    resources.find((resource) => {
+      if (!resource.data.documentId) return false;
+      const document = documents.find((d) => d.id === resource.data.documentId);
+      return document?.entityIds.T.includes(tId) ?? false;
+    });
+
+  let resourceWithAnchor = findAnchoringResource(territoryId);
+
+  if (!resourceWithAnchor) {
+    for (let i = selectedTerritoryPath.length - 1; i > 0; i--) {
+      resourceWithAnchor = findAnchoringResource(selectedTerritoryPath[i]);
+      if (resourceWithAnchor) break;
+    }
+  }
+
+  return resourceWithAnchor ? resourceWithAnchor.id : false;
+};

--- a/packages/client/src/pages/Main/containers/EntityDetailBox/EntityDetailBox.tsx
+++ b/packages/client/src/pages/Main/containers/EntityDetailBox/EntityDetailBox.tsx
@@ -126,11 +126,9 @@ export const EntityDetailBox: React.FC<EntityDetailBox> = ({ onTabOpen, maxTabs 
 
   return (
     <>
-      {(showContent || detailBoxMinimized) && (
+      {entities && entities.length > 0 && (
         <StyledTabGroup>
-          {entities &&
-            entities.length > 0 &&
-            entities?.map((entity, key) => (
+          {entities.map((entity, key) => (
               <EntityDetailTab
                 key={key}
                 index={key}
@@ -162,7 +160,11 @@ export const EntityDetailBox: React.FC<EntityDetailBox> = ({ onTabOpen, maxTabs 
             isFetching={isFetching}
           />
         ) : (
-          <>{(ping === -10 || ping >= 0) && !detailBoxMinimized && <Loader show />}</>
+          <>
+            {(ping === -10 || ping >= 0) && !detailBoxMinimized && (
+              <Loader show />
+            )}
+          </>
         )}
       </>
     </>

--- a/packages/client/src/pages/Main/containers/StatementsListBox/StatementListHeader/StatementListHeaderStyles.tsx
+++ b/packages/client/src/pages/Main/containers/StatementsListBox/StatementListHeader/StatementListHeaderStyles.tsx
@@ -25,14 +25,6 @@ export const StyledMoveToParent = styled(animated.div)`
   margin-left: 0.3rem;
 `;
 
-export const StyledInfoText = styled.div`
-  font-size: ${({ theme }) => theme.fontSize["sm"]};
-  font-weight: ${({ theme }) => theme.fontWeight["normal"]};
-  display: flex;
-  align-items: center;
-  color: ${({ theme }) => theme.color["info"]};
-  margin-left: 0.3rem;
-`;
 export const StyledHeadingText = styled.div``;
 export const StyledSuggesterRow = styled.div`
   display: flex;

--- a/packages/client/src/pages/Main/hooks/useVerticalSeparators.ts
+++ b/packages/client/src/pages/Main/hooks/useVerticalSeparators.ts
@@ -245,12 +245,16 @@ export function useVerticalSeparators() {
           );
 
           if (
-            arePanelWidthsUndersized(savedWidths, [
-              firstPanelExpanded,
-              secondPanelExpanded,
-              thirdPanelExpanded,
-              fourthPanelExpanded,
-            ])
+            arePanelWidthsUndersized(
+              savedWidths,
+              [
+                firstPanelExpanded,
+                secondPanelExpanded,
+                thirdPanelExpanded,
+                fourthPanelExpanded,
+              ],
+              layoutWidth,
+            )
           ) {
             // something is undersized
             console.log("something is undersized");

--- a/packages/client/src/redux/features/layout/mainPage/panelWidthsSlice.tsx
+++ b/packages/client/src/redux/features/layout/mainPage/panelWidthsSlice.tsx
@@ -33,7 +33,7 @@ function computeInitialPanelWidths(): number[] {
       localStorage.getItem("thirdPanelExpanded") !== "false",
       localStorage.getItem("fourthPanelExpanded") !== "false",
     ];
-    if (!arePanelWidthsUndersized(widths, expanded)) {
+    if (!arePanelWidthsUndersized(widths, expanded, layoutWidth)) {
       return widths.map(floorNumberToOneDecimal);
     }
   }

--- a/packages/client/src/utils/layoutUtils.ts
+++ b/packages/client/src/utils/layoutUtils.ts
@@ -1,4 +1,5 @@
 import {
+  COLLAPSED_PANEL_WIDTH,
   EXTRA_SMALL_SCREEN_LIMIT,
   FIRST_PANEL_MIN_WIDTH,
   FOURTH_PANEL_MIN_WIDTH,
@@ -37,14 +38,64 @@ export function panelWidthsFromSeparators(
   ];
 }
 
+// Translates the stored base (fully expanded) panel widths into the widths the
+// panels actually render at, given which panels are collapsed. A collapsed
+// panel shrinks to COLLAPSED_PANEL_WIDTH and hands its freed space to the
+// neighbour that absorbs it. Mirrors the width memos in MainPage so the
+// undersized check below reasons about what the user really sees - otherwise a
+// collapsed neighbour (e.g. a collapsed fourth panel) leaves a stored width
+// looking negative/undersized even though the visible layout is fine.
+export function getEffectivePanelWidths(
+  widths: number[],
+  expanded: boolean[],
+  layoutWidth: number,
+): number[] {
+  const [firstExpanded, secondExpanded, thirdExpanded, fourthExpanded] = expanded;
+
+  const firstWidth = !firstExpanded
+    ? COLLAPSED_PANEL_WIDTH
+    : secondExpanded || thirdExpanded || fourthExpanded
+      ? widths[0]
+      : layoutWidth - 3 * COLLAPSED_PANEL_WIDTH;
+
+  const secondBaseWidth = firstExpanded
+    ? widths[1]
+    : widths[1] + widths[0] - COLLAPSED_PANEL_WIDTH;
+
+  const secondWidth = !secondExpanded
+    ? COLLAPSED_PANEL_WIDTH
+    : secondBaseWidth +
+      (!thirdExpanded && !fourthExpanded
+        ? widths[2] + widths[3] - 2 * COLLAPSED_PANEL_WIDTH
+        : 0);
+
+  let thirdWidth = !thirdExpanded
+    ? COLLAPSED_PANEL_WIDTH
+    : fourthExpanded
+      ? widths[2]
+      : widths[2] + widths[3] - COLLAPSED_PANEL_WIDTH;
+
+  if (!secondExpanded && thirdExpanded) {
+    thirdWidth += secondBaseWidth - COLLAPSED_PANEL_WIDTH;
+  }
+
+  const fourthWidth = !fourthExpanded
+    ? COLLAPSED_PANEL_WIDTH
+    : layoutWidth - firstWidth - secondWidth - thirdWidth;
+
+  return [firstWidth, secondWidth, thirdWidth, fourthWidth];
+}
+
 export function arePanelWidthsUndersized(
   widths: number[],
   expanded: boolean[] = [true, true, true, true],
+  layoutWidth: number = widths.reduce((sum, width) => sum + width, 0),
 ): boolean {
+  const effective = getEffectivePanelWidths(widths, expanded, layoutWidth);
   return (
-    (expanded[0] && widths[0] < FIRST_PANEL_MIN_WIDTH) ||
-    (expanded[1] && widths[1] < SECOND_PANEL_MIN_WIDTH) ||
-    (expanded[2] && widths[2] < THIRD_PANEL_MIN_WIDTH) ||
-    (expanded[3] && widths[3] < FOURTH_PANEL_MIN_WIDTH)
+    (expanded[0] && effective[0] < FIRST_PANEL_MIN_WIDTH) ||
+    (expanded[1] && effective[1] < SECOND_PANEL_MIN_WIDTH) ||
+    (expanded[2] && effective[2] < THIRD_PANEL_MIN_WIDTH) ||
+    (expanded[3] && effective[3] < FOURTH_PANEL_MIN_WIDTH)
   );
 }


### PR DESCRIPTION
- Fix scroll-to-anchor when switching territories sharing the same document — keep annotator alive, refetch document for fresh anchors instead of destroying and rebuilding Close #3147 
- Keep document title visible during background refetch — only show loader on initial load
- Reset warning chip when document changes — prevents stale warnings from previous document
- Keep locate anchor button visible during save — no longer hidden by fetching state
- Accept new server content on refetch — when no local edit is active, ingest updated anchors from other users
- Add highlight info tooltip on minimized button — shows colored column list of active entity classes
- Enable "select all" option in highlight dropdowns — both inline and modal versions
- Make sure double click on EntityTag always focuses the last opened tab
- Fix the direction of third panel toggle button in some combinations where directed non-intuitively
- Fix panel widths flashing to default on reload when fourth panel collapsed
- Fix z-index of suggester entity list in modal
