### PR TITLE
Perf/territory tree rebuild+territory warnings (#2) - optimized queries

### DIFF
--- a/packages/server/src/models/statement/response.ts
+++ b/packages/server/src/models/statement/response.ts
@@ -250,10 +250,22 @@ export class ResponseStatement extends Statement implements IResponseStatement {
 
     const parentTId = this.data.territory?.territoryId as string;
     const lineageTIds = [parentTId, ...treeCache.tree.idMap[parentTId].path];
-    const territoryEs = await getEntitiesByIds<ITerritory>(
-      req.db.connection,
-      lineageTIds
+    // The tree cache already holds full Territory entities (including
+    // data.validations) and is rebuilt synchronously on every territory write
+    // (Territory.save/update/delete -> treeCache.initialize). On a
+    // single-instance deployment it is therefore always current, so we can read
+    // the lineage territories straight from memory and skip a per-statement DB
+    // round-trip. Falls back to the DB if any id is missing from the cache (e.g.
+    // NODE_ENV=test, where the cache is not initialized). Only .id and
+    // .data.validations are read downstream, both present on the cached
+    // Territory instances. Cross-ancestor warning order may differ from the DB
+    // path, but getAll(...) never guaranteed an order to begin with.
+    const cachedLineage = lineageTIds.map(
+      (tid) => treeCache.tree.idMap[tid]?.territory as ITerritory | undefined
     );
+    const territoryEs: ITerritory[] = cachedLineage.every((t) => t)
+      ? (cachedLineage as ITerritory[])
+      : await getEntitiesByIds<ITerritory>(req.db.connection, lineageTIds);
 
     // The per-entity loop below exists only to evaluate territory validations
     // (getTBasedWarnings) against each referenced entity. If no ancestor

--- a/packages/server/src/models/statement/response.ts
+++ b/packages/server/src/models/statement/response.ts
@@ -255,13 +255,33 @@ export class ResponseStatement extends Statement implements IResponseStatement {
       lineageTIds
     );
 
+    // The per-entity loop below exists only to evaluate territory validations
+    // (getTBasedWarnings) against each referenced entity. If no ancestor
+    // territory in the lineage defines an active validation, that evaluation
+    // can only return [], so every per-entity relation/entity round-trip is
+    // dead work - and it dominates the territory detail endpoint's latency on
+    // projects without active validations. Detect it once and skip the
+    // expensive lookups. The condition mirrors the active filter inside
+    // Entity.getTBasedWarnings (active !== false).
+    const hasActiveValidations = territoryEs.some((t) =>
+      t.data.validations?.some((v) => v.active !== false)
+    );
+
     // prepare entities
     for (const ei in allEntities) {
       const entityId = allEntities[ei];
       if (entityId) {
+        // obtainEntity is kept even when there are no validations: it has the
+        // side effect of populating this.entities (notably the statement's own
+        // id) which is part of the serialized response. Only the relation /
+        // entity fetches that feed getTBasedWarnings are skipped below.
         const entityData = await this.obtainEntity(entityId, req);
 
         if (entityData?.id === entityId) {
+          if (!hasActiveValidations) {
+            continue;
+          }
+
           const entity = new Entity(entityData);
 
           const classificationRels =

--- a/packages/server/src/models/statement/statement.ts
+++ b/packages/server/src/models/statement/statement.ts
@@ -356,7 +356,10 @@ class Statement extends Entity implements IStatement {
    * @param db db connection
    * @returns Promise<boolean> to indicate result of the operation
    */
-  async save(db: Connection | undefined): Promise<boolean> {
+  async save(
+    db: Connection | undefined,
+    skipTreeCache = false
+  ): Promise<boolean> {
     const siblings = await this.findTerritorySiblings(db);
     if (this.data.territory) {
       this.data.territory.order = determineOrder(
@@ -366,7 +369,7 @@ class Statement extends Entity implements IStatement {
     }
 
     const result = await super.save(db);
-    if (result) {
+    if (result && !skipTreeCache) {
       await treeCache.initialize();
     }
 
@@ -385,6 +388,14 @@ class Statement extends Entity implements IStatement {
     updateData: Record<string, unknown>,
     skipTreeCache = false
   ): Promise<WriteResult> {
+    // The territory tree only tracks per-territory statement counts (and the
+    // derived `empty` flag), so a statement update changes the tree only when
+    // it moves the statement to another territory. A move always carries a
+    // territoryId in the patch; plain content edits (text/props/actants/tags),
+    // reference edits and in-place reorders (order only) do not, so they must
+    // not pay the full ~150ms tree rebuild.
+    const movesTerritory = !!(updateData["data"] as any)?.territory?.territoryId;
+
     if (
       updateData["data"] &&
       (updateData["data"] as any).territory &&
@@ -407,7 +418,7 @@ class Statement extends Entity implements IStatement {
 
     const result = await super.update(db, updateData);
 
-    if (!skipTreeCache) {
+    if (!skipTreeCache && movesTerritory) {
       await treeCache.initialize();
     }
 

--- a/packages/server/src/models/territory/response.ts
+++ b/packages/server/src/models/territory/response.ts
@@ -93,9 +93,25 @@ export class ResponseTerritory extends Territory implements IResponseTerritory {
           req,
           preloadedEntities as Record<string, IEntity>
         );
-        if (useWarnings && !this.isTemplate) {
-          responseStatement.warnings = await responseStatement.getWarnings(req, settings);
-        }
+      }
+
+      if (useWarnings && !this.isTemplate) {
+        // Each statement's getWarnings is an independent chain of DB
+        // round-trips. Awaiting them one statement at a time serialized the
+        // whole territory; rethinkdb-ts multiplexes concurrent queries over
+        // the single per-request connection, so running them together
+        // pipelines the work. Peak in-flight stays roughly the statement
+        // count because each statement's own per-entity lookups remain
+        // sequential internally. Statements are distinct instances with no
+        // shared mutable state, so order of responseStatements is preserved.
+        await Promise.all(
+          responseStatements.map(async (responseStatement) => {
+            responseStatement.warnings = await responseStatement.getWarnings(
+              req,
+              settings
+            );
+          })
+        );
       }
     } else {
       // Add parent territory entity if it exists

--- a/packages/server/src/modules/statements/index.ts
+++ b/packages/server/src/modules/statements/index.ts
@@ -313,7 +313,8 @@ export default Router()
 
         model.resetIds();
 
-        await model.save(req.db.connection);
+        // Skip the per-statement tree rebuild; we rebuild once after the loop.
+        await model.save(req.db.connection, true);
         newIds.push(model.id);
 
         const origId = stmtData.id;
@@ -328,6 +329,9 @@ export default Router()
           relsErr = true;
         }
       }
+
+      // One rebuild for the whole batch instead of N (one per saved statement).
+      await treeCache.initialize();
 
       let msg = `${statementsCount} statements have been copied under '${territory.labels[0]}'`;
       if (relsErr) {


### PR DESCRIPTION
Optimized GET requests to territory detail endpoint: 
- multiplexing db query if needed
- ignoring db query for validation errors if not needed
- territory lineage optimized  (fewer db calls)

Net gain ~ up to 3x in some cases