### PR TITLE
fix(annotator): copy natural source breaks, not soft-wrap line breaks (#2551)

### DIFF
--- a/packages/annotator/src/copyNaturalBreaks.test.ts
+++ b/packages/annotator/src/copyNaturalBreaks.test.ts
@@ -1,0 +1,64 @@
+import Text from "./lib/Text";
+import { EditMode } from "./lib/constants";
+
+const fullRange = (t: Text): string => {
+  const visualLines = t.getRangeLines(0, t.noLines);
+  const lastLine = visualLines[visualLines.length - 1] ?? "";
+  return t.getRangeText(
+    { xLine: 0, yLine: 0 },
+    { xLine: lastLine.length, yLine: t.noLines - 1 }
+  );
+};
+
+describe("copy with natural breaks (#2551)", () => {
+  test("a single soft-wrapped paragraph copies with no injected newlines", () => {
+    const source = "the quick brown fox jumps over the lazy dog";
+    const t = new Text(source, 10); // budget 10 chars -> forces wrapping
+
+    expect(t.noLines).toBeGreaterThan(1); // sanity: it really wrapped
+    const copied = fullRange(t);
+
+    expect(copied.includes("\n")).toBe(false);
+    expect(copied).toBe(source);
+  });
+
+  test("real newlines between paragraphs are preserved exactly once", () => {
+    const source = "first paragraph here\nsecond paragraph here";
+    const t = new Text(source, 8); // both paragraphs wrap
+
+    expect(t.noLines).toBeGreaterThan(2);
+    const copied = fullRange(t);
+
+    expect(copied).toBe(source);
+    expect((copied.match(/\n/g) || []).length).toBe(1);
+  });
+
+  test("a sub-range that spans a soft-wrap boundary has no injected newline", () => {
+    const source = "alpha beta gamma delta";
+    const t = new Text(source, 10);
+    // Select from start of doc to the end of the second visual line.
+    const visualLines = t.getRangeLines(0, t.noLines);
+    const copied = t.getRangeText(
+      { xLine: 0, yLine: 0 },
+      { xLine: visualLines[1].length, yLine: 1 }
+    );
+    expect(copied.includes("\n")).toBe(false);
+  });
+
+  test("blank lines (empty segments) between paragraphs are preserved", () => {
+    const source = "alpha\n\nbeta";
+    const t = new Text(source, 20); // no wrapping needed; tests segment joining
+    expect(fullRange(t)).toBe(source);
+  });
+
+  test("HIGHLIGHT mode still strips tags and injects no soft-wrap newline", () => {
+    const source = "the <person>quick brown</person> fox runs";
+    const t = new Text(source, 12);
+    t.mode = EditMode.HIGHLIGHT;
+    t.calculateLines();
+
+    const copied = fullRange(t);
+    expect(copied.includes("\n")).toBe(false);
+    expect(copied).toBe("the quick brown fox runs");
+  });
+});

--- a/packages/annotator/src/lib/Text.ts
+++ b/packages/annotator/src/lib/Text.ts
@@ -1568,6 +1568,12 @@ class Text {
   /**
    * Gets text content within the specified absolute coordinate range.
    *
+   * Only the real line breaks of the source (segment boundaries, i.e. the `\n`
+   * in {@link value}) appear in the result. The soft-wrap breaks the annotator
+   * inserts to fit text to the view width are NOT emitted - copying must yield
+   * the natural paragraph/line breaks of the original, not view-imposed ones
+   * Within a segment the wrapped visual lines are concatenated back together; segments are joined with a single `\n`.
+   *
    * @param start - The start coordinates of the range
    * @param end - The end coordinates of the range
    * @returns The text content within the range
@@ -1583,15 +1589,25 @@ class Text {
       end = tempStart;
     }
 
-    const rangeLines = this.getRangeLines(start.yLine, end.yLine + 1);
-    const linesSize = rangeLines.length;
-    if (!linesSize) {
+    const startPos = this.getSegmentPosition(start.yLine, start.xLine);
+    const endPos = this.getSegmentPosition(end.yLine, end.xLine);
+    if (!startPos || !endPos) {
       return "";
     }
 
-    rangeLines[linesSize - 1] = rangeLines[linesSize - 1].slice(0, end.xLine);
-    rangeLines[0] = rangeLines[0].slice(start.xLine, rangeLines[0].length + 1);
-    return rangeLines.join("\n");
+    const parts: string[] = [];
+    for (let i = startPos.segmentIndex; i <= endPos.segmentIndex; i++) {
+      // Joining the wrapped visual lines back together reconstructs the
+      // segment's display text (raw in RAW mode, tag-free in HIGHLIGHT/SEMI)
+      // without the soft-wrap breaks. calculateLines only ever partitions this
+      // text, so no characters are lost or added.
+      const display = this.segments[i].lines.join("");
+      const from = i === startPos.segmentIndex ? startPos.parsedTextIndex : 0;
+      const to =
+        i === endPos.segmentIndex ? endPos.parsedTextIndex : display.length;
+      parts.push(display.slice(from, to));
+    }
+    return parts.join("\n");
   }
 
   /**


### PR DESCRIPTION
Copying from the annotator now emits only the real paragraph/line breaks of the source, not the soft-wrap breaks inserted purely for display (closes #2551).