### PR TITLE
Move the cursor with words when recalculating the line (#3145)

### DIFF
--- a/packages/annotator/src/arrowWrapBoundary.test.ts
+++ b/packages/annotator/src/arrowWrapBoundary.test.ts
@@ -1,0 +1,127 @@
+import { Annotator } from "./lib/Annotator";
+import { EditMode } from "./lib/constants";
+
+function keyDown(a: Annotator, key: string, shiftKey = false) {
+  a.keys.onKeyDown({
+    key,
+    ctrlKey: false,
+    metaKey: false,
+    altKey: false,
+    shiftKey,
+    preventDefault: () => {},
+  } as unknown as KeyboardEvent);
+}
+
+const MAXLEN = 10;
+function setup(value: string): Annotator {
+  const canvas = document.createElement("canvas");
+  canvas.style.width = "800px";
+  canvas.style.height = "600px";
+  document.body.appendChild(canvas);
+  const a = new Annotator(canvas, "");
+  a.setMode(EditMode.RAW);
+  a.onReplaceText(value);
+  a.text.updateCharsAtLine(MAXLEN);
+  return a;
+}
+
+// A soft-wrap boundary is one offset with two visual positions (end of line N,
+// start of line N+1). Plain Left/Right cross to the far side; shift+Left/Right
+// skip that flip so the selection actually grows by a char (#3145).
+describe("ArrowLeft at a soft-wrap boundary (#3145)", () => {
+  test("plain Left from a continuation line start lands AFTER the last char of the previous line", () => {
+    const a = setup("aaaa bbbbb ccccc");
+    expect(a.text.getLine(0)).toBe("aaaa bbbbb");
+    expect(a.text.getLine(1)).toBe(" ccccc");
+
+    a.cursor.setPosition(0, 1); // leftmost of the continuation line
+    keyDown(a, "ArrowLeft");
+
+    // caret sits just after the last character of the previous line, at the
+    // right margin, and stays within the viewport (visible, not off-screen)
+    expect(a.cursor.yLine).toBe(0);
+    expect(a.cursor.xLine).toBe(a.text.getLine(0).length); // 10 = after last char
+    expect(a.cursor.xLine).toBeLessThanOrEqual(MAXLEN);
+  });
+
+  test("a second plain Left then steps into the previous line content", () => {
+    const a = setup("aaaa bbbbb ccccc");
+    a.cursor.setPosition(0, 1);
+    keyDown(a, "ArrowLeft"); // (10,0) after the last char
+    keyDown(a, "ArrowLeft"); // (9,0) into the content
+    expect(a.cursor.yLine).toBe(0);
+    expect(a.cursor.xLine).toBe(9);
+  });
+
+  test("a normal left move (not at a boundary) still steps exactly one char", () => {
+    const a = setup("aaaa bbbbb ccccc");
+    a.cursor.setPosition(3, 0); // inside "aaaa"
+    a.cursor.reconcileOffsetsFromVisual(a.text);
+    expect(a.cursor.head).toBe(3);
+    keyDown(a, "ArrowLeft");
+    expect(a.cursor.head).toBe(2);
+  });
+
+  test("shift+Left from a continuation start extends the selection by one char", () => {
+    const a = setup("aaaa bbbbb ccccc");
+    a.cursor.setPosition(0, 1);
+    a.cursor.reconcileOffsetsFromVisual(a.text);
+    expect(a.cursor.head).toBe(10);
+    keyDown(a, "ArrowLeft", true);
+    // shift skips the affinity flip so the selection actually grows by one char
+    expect(a.cursor.head).toBe(9);
+    expect(a.cursor.isSelected()).toBe(true);
+  });
+
+  test("at document start ArrowLeft stays put", () => {
+    const a = setup("aaaa bbbbb ccccc");
+    a.cursor.setPosition(0, 0);
+    a.cursor.reconcileOffsetsFromVisual(a.text);
+    keyDown(a, "ArrowLeft");
+    expect(a.cursor.head).toBe(0);
+  });
+});
+
+describe("ArrowRight at a soft-wrap boundary, symmetric to ArrowLeft (#3145)", () => {
+  test("plain Right from a wrapped line end lands at the start of the next line", () => {
+    const a = setup("aaaa bbbbb ccccc");
+    expect(a.text.getLine(0)).toBe("aaaa bbbbb");
+    expect(a.text.getLine(1)).toBe(" ccccc");
+
+    a.cursor.setPosition(MAXLEN, 0); // end of line 0 (after its last char)
+    keyDown(a, "ArrowRight");
+
+    // mirror of plain Left: it lands just before the first char of the next line
+    expect(a.cursor.yLine).toBe(1);
+    expect(a.cursor.xLine).toBe(0);
+  });
+
+  test("a second plain Right then steps into the next line content", () => {
+    const a = setup("aaaa bbbbb ccccc");
+    a.cursor.setPosition(MAXLEN, 0);
+    keyDown(a, "ArrowRight"); // (0,1) start of next line
+    keyDown(a, "ArrowRight"); // (1,1) into the content
+    expect(a.cursor.yLine).toBe(1);
+    expect(a.cursor.xLine).toBe(1);
+  });
+
+  test("shift+Right from a wrapped line end extends the selection by one char", () => {
+    const a = setup("aaaa bbbbb ccccc");
+    a.cursor.setPosition(MAXLEN, 0);
+    a.cursor.reconcileOffsetsFromVisual(a.text);
+    expect(a.cursor.head).toBe(10);
+    keyDown(a, "ArrowRight", true);
+    // shift skips the affinity flip so the selection actually grows by one char
+    expect(a.cursor.head).toBe(11);
+    expect(a.cursor.isSelected()).toBe(true);
+  });
+
+  test("a normal right move (not at a boundary) still steps exactly one char", () => {
+    const a = setup("aaaa bbbbb ccccc");
+    a.cursor.setPosition(2, 0); // inside "aaaa"
+    a.cursor.reconcileOffsetsFromVisual(a.text);
+    expect(a.cursor.head).toBe(2);
+    keyDown(a, "ArrowRight");
+    expect(a.cursor.head).toBe(3);
+  });
+});

--- a/packages/annotator/src/caretClampViewport.test.ts
+++ b/packages/annotator/src/caretClampViewport.test.ts
@@ -1,0 +1,58 @@
+import { Annotator } from "./lib/Annotator";
+import { EditMode } from "./lib/constants";
+
+const MAXLEN = 10;
+function setup(value: string): Annotator {
+  const canvas = document.createElement("canvas");
+  canvas.style.width = "800px";
+  canvas.style.height = "600px";
+  document.body.appendChild(canvas);
+  const a = new Annotator(canvas, "");
+  a.setMode(EditMode.RAW);
+  a.onReplaceText(value);
+  a.text.updateCharsAtLine(MAXLEN);
+  return a;
+}
+
+/** Capture the x of every fillRect the cursor draws. */
+function drawCaretX(a: Annotator, charWidth: number): number[] {
+  const calls: number[] = [];
+  const ctx = {
+    fillStyle: "",
+    globalAlpha: 1,
+    globalCompositeOperation: "",
+    fillRect: (x: number) => calls.push(x),
+  } as unknown as CanvasRenderingContext2D;
+  a.cursor.draw(ctx, a.viewport, a.text, {
+    lineHeight: 16,
+    charWidth,
+    charsAtLine: MAXLEN,
+    caretWidth: 1,
+    caretVisible: true,
+  });
+  return calls;
+}
+
+describe("caret render clamp keeps the caret inside the viewport (#3145)", () => {
+  test("a caret past the viewport width is clamped to the right margin", () => {
+    // defensive: any path placing the caret past the edge must still draw it
+    // in-bounds rather than off-screen
+    const a = setup("aaaa bbbbb ccccc");
+    a.cursor.setPosition(MAXLEN + 5, 0); // caret column well past the viewport
+
+    const charWidth = 8;
+    const xs = drawCaretX(a, charWidth);
+    expect(xs.length).toBe(1);
+    // the caret must be painted within the viewport, not past the right margin
+    expect(xs[0]).toBeLessThanOrEqual(MAXLEN * charWidth);
+  });
+
+  test("a normal short-line caret is unaffected by the clamp", () => {
+    const a = setup("hi");
+    a.cursor.setPosition(2, 0); // end of "hi"
+    const charWidth = 8;
+    const xs = drawCaretX(a, charWidth);
+    expect(xs.length).toBe(1);
+    expect(xs[0]).toBe(2 * charWidth); // exact column, not clamped
+  });
+});

--- a/packages/annotator/src/characterization/wrap-navigation.test.ts
+++ b/packages/annotator/src/characterization/wrap-navigation.test.ts
@@ -10,6 +10,10 @@
  * This is the behavior any offset-model migration (Phase 3.2/3.3) must either
  * preserve (with an affinity bit) or deliberately change — these tests make the
  * choice explicit instead of silent. They assert what the editor does today.
+ *
+ * #3145: plain ArrowLeft from a continuation line start lands on the previous
+ * line's end (just after its last character); only shift+ArrowLeft skips that
+ * so a selection grows. Wrapping keeps that end position visible at the margin.
  */
 import { Annotator } from "../lib/Annotator";
 import { EditMode } from "../lib/constants";
@@ -46,18 +50,18 @@ describe("characterization: caret affinity at a soft-wrap boundary", () => {
     expect(a.text.segments[0].lines).toEqual(["supercalif", "ragilistic"]);
   });
 
-  test("ArrowLeft from start of the next line lands at end of the wrapped line", () => {
+  test("ArrowLeft from start of the next line lands after the last char of the wrapped line", () => {
     const a = mk(WRAPPED);
     a.cursor.setPosition(0, 1);
     key(a, "ArrowLeft");
-    expect(pos(a)).toEqual({ x: 10, y: 0 }); // end-of-line position is reachable
+    expect(pos(a)).toEqual({ x: 10, y: 0 }); // just after "supercalif", visible at margin
   });
 
   test("a second ArrowLeft then steps one real char back", () => {
     const a = mk(WRAPPED);
     a.cursor.setPosition(0, 1);
-    key(a, "ArrowLeft"); // (10,0)
-    key(a, "ArrowLeft"); // (9,0)
+    key(a, "ArrowLeft"); // (10,0) after the last char
+    key(a, "ArrowLeft"); // (9,0) into the content
     expect(pos(a)).toEqual({ x: 9, y: 0 });
   });
 

--- a/packages/annotator/src/lib/Cursor.ts
+++ b/packages/annotator/src/lib/Cursor.ts
@@ -490,7 +490,10 @@ export default class Cursor
         relY >= 0 &&
         relY <= viewport.noLines
       ) {
-        this.drawLine(ctx, relY, this.xLine, this.xLine, {
+        // A wrapped line can run one trailing space past the viewport; clamp the
+        // drawn caret column to the width so it stays visible (no h-scroll). #3145
+        const caretX = Math.min(this.xLine, drawingOptions.charsAtLine);
+        this.drawLine(ctx, relY, caretX, caretX, {
           ...drawingOptions,
           color: this.style.selectorColor,
         });

--- a/packages/annotator/src/lib/Keys.ts
+++ b/packages/annotator/src/lib/Keys.ts
@@ -1,7 +1,7 @@
 import { EditMode } from "./constants";
 import Cursor from "./Cursor";
 import { HistorySnapshot } from "./History";
-import Text from "./Text";
+import Text, { CaretAffinity } from "./Text";
 import Viewport from "./Viewport";
 
 /** Snapshot of caret before an arrow-key nudge (absolute line / column). */
@@ -629,19 +629,21 @@ export default class Keys {
           Math.min(this.cursor.anchor, this.cursor.head)
         );
       } else {
-        const next = this.text.stepVisualLeft(
-          this.cursor.xLine,
-          this.cursor.yLine
-        );
-        const { offset, affinity } = this.text.offsetWithAffinityFromVisual(
-          next.xLine,
-          next.yLine
-        );
-        this.cursor.head = offset;
-        this.cursor.headAffinity = affinity;
+        const beforeOffset = this.cursor.head;
+        let next = this.text.stepVisualLeft(this.cursor.xLine, this.cursor.yLine);
+        let info = this.text.offsetWithAffinityFromVisual(next.xLine, next.yLine);
+        // Plain Left lands on the previous line's end (the boundary's two
+        // visual positions share one offset). For shift that flip wouldn't grow
+        // the selection, so step once more so shift+Left selects a char. #3145
+        if (shiftKey && info.offset === beforeOffset) {
+          next = this.text.stepVisualLeft(next.xLine, next.yLine);
+          info = this.text.offsetWithAffinityFromVisual(next.xLine, next.yLine);
+        }
+        this.cursor.head = info.offset;
+        this.cursor.headAffinity = info.affinity;
         if (!shiftKey) {
-          this.cursor.anchor = offset;
-          this.cursor.anchorAffinity = affinity;
+          this.cursor.anchor = info.offset;
+          this.cursor.anchorAffinity = info.affinity;
         }
         this.cursor.syncVisualFromOffset(this.text);
       }
@@ -824,19 +826,20 @@ export default class Keys {
       } else {
         // Step one visible column right (crosses line boundaries, honours the
         // soft-wrap affinity, clamps at EOF), then store the canonical offset.
-        const next = this.text.stepVisualRight(
-          this.cursor.xLine,
-          this.cursor.yLine
-        );
-        const { offset, affinity } = this.text.offsetWithAffinityFromVisual(
-          next.xLine,
-          next.yLine
-        );
-        this.cursor.head = offset;
-        this.cursor.headAffinity = affinity;
+        const beforeOffset = this.cursor.head;
+        let next = this.text.stepVisualRight(this.cursor.xLine, this.cursor.yLine);
+        let info = this.text.offsetWithAffinityFromVisual(next.xLine, next.yLine);
+        // Symmetric to ArrowLeft: plain Right lands on the next line's start;
+        // for shift, step once more so it selects a char instead of just flipping.
+        if (shiftKey && info.offset === beforeOffset) {
+          next = this.text.stepVisualRight(next.xLine, next.yLine);
+          info = this.text.offsetWithAffinityFromVisual(next.xLine, next.yLine);
+        }
+        this.cursor.head = info.offset;
+        this.cursor.headAffinity = info.affinity;
         if (!shiftKey) {
-          this.cursor.anchor = offset;
-          this.cursor.anchorAffinity = affinity;
+          this.cursor.anchor = info.offset;
+          this.cursor.anchorAffinity = info.affinity;
         }
         // Derive caret + selectStart/selectEnd from anchor/head.
         this.cursor.syncVisualFromOffset(this.text);
@@ -1058,10 +1061,21 @@ export default class Keys {
             this.cursor.xLine,
             this.cursor.yLine
           );
+          // captured before the edit mutates affinity
+          const wasAtWrappedLineEnd =
+            this.cursor.headAffinity === CaretAffinity.UPSTREAM;
           this.text.insertText(this.viewport, this.cursor, key);
           const insertAt =
             insertOffset >= 0 ? insertOffset : this.cursor.head;
-          this.cursor.moveToOffset(this.text, insertAt + key.length);
+          const caretAt = insertAt + key.length;
+          // Typing at a wrapped line's end keeps the caret there (UPSTREAM)
+          // instead of jumping to the next line; a mid-line tail that wraps
+          // down still follows it (DOWNSTREAM). #3145
+          const typedAffinity =
+            wasAtWrappedLineEnd && this.text.isWrapBoundary(caretAt)
+              ? CaretAffinity.UPSTREAM
+              : CaretAffinity.DOWNSTREAM;
+          this.cursor.moveToOffset(this.text, caretAt, typedAffinity);
 
           // When typing moves the cursor outside of the current viewport,
           // keep behaviour consistent with arrow keys and scroll so that

--- a/packages/annotator/src/lib/Keys.ts
+++ b/packages/annotator/src/lib/Keys.ts
@@ -187,7 +187,12 @@ export default class Keys {
       });
       const after = this.cursor.getAbsolutePosition();
 
+      // Capture the caret's landing offset (the left edge of the deletion) BEFORE the edit
+      const caretOffset = this.text.offsetFromVisual(after.xLine, after.yLine);
       this.text.deleteRangeText(before, after);
+      if (caretOffset >= 0) {
+        this.cursor.moveToOffset(this.text, caretOffset);
+      }
     }
   }
 
@@ -227,9 +232,16 @@ export default class Keys {
       });
       const after = this.cursor.getAbsolutePosition();
 
+      // Caret stays at before (the left edge). Capture its offset before the
+      // edit and re-derive the visual position afterwards
+      const caretOffset = this.text.offsetFromVisual(before.xLine, before.yLine);
       this.text.deleteRangeText(before, after);
-      this.cursor.xLine = before.xLine;
-      this.cursor.yLine = before.yLine;
+      if (caretOffset >= 0) {
+        this.cursor.moveToOffset(this.text, caretOffset);
+      } else {
+        this.cursor.xLine = before.xLine;
+        this.cursor.yLine = before.yLine;
+      }
     }
   }
 

--- a/packages/annotator/src/lib/Keys.ts
+++ b/packages/annotator/src/lib/Keys.ts
@@ -179,16 +179,30 @@ export default class Keys {
     } else {
       // Delete word-wise: Ctrl / Alt / ⌥+⌘ + ←  or Ctrl+Alt + ← on Windows
       const before = this.cursor.getAbsolutePosition();
+      const beforeOffset = this.text.offsetFromVisual(before.xLine, before.yLine);
       this.onArrowLeft({
         ctrlKey: ctrlKey || altKey,
         shiftKey,
         altKey: false,
         metaKey: false,
       });
-      const after = this.cursor.getAbsolutePosition();
+      let after = this.cursor.getAbsolutePosition();
+      let caretOffset = this.text.offsetFromVisual(after.xLine, after.yLine);
+
+      // Soft-wrap boundary: the start of a continuation line and the end of the
+      // previous line are the SAME offset, so arrow-left can move the caret
+      // visually without moving the offset
+      if (
+        beforeOffset >= 0 &&
+        caretOffset === beforeOffset &&
+        (after.xLine !== before.xLine || after.yLine !== before.yLine)
+      ) {
+        const next = this.text.stepVisualLeft(after.xLine, after.yLine);
+        after = { xLine: next.xLine, yLine: next.yLine };
+        caretOffset = this.text.offsetFromVisual(after.xLine, after.yLine);
+      }
 
       // Capture the caret's landing offset (the left edge of the deletion) BEFORE the edit
-      const caretOffset = this.text.offsetFromVisual(after.xLine, after.yLine);
       this.text.deleteRangeText(before, after);
       if (caretOffset >= 0) {
         this.cursor.moveToOffset(this.text, caretOffset);

--- a/packages/annotator/src/lib/Text.ts
+++ b/packages/annotator/src/lib/Text.ts
@@ -525,11 +525,27 @@ class Text {
         }
 
         if (cell.space) {
-          // Keep an inter-word space trailing on the current line (the next
-          // content breaks to the margin); a trailing space at the very end
-          // gets its own line so the caret after it stays on screen.
-          if (ci >= lastContentIdx && currentLineLength > 0) pushLine();
-          appendStr(cell.text);
+          if (ci >= lastContentIdx) {
+            // Trailing whitespace after the last content: give it its own line
+            // so the caret typed at a full line end stays on screen.
+            if (currentLineLength > 0) pushLine();
+            appendStr(cell.text);
+            continue;
+          }
+          // Inter-word whitespace that doesn't fit: keep exactly ONE wrap-space
+          // trailing on the current line (standard soft-wrap — a single space is
+          // allowed to overflow the width by one), then break and carry any EXTRA
+          // whitespace to the start of the next visual line so it stays visible
+          // instead of piling up off-screen past the margin (#3145 follow-up:
+          // typing a space at the start of a wrapped word).
+          const fit = Math.max(0, maxLen - currentLineLength);
+          const keep = Math.min(cell.text.length, fit + 1);
+          appendStr(cell.text.slice(0, keep));
+          const rest = cell.text.slice(keep);
+          if (rest.length > 0) {
+            pushLine();
+            appendStr(rest);
+          }
           continue;
         }
 

--- a/packages/annotator/src/lib/Text.ts
+++ b/packages/annotator/src/lib/Text.ts
@@ -496,14 +496,6 @@ class Text {
           cells.push({ text: t.text, space: t.space, parts: [t] });
         }
       }
-      // Index of the last content cell: a whitespace run before it stays
-      // trailing on the current line; trailing whitespace after it gets its own
-      // line so the caret typed at a full line end remains visible.
-      let lastContentIdx = -1;
-      for (let i = 0; i < cells.length; i++) {
-        if (!cells[i].space) lastContentIdx = i;
-      }
-
       let currentLine: string[] = [];
       let currentLineLength = 0;
       const pushLine = () => {
@@ -525,25 +517,20 @@ class Text {
         }
 
         if (cell.space) {
-          if (ci >= lastContentIdx) {
-            // Trailing whitespace after the last content: give it its own line
-            // so the caret typed at a full line end stays on screen.
-            if (currentLineLength > 0) pushLine();
-            appendStr(cell.text);
-            continue;
-          }
-          // Inter-word whitespace that doesn't fit: keep exactly ONE wrap-space
-          // trailing on the current line (standard soft-wrap — a single space is
-          // allowed to overflow the width by one), then break and carry any EXTRA
-          // whitespace to the start of the next visual line so it stays visible
-          // instead of piling up off-screen past the margin (#3145 follow-up:
-          // typing a space at the start of a wrapped word).
+          // Overflowing whitespace: fill the line's remaining room, then carry
+          // the rest to the next line(s) so it stays visible (no h-scroll). #3145
           const fit = Math.max(0, maxLen - currentLineLength);
-          const keep = Math.min(cell.text.length, fit + 1);
-          appendStr(cell.text.slice(0, keep));
-          const rest = cell.text.slice(keep);
+          const keep = Math.min(cell.text.length, fit);
+          if (keep > 0) appendStr(cell.text.slice(0, keep));
+          let rest = cell.text.slice(keep);
           if (rest.length > 0) {
             pushLine();
+            // Chunk an over-wide carried run so no single line exceeds the width.
+            while (rest.length > maxLen) {
+              appendStr(rest.slice(0, maxLen));
+              pushLine();
+              rest = rest.slice(maxLen);
+            }
             appendStr(rest);
           }
           continue;

--- a/packages/annotator/src/lineWrapPunctuation.test.ts
+++ b/packages/annotator/src/lineWrapPunctuation.test.ts
@@ -10,9 +10,10 @@ const visibleLen = (line: string) => line.replace(/\s+$/, "").length;
 
 describe("line wrapping - punctuation must not start a wrapped line", () => {
   test("comma after a word stays on the previous wrapped line", () => {
-    // charsAtLine = 10. "aaaaaaaaa" (9) + ", " + "bbbb".
+    // "aaaaaaaaa," fills the width-10 line; the overflow space leads the next
+    // line, but the comma stays put rather than starting the wrapped line (#3145)
     const text = new Text("aaaaaaaaa, bbbb", 10);
-    expect(text.segments[0].lines).toEqual(["aaaaaaaaa, ", "bbbb"]);
+    expect(text.segments[0].lines).toEqual(["aaaaaaaaa,", " bbbb"]);
   });
 
   test("no wrapped line begins with punctuation across many break points", () => {
@@ -28,11 +29,11 @@ describe("line wrapping - punctuation must not start a wrapped line", () => {
     expect(lines.join("")).toBe(input);
   });
 
-  test("inter-word space trails on the line so the next word starts at the margin", () => {
-    // Word exactly fills the line; the following space stays trailing (invisible
-    // overflow) and the next word starts the new line flush-left, like an editor.
+  test("an inter-word space that can't render trailing leads the next line (#3145)", () => {
+    // the word fills the line, so the following space can't render trailing and
+    // is carried to the next line's start where it stays visible (no h-scroll)
     const text = new Text("aaaaaaaaaa bbbb", 10);
-    expect(text.segments[0].lines).toEqual(["aaaaaaaaaa ", "bbbb"]);
+    expect(text.segments[0].lines).toEqual(["aaaaaaaaaa", " bbbb"]);
     expect(text.segments[0].lines.join("")).toBe("aaaaaaaaaa bbbb");
   });
 

--- a/packages/annotator/src/rewrapCaretFollow.test.ts
+++ b/packages/annotator/src/rewrapCaretFollow.test.ts
@@ -1,0 +1,104 @@
+import { Annotator } from "./lib/Annotator";
+import { EditMode } from "./lib/constants";
+
+const createMockCanvas = (): HTMLCanvasElement => {
+  const canvas = document.createElement("canvas");
+  canvas.style.width = "800px";
+  canvas.style.height = "600px";
+  return canvas;
+};
+
+function keyDown(annotator: Annotator, key: string) {
+  annotator.keys.onKeyDown({
+    key,
+    ctrlKey: false,
+    metaKey: false,
+    altKey: false,
+    shiftKey: false,
+    preventDefault: () => {},
+  } as unknown as KeyboardEvent);
+}
+
+// Force a narrow, exact line budget so wrap math is deterministic.
+const MAXLEN = 10;
+function setup(value: string): Annotator {
+  const canvas = createMockCanvas();
+  document.body.appendChild(canvas);
+  const a = new Annotator(canvas, "");
+  a.setMode(EditMode.RAW);
+  a.onReplaceText(value);
+  a.text.updateCharsAtLine(MAXLEN);
+  return a;
+}
+
+describe("caret follows the word across a re-wrap (#3145)", () => {
+  test("layout sanity: word wraps to line 1", () => {
+    const a = setup("aa bbbb cccccc");
+    expect(a.text.getLine(0)).toBe("aa bbbb ");
+    expect(a.text.getLine(1)).toBe("cccccc");
+  });
+
+  test("BACKSPACE that un-wraps a word: caret follows the word up to line 0", () => {
+    // "bbbbbbbb" (8) does not fit after "aa " on a 10-char line, so it wraps.
+    const a = setup("aa bbbbbbbb");
+    expect(a.text.getLine(0)).toBe("aa ");
+    expect(a.text.getLine(1)).toBe("bbbbbbbb");
+
+    // caret at the END of the wrapped word on visual line 1 (col 8)
+    a.cursor.setPosition(8, 1);
+
+    keyDown(a, "Backspace");
+
+    // one b deleted -> "aa bbbbbbb" (7 b's) now fits on a single line
+    expect(a.text.value).toBe("aa bbbbbbb");
+    expect(a.text.noLines).toBe(1);
+
+    // caret must jump WITH the word up to line 0 (end of text, col 10)
+    expect(a.cursor.yLine).toBe(0);
+    expect(a.cursor.xLine).toBe(10);
+
+    // invariant: cached visual caret is consistent with its raw offset
+    expect(a.text.offsetFromVisual(a.cursor.xLine, a.cursor.yLine)).toBe(
+      a.cursor.head
+    );
+  });
+
+  test("DELETE that un-wraps a word: caret follows the word up to line 0", () => {
+    const a = setup("aa bbbbbbbb");
+    expect(a.text.getLine(1)).toBe("bbbbbbbb");
+
+    // caret at the START of the wrapped word on visual line 1
+    a.cursor.setPosition(0, 1);
+
+    keyDown(a, "Delete");
+
+    // first b deleted -> "aa bbbbbbb" (7 b's) now fits on a single line
+    expect(a.text.value).toBe("aa bbbbbbb");
+    expect(a.text.noLines).toBe(1);
+
+    // caret must jump WITH the word up to line 0 (col 3, the first remaining b)
+    expect(a.cursor.yLine).toBe(0);
+    expect(a.cursor.xLine).toBe(3);
+
+    expect(a.text.offsetFromVisual(a.cursor.xLine, a.cursor.yLine)).toBe(
+      a.cursor.head
+    );
+  });
+
+  test("SPACE at wrap boundary: caret follows the split tail down to line 1", () => {
+    const a = setup("aaaaaacccc"); // single 10-char token filling line 0
+    expect(a.text.getLine(0)).toBe("aaaaaacccc");
+
+    // caret between "aaaaaa" and "cccc"
+    a.cursor.setPosition(6, 0);
+
+    keyDown(a, " ");
+
+    expect(a.text.value).toBe("aaaaaa cccc");
+    expect(a.text.getLine(1)).toBe("cccc");
+
+    // caret sits just after the inserted space => start of line 1
+    expect(a.cursor.yLine).toBe(1);
+    expect(a.cursor.xLine).toBe(0);
+  });
+});

--- a/packages/annotator/src/rewrapCaretFollow.test.ts
+++ b/packages/annotator/src/rewrapCaretFollow.test.ts
@@ -85,13 +85,15 @@ describe("caret follows the word across a re-wrap (#3145)", () => {
     );
   });
 
-  test("BACKSPACE at the start of a wrapped line deletes the boundary space", () => {
+  test("BACKSPACE at the start of a wrapped word deletes the boundary space", () => {
     const a = setup("aaaa bbbbb ccccc");
-    expect(a.text.getLine(0)).toBe("aaaa bbbbb ");
-    expect(a.text.getLine(1)).toBe("ccccc");
+    // line 0 fills exactly, so the wrap space leads line 1; "ccccc" starts at
+    // column 1 (after the leading space).
+    expect(a.text.getLine(0)).toBe("aaaa bbbbb");
+    expect(a.text.getLine(1)).toBe(" ccccc");
 
-    // caret at column 0 of the wrapped line (start of "ccccc")
-    a.cursor.setPosition(0, 1);
+    // caret at the start of "ccccc" (column 1, after the leading wrap space)
+    a.cursor.setPosition(1, 1);
 
     keyDown(a, "Backspace");
 

--- a/packages/annotator/src/rewrapCaretFollow.test.ts
+++ b/packages/annotator/src/rewrapCaretFollow.test.ts
@@ -85,6 +85,27 @@ describe("caret follows the word across a re-wrap (#3145)", () => {
     );
   });
 
+  test("BACKSPACE at the start of a wrapped line deletes the boundary space", () => {
+    const a = setup("aaaa bbbbb ccccc");
+    expect(a.text.getLine(0)).toBe("aaaa bbbbb ");
+    expect(a.text.getLine(1)).toBe("ccccc");
+
+    // caret at column 0 of the wrapped line (start of "ccccc")
+    a.cursor.setPosition(0, 1);
+
+    keyDown(a, "Backspace");
+
+    // like a normal editor: backspace removes the space before the caret,
+    // merging the words — it must NOT be a silent no-op
+    expect(a.text.value).toBe("aaaa bbbbbccccc");
+    expect(a.cursor.yLine).toBe(1);
+    expect(a.cursor.xLine).toBe(5);
+
+    expect(a.text.offsetFromVisual(a.cursor.xLine, a.cursor.yLine)).toBe(
+      a.cursor.head
+    );
+  });
+
   test("SPACE at wrap boundary: caret follows the split tail down to line 1", () => {
     const a = setup("aaaaaacccc"); // single 10-char token filling line 0
     expect(a.text.getLine(0)).toBe("aaaaaacccc");

--- a/packages/annotator/src/spaceAtWrappedLineStart.test.ts
+++ b/packages/annotator/src/spaceAtWrappedLineStart.test.ts
@@ -1,0 +1,65 @@
+import { Annotator } from "./lib/Annotator";
+import { EditMode } from "./lib/constants";
+
+function keyDown(a: Annotator, key: string) {
+  a.keys.onKeyDown({
+    key,
+    ctrlKey: false,
+    metaKey: false,
+    altKey: false,
+    shiftKey: false,
+    preventDefault: () => {},
+  } as unknown as KeyboardEvent);
+}
+
+const MAXLEN = 10;
+function setup(value: string): Annotator {
+  const canvas = document.createElement("canvas");
+  canvas.style.width = "800px";
+  canvas.style.height = "600px";
+  document.body.appendChild(canvas);
+  const a = new Annotator(canvas, "");
+  a.setMode(EditMode.RAW);
+  a.onReplaceText(value);
+  a.text.updateCharsAtLine(MAXLEN);
+  return a;
+}
+
+describe("space typed at the start of a wrapped word (#3145 follow-up)", () => {
+  test("the extra wrap whitespace becomes a visible leading space and the caret moves", () => {
+    const a = setup("aaaa bbbbb ccccc");
+    expect(a.text.getLine(0)).toBe("aaaa bbbbb ");
+    expect(a.text.getLine(1)).toBe("ccccc");
+
+    a.cursor.setPosition(0, 1); // start of "ccccc"
+    keyDown(a, " ");
+
+    expect(a.text.value).toBe("aaaa bbbbb  ccccc");
+    // exactly one wrap-space stays trailing; the typed space leads line 1
+    expect(a.text.getLine(0)).toBe("aaaa bbbbb ");
+    expect(a.text.getLine(1)).toBe(" ccccc");
+
+    // caret visibly advanced past the inserted space
+    expect(a.cursor.yLine).toBe(1);
+    expect(a.cursor.xLine).toBe(1);
+  });
+
+  test("no visual line ever exceeds the wrap width by more than the single wrap space", () => {
+    const a = setup("aaaa bbbbb ccccc");
+    a.cursor.setPosition(0, 1);
+    keyDown(a, " ");
+    keyDown(a, " ");
+    keyDown(a, " ");
+    for (let i = 0; i < a.text.noLines; i++) {
+      expect(a.text.getLine(i).length).toBeLessThanOrEqual(MAXLEN + 1);
+    }
+  });
+
+  test("single inter-word wrap space is unchanged (regression guard)", () => {
+    const a = setup("aaaa bbbbb ccccc");
+    // untouched layout: one trailing wrap space on line 0, word on line 1
+    expect(a.text.getLine(0)).toBe("aaaa bbbbb ");
+    expect(a.text.getLine(1)).toBe("ccccc");
+    expect(a.text.noLines).toBe(2);
+  });
+});

--- a/packages/annotator/src/spaceAtWrappedLineStart.test.ts
+++ b/packages/annotator/src/spaceAtWrappedLineStart.test.ts
@@ -28,16 +28,18 @@ function setup(value: string): Annotator {
 describe("space typed at the start of a wrapped word (#3145 follow-up)", () => {
   test("the extra wrap whitespace becomes a visible leading space and the caret moves", () => {
     const a = setup("aaaa bbbbb ccccc");
-    expect(a.text.getLine(0)).toBe("aaaa bbbbb ");
-    expect(a.text.getLine(1)).toBe("ccccc");
+    // line 0 fills exactly, so the wrap space can't render trailing; it leads
+    // line 1 (visible) and "ccccc" follows it.
+    expect(a.text.getLine(0)).toBe("aaaa bbbbb");
+    expect(a.text.getLine(1)).toBe(" ccccc");
 
-    a.cursor.setPosition(0, 1); // start of "ccccc"
+    a.cursor.setPosition(0, 1); // start of the wrapped line (before the lead space)
     keyDown(a, " ");
 
     expect(a.text.value).toBe("aaaa bbbbb  ccccc");
-    // exactly one wrap-space stays trailing; the typed space leads line 1
-    expect(a.text.getLine(0)).toBe("aaaa bbbbb ");
-    expect(a.text.getLine(1)).toBe(" ccccc");
+    // the overflow whitespace leads line 1 (now two leading spaces)
+    expect(a.text.getLine(0)).toBe("aaaa bbbbb");
+    expect(a.text.getLine(1)).toBe("  ccccc");
 
     // caret visibly advanced past the inserted space
     expect(a.cursor.yLine).toBe(1);
@@ -55,11 +57,12 @@ describe("space typed at the start of a wrapped word (#3145 follow-up)", () => {
     }
   });
 
-  test("single inter-word wrap space is unchanged (regression guard)", () => {
+  test("a single wrap space on a full line leads the next line (overflow)", () => {
     const a = setup("aaaa bbbbb ccccc");
-    // untouched layout: one trailing wrap space on line 0, word on line 1
-    expect(a.text.getLine(0)).toBe("aaaa bbbbb ");
-    expect(a.text.getLine(1)).toBe("ccccc");
+    // line 0 is exactly full, so the single wrap space overflows the width and
+    // leads line 1 (visible) rather than sitting off-screen trailing line 0.
+    expect(a.text.getLine(0)).toBe("aaaa bbbbb");
+    expect(a.text.getLine(1)).toBe(" ccccc");
     expect(a.text.noLines).toBe(2);
   });
 });

--- a/packages/annotator/src/wrapWhitespace.test.ts
+++ b/packages/annotator/src/wrapWhitespace.test.ts
@@ -1,0 +1,137 @@
+import { Annotator } from "./lib/Annotator";
+import Text from "./lib/Text";
+import { EditMode } from "./lib/constants";
+
+function keyDown(a: Annotator, key: string) {
+  a.keys.onKeyDown({
+    key,
+    ctrlKey: false,
+    metaKey: false,
+    altKey: false,
+    shiftKey: false,
+    preventDefault: () => {},
+  } as unknown as KeyboardEvent);
+}
+
+const MAXLEN = 10;
+function setup(value: string): Annotator {
+  const canvas = document.createElement("canvas");
+  canvas.style.width = "800px";
+  canvas.style.height = "600px";
+  document.body.appendChild(canvas);
+  const a = new Annotator(canvas, "");
+  a.setMode(EditMode.RAW);
+  a.onReplaceText(value);
+  a.text.updateCharsAtLine(MAXLEN);
+  return a;
+}
+
+// No horizontal scroll: renderable spaces fill the line, overflow wraps to the
+// next visual line so it stays visible (#3145).
+describe("whitespace wrapping model (#3145)", () => {
+  describe("renderable spaces trail, overflow leads/wraps", () => {
+    test("trailing spaces fill the line to the width before overflowing", () => {
+      // 8 content + 3 spaces, width 10: 2 spaces fit, only the 3rd overflows
+      const text = new Text("aaaaaaaa   ", 10);
+      expect(text.segments[0].lines).toEqual(["aaaaaaaa  ", " "]);
+    });
+
+    test("two spaces split across the boundary instead of overflowing line 1", () => {
+      // 9 letters + 2 spaces + "cc": one space fits, the second overflows
+      const a = setup("aaaaaaaaa  cc");
+      expect(a.text.getLine(0)).toBe("aaaaaaaaa "); // one trailing space
+      expect(a.text.getLine(1)).toBe(" cc"); // overflow space leads line 2
+    });
+
+    test("a single wrap space on a non-full line still trails (no leading space)", () => {
+      // the space fits at col 7, so it stays trailing rather than leading line 1
+      const a = setup("aa bb ccccccccc");
+      expect(a.text.getLine(0)).toBe("aa bb ");
+      expect(a.text.getLine(1)).toBe("ccccccccc");
+    });
+  });
+
+  describe("no visual line is ever wider than the viewport", () => {
+    test("inter-word wrap whitespace keeps every line within the width", () => {
+      const a = setup("aaaaaaaaa  cc");
+      for (let l = 0; l < a.text.noLines; l++) {
+        expect(a.text.getLine(l).length).toBeLessThanOrEqual(MAXLEN);
+      }
+    });
+
+    test("a large inter-word whitespace run wraps instead of overflowing one line", () => {
+      const a = setup("a" + " ".repeat(25) + "b");
+      for (let l = 0; l < a.text.noLines; l++) {
+        expect(a.text.getLine(l).length).toBeLessThanOrEqual(MAXLEN);
+      }
+    });
+
+    test("leading indentation before a word wraps instead of overflowing", () => {
+      const a = setup(" ".repeat(30) + "word");
+      for (let l = 0; l < a.text.noLines; l++) {
+        expect(a.text.getLine(l).length).toBeLessThanOrEqual(MAXLEN);
+      }
+    });
+  });
+
+  describe("typing spaces never pushes the caret off screen", () => {
+    test("typing the overflowing space keeps the fitting spaces on line 0", () => {
+      const a = setup("aaaaaa"); // 6 chars, width 10
+      a.cursor.setPosition(6, 0);
+      for (let i = 0; i < 5; i++) keyDown(a, " ");
+      // 4 spaces fill line 0 up to the width; only the 5th overflows to line 1
+      expect(a.text.getLine(0)).toBe("aaaaaa    ");
+      expect(a.text.getLine(1)).toBe(" ");
+    });
+
+    test("typing many trailing spaces keeps every wrapped line within the width", () => {
+      const a = setup("ccccc");
+      a.cursor.setPosition(5, 0); // end of "ccccc"
+      for (let i = 0; i < 25; i++) {
+        keyDown(a, " ");
+        for (let l = 0; l < a.text.noLines; l++) {
+          expect(a.text.getLine(l).length).toBeLessThanOrEqual(MAXLEN);
+        }
+        // caret must stay inside the visible width
+        expect(a.cursor.xLine).toBeLessThanOrEqual(MAXLEN);
+      }
+    });
+
+    test("trailing spaces on an otherwise empty line wrap instead of running off", () => {
+      const a = setup("");
+      a.cursor.setPosition(0, 0);
+      for (let i = 0; i < 25; i++) keyDown(a, " ");
+      for (let l = 0; l < a.text.noLines; l++) {
+        expect(a.text.getLine(l).length).toBeLessThanOrEqual(MAXLEN);
+      }
+      expect(a.cursor.xLine).toBeLessThanOrEqual(MAXLEN);
+    });
+  });
+
+  describe("a space that still fits keeps the caret on the same line", () => {
+    test("typing a space within the line's room stays on line 0", () => {
+      const a = setup("aaa bbb "); // 8 chars incl. a trailing space, room for 2
+      a.cursor.setPosition(8, 0);
+      keyDown(a, " ");
+      expect(a.text.getLine(0)).toBe("aaa bbb  "); // 9 chars, still fits
+      expect(a.cursor.yLine).toBe(0);
+      expect(a.text.noLines).toBe(1);
+    });
+
+    test("typing a space at a wrapped line end with room keeps the caret on that line", () => {
+      // the new space lands on the soft-wrap boundary; the caret must stay at
+      // line 0's end (where it was typed), not jump to line 1
+      const a = setup("aa bb cccccccc");
+      expect(a.text.getLine(0)).toBe("aa bb ");
+      expect(a.text.getLine(1)).toBe("cccccccc");
+
+      a.cursor.setPosition(6, 0); // end of line 0 (after the trailing space)
+      keyDown(a, " ");
+
+      expect(a.text.value).toBe("aa bb  cccccccc");
+      expect(a.text.getLine(0)).toBe("aa bb  "); // the new space stays on line 0
+      expect(a.cursor.yLine).toBe(0); // caret stays on line 0
+      expect(a.cursor.xLine).toBe(7); // just after the two spaces
+    });
+  });
+});


### PR DESCRIPTION
Keep the caret with its word across re-wraps and make space/backspace at the start of a wrapped line behave like a normal editor.
close #3145