### PR TITLE
Client/minimize api calls count and deduplicate queries

### DIFF
--- a/packages/annotator/src/lib/SettingsOverlay.ts
+++ b/packages/annotator/src/lib/SettingsOverlay.ts
@@ -71,7 +71,12 @@ export class SettingsOverlay {
    */
   private colors: MenuColors = LIGHT_MENU_COLORS;
 
-  open(settings: SettingControl[] = [], anchor?: HTMLElement, footer: FooterAction[] = [], colors?: MenuColors): void {
+  open(
+    settings: SettingControl[] = [],
+    anchor?: HTMLElement,
+    footer: FooterAction[] = [],
+    colors?: MenuColors
+  ): void {
     if (colors) this.colors = colors;
     this.close();
 
@@ -113,7 +118,7 @@ export class SettingsOverlay {
 
     const body = document.createElement("div");
     Object.assign(body.style, {
-      padding: "16px 14px",
+      padding: "1.2rem",
       display: "flex",
       flexDirection: "column",
       gap: "14px",
@@ -222,7 +227,7 @@ export class SettingsOverlay {
       display: "flex",
       alignItems: "center",
       justifyContent: "space-between",
-      padding: "10px 14px",
+      padding: "1.2rem",
       borderBottom: `1px solid ${this.colors.separator}`,
       fontWeight: "bold",
     } as Partial<CSSStyleDeclaration>);
@@ -231,12 +236,12 @@ export class SettingsOverlay {
     title.textContent = "Options";
 
     const closeBtn = document.createElement("span");
-    closeBtn.textContent = "×";
+    closeBtn.innerHTML = `<svg width="13" height="13" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg"><line x1="3" y1="3" x2="13" y2="13" stroke="currentColor" stroke-width="2" stroke-linecap="round"/><line x1="13" y1="3" x2="3" y2="13" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg>`;
     Object.assign(closeBtn.style, {
       cursor: "pointer",
-      padding: "0 4px",
-      fontSize: "18px",
-      lineHeight: "1",
+      padding: "0",
+      display: "flex",
+      alignItems: "center",
     } as Partial<CSSStyleDeclaration>);
     closeBtn.addEventListener("mousedown", (e) => {
       e.preventDefault();
@@ -256,7 +261,7 @@ export class SettingsOverlay {
       display: "flex",
       justifyContent: "flex-end",
       gap: "8px",
-      padding: "10px 14px",
+      padding: "1.2rem",
       borderTop: `1px solid ${this.colors.separator}`,
     } as Partial<CSSStyleDeclaration>);
 
@@ -267,7 +272,7 @@ export class SettingsOverlay {
       Object.assign(btn.style, {
         font: "inherit",
         fontWeight: "bold",
-        padding: "6px 14px",
+        padding: "6px 1.4rem",
         border: "none",
         borderRadius: "5px",
         background: this.colors.accent,
@@ -402,7 +407,7 @@ export class SettingsOverlay {
       const seg = document.createElement("div");
       seg.textContent = opt.label;
       Object.assign(seg.style, {
-        padding: "4px 12px",
+        padding: "0.4rem 1rem",
         cursor: "pointer",
         borderRadius: "3px",
         transition: "background-color 0.12s ease",

--- a/packages/annotator/src/lib/SettingsOverlay.ts
+++ b/packages/annotator/src/lib/SettingsOverlay.ts
@@ -88,7 +88,7 @@ export class SettingsOverlay {
       alignItems: "center",
       justifyContent: "center",
       // primary-tinted dim to match the app's modal backdrop (theme.color.modalBg)
-      background: "rgba(9, 16, 52, 0.3)",
+      background: "rgba(9, 16, 52, 0.4)",
     } as Partial<CSSStyleDeclaration>);
 
     this.anchor = anchor ?? null;

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -46,7 +46,7 @@
     "react-dnd-html5-backend": "^16.0.1",
     "react-dom": "^19.2.6",
     "react-helmet-async": "^2.0.5",
-    "react-icons": "^5.6.0",
+    "react-icons": "^5.7.0",
     "react-json-view": "^1.21.3",
     "react-popper": "^2.3.0",
     "react-redux": "^9.3.0",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -67,6 +67,7 @@
   },
   "devDependencies": {
     "@redux-devtools/extension": "^3.3.0",
+    "@tanstack/eslint-plugin-query": "^5.101.2",
     "@tanstack/react-query-devtools": "^5.100.10",
     "@types/d3": "^7.4.3",
     "@types/node": "^24.12.4",

--- a/packages/client/src/Theme/icons.ts
+++ b/packages/client/src/Theme/icons.ts
@@ -1,0 +1,232 @@
+// Central icon registry — swap any icon here to change it everywhere.
+
+// ai
+export { AiOutlineApartment as IcoApartment } from "react-icons/ai";
+export { AiOutlineCaretRight as IcoCaretRight } from "react-icons/ai";
+export { AiOutlineLink as IcoLinkOutline } from "react-icons/ai";
+export { AiOutlineTag as IcoTagOutline } from "react-icons/ai";
+export { AiOutlineTags as IcoTagsOutline } from "react-icons/ai";
+export { AiOutlineWarning as IcoWarningOutline } from "react-icons/ai";
+
+// bi
+export { BiBarChartAlt2 as IcoBarChart } from "react-icons/bi";
+export { BiChevronLeft as IcoChevronLeftBi } from "react-icons/bi";
+export { BiChevronRight as IcoChevronRightBi } from "react-icons/bi";
+export { BiCommentAdd as IcoCommentAdd } from "react-icons/bi";
+export { BiCommentDetail as IcoCommentDetail } from "react-icons/bi";
+export { BiCommentMinus as IcoCommentRemove } from "react-icons/bi";
+export { BiHide as IcoHide } from "react-icons/bi";
+export { BiLinkExternal as IcoLinkExternal } from "react-icons/bi";
+export { BiLogOut as IcoLogout } from "react-icons/bi";
+export { BiNetworkChart as IcoNetwork } from "react-icons/bi";
+export { BiRefresh as IcoRefresh } from "react-icons/bi";
+export { BiSearch as IcoSearch } from "react-icons/bi";
+export { BiShow as IcoShow } from "react-icons/bi";
+export { BiTable as IcoTable } from "react-icons/bi";
+
+// bs
+export { BsArrow90DegLeft as IcoArrow90DegLeft } from "react-icons/bs";
+export { BsArrowDown as IcoArrowDown } from "react-icons/bs";
+export { BsArrowReturnRight as IcoArrowReturnRight } from "react-icons/bs";
+export { BsArrowRightShort as IcoArrowRightShort } from "react-icons/bs";
+export { BsArrowsCollapse as IcoCollapse } from "react-icons/bs";
+export { BsArrowsExpand as IcoExpand } from "react-icons/bs";
+export { BsArrowUp as IcoArrowUp } from "react-icons/bs";
+export { BsBoxSeamFill as IcoBox } from "react-icons/bs";
+export { BsCardText as IcoCardText } from "react-icons/bs";
+export { BsClipboard as IcoClipboard } from "react-icons/bs";
+export { BsEnvelopeArrowUpFill as IcoEnvelopeUpload } from "react-icons/bs";
+export { BsFileTextFill as IcoFileTextFill } from "react-icons/bs";
+export { BsFilter as IcoFilter } from "react-icons/bs";
+export { BsInfoCircle as IcoInfo } from "react-icons/bs";
+export { BsShieldExclamation as IcoShieldWarning } from "react-icons/bs";
+export { BsShieldFillCheck as IcoShieldCheck } from "react-icons/bs";
+export { BsShieldShaded as IcoShield } from "react-icons/bs";
+export { BsSquareFill as IcoSquareFill } from "react-icons/bs";
+export { BsSquareHalf as IcoSquareHalf } from "react-icons/bs";
+
+// cg
+export { CgClose as IcoCloseCg } from "react-icons/cg";
+export { CgFileDocument as IcoFileDocument } from "react-icons/cg";
+export { CgListTree as IcoListTree } from "react-icons/cg";
+export { CgMenuBoxed as IcoMenuBoxed } from "react-icons/cg";
+export { CgOptions as IcoOptions } from "react-icons/cg";
+export { CgPlayListAdd as IcoPlayListAdd } from "react-icons/cg";
+export { CgPlayListRemove as IcoPlayListRemove } from "react-icons/cg";
+
+// fa
+export { FaAnchor as IcoAnchor } from "react-icons/fa";
+export { FaBolt as IcoBolt } from "react-icons/fa";
+export { FaCalendarPlus as IcoCalendarAdd } from "react-icons/fa";
+export { FaCheck as IcoCheck } from "react-icons/fa";
+export { FaCheckSquare as IcoCheckboxChecked } from "react-icons/fa";
+export { FaChevronCircleRight as IcoChevronCircleRight } from "react-icons/fa";
+export { FaChevronDown as IcoChevronDown } from "react-icons/fa";
+export { FaCircle as IcoCircle } from "react-icons/fa";
+export { FaClipboard as IcoClipboardFilled } from "react-icons/fa";
+export { FaClone as IcoClone } from "react-icons/fa";
+export { FaDotCircle as IcoDotCircle } from "react-icons/fa";
+export { FaDownload as IcoDownload } from "react-icons/fa";
+export { FaEdit as IcoEdit } from "react-icons/fa";
+export { FaExchangeAlt as IcoExchange } from "react-icons/fa";
+export { FaExclamationTriangle as IcoExclamation } from "react-icons/fa";
+export { FaExternalLinkAlt as IcoExternalLink } from "react-icons/fa";
+export { FaFolder as IcoFolder } from "react-icons/fa";
+export { FaFolderOpen as IcoFolderOpen } from "react-icons/fa";
+export { FaGripVertical as IcoDragHandle } from "react-icons/fa";
+export { FaHeadSideVirus as IcoHeadVirus } from "react-icons/fa";
+export { FaHighlighter as IcoHighlighter } from "react-icons/fa";
+export { FaHome as IcoHome } from "react-icons/fa";
+export { FaLink as IcoLink } from "react-icons/fa";
+export { FaLock as IcoLock } from "react-icons/fa";
+export { FaLongArrowAltRight as IcoLongArrowRight } from "react-icons/fa";
+export { FaMinus as IcoMinus } from "react-icons/fa";
+export { FaPen as IcoPen } from "react-icons/fa";
+export { FaPlus as IcoPlus } from "react-icons/fa";
+export { FaPlusSquare as IcoPlusSquare } from "react-icons/fa";
+export { FaQuestion as IcoQuestion } from "react-icons/fa";
+export { FaRegArrowAltCircleDown as IcoArrowCircleDown } from "react-icons/fa";
+export { FaRegArrowAltCircleUp as IcoArrowCircleUp } from "react-icons/fa";
+export { FaRegCalendarAlt as IcoCalendar } from "react-icons/fa";
+export { FaRegCopy as IcoCopy } from "react-icons/fa";
+export { FaRegFolder as IcoFolderOutline } from "react-icons/fa";
+export { FaRegFolderOpen as IcoFolderOpenOutline } from "react-icons/fa";
+export { FaRegSave as IcoSave } from "react-icons/fa";
+export { FaRegSquare as IcoCheckboxUnchecked } from "react-icons/fa";
+export { FaRegUser as IcoUserOutline } from "react-icons/fa";
+export { FaSquareFull as IcoSquareFull } from "react-icons/fa";
+export { FaStar as IcoStar } from "react-icons/fa";
+export { FaTag as IcoTag } from "react-icons/fa";
+export { FaToggleOff as IcoToggleOff } from "react-icons/fa";
+export { FaToggleOn as IcoToggleOn } from "react-icons/fa";
+export { FaUndo as IcoUndo } from "react-icons/fa";
+export { FaUnlink as IcoUnlink } from "react-icons/fa";
+export { FaUser as IcoUser } from "react-icons/fa";
+export { FaUserAlt as IcoUserAlt } from "react-icons/fa";
+export { FaUserEdit as IcoUserEdit } from "react-icons/fa";
+export { FaUserPlus as IcoUserAdd } from "react-icons/fa";
+export { FaUserTag as IcoUserTag } from "react-icons/fa";
+
+// fa6 — IcoTrash is the canonical trash icon; change here to swap everywhere
+export { FaTrashCan as IcoTrash } from "react-icons/fa6";
+export { FaAnchorCircleCheck as IcoAnchorCheck } from "react-icons/fa6";
+export { FaArrowDownShortWide as IcoSortDown } from "react-icons/fa6";
+export { FaArrowDownLong as IcoArrowDownLong } from "react-icons/fa6";
+export { FaArrowUpLong as IcoArrowUpLong } from "react-icons/fa6";
+export { FaCaretDown as IcoCaretDown } from "react-icons/fa6";
+export { FaDiagramNext as IcoDiagramNext } from "react-icons/fa6";
+export { FaExpand as IcoExpandFull } from "react-icons/fa6";
+export { FaScissors as IcoScissors } from "react-icons/fa6";
+export { FaUserGear as IcoUserGear } from "react-icons/fa6";
+export { FaUserTie as IcoUserTie } from "react-icons/fa6";
+export { FaX as IcoX } from "react-icons/fa6";
+
+// fi
+export { FiLogIn as IcoLogin } from "react-icons/fi";
+export { FiMove as IcoMove } from "react-icons/fi";
+
+// gr
+export { GrClone as IcoCloneAlt } from "react-icons/gr";
+export { GrClose as IcoCloseGr } from "react-icons/gr";
+export { GrDocumentMissing as IcoDocumentMissing } from "react-icons/gr";
+
+// hi
+export { HiClipboardList as IcoClipboardList } from "react-icons/hi";
+export { HiLink as IcoLinkHi } from "react-icons/hi";
+
+// hi2
+export { HiArrowDownTray as IcoArrowDownTray } from "react-icons/hi2";
+export { HiArrowUpTray as IcoArrowUpTray } from "react-icons/hi2";
+export { HiCodeBracket as IcoCode } from "react-icons/hi2";
+
+// im
+export { ImListNumbered as IcoListNumbered } from "react-icons/im";
+
+// io
+export { IoIosArrowBack as IcoArrowBack } from "react-icons/io";
+export { IoIosArrowForward as IcoArrowForward } from "react-icons/io";
+
+// io5
+export { IoClose as IcoClose } from "react-icons/io5";
+export { IoEnter as IcoEnter } from "react-icons/io5";
+export { IoReloadCircle as IcoReload } from "react-icons/io5";
+export { IoStar as IcoStarFilled } from "react-icons/io5";
+export { IoStarOutline as IcoStarOutline } from "react-icons/io5";
+
+// lu
+export { LuCaseSensitive as IcoCaseSensitive } from "react-icons/lu";
+export { LuListTodo as IcoListTodo } from "react-icons/lu";
+export { LuRegex as IcoRegex } from "react-icons/lu";
+export { LuReplace as IcoReplace } from "react-icons/lu";
+export { LuReplaceAll as IcoReplaceAll } from "react-icons/lu";
+export { LuScanSearch as IcoScanSearch } from "react-icons/lu";
+export { LuWholeWord as IcoWholeWord } from "react-icons/lu";
+
+// md
+export { MdAddCircleOutline as IcoAddCircle } from "react-icons/md";
+export { MdCancel as IcoCancel } from "react-icons/md";
+export { MdCheck as IcoCheckMd } from "react-icons/md";
+export { MdChevronLeft as IcoChevronLeft } from "react-icons/md";
+export { MdChevronRight as IcoChevronRight } from "react-icons/md";
+export { MdCleaningServices as IcoClean } from "react-icons/md";
+export { MdClose as IcoCloseMd } from "react-icons/md";
+export { MdDarkMode as IcoDarkMode } from "react-icons/md";
+export { MdDatasetLinked as IcoDatasetLinked } from "react-icons/md";
+export { MdDeleteSweep as IcoDeleteSweep } from "react-icons/md";
+export { MdDragIndicator as IcoDragIndicator } from "react-icons/md";
+export { MdEdit as IcoEditMd } from "react-icons/md";
+export { MdLibraryAddCheck as IcoLibraryAddCheck } from "react-icons/md";
+export { MdMail as IcoMail } from "react-icons/md";
+export { MdMood as IcoMood } from "react-icons/md";
+export { MdOutlineCheckBox as IcoCheckBoxOutline } from "react-icons/md";
+export { MdOutlineCheckBoxOutlineBlank as IcoCheckBoxBlankOutline } from "react-icons/md";
+export { MdOutlineDone as IcoDoneOutline } from "react-icons/md";
+export { MdOutlineEdit as IcoEditOutline } from "react-icons/md";
+export { MdOutlineLabel as IcoLabelOutline } from "react-icons/md";
+export { MdOutlineLibraryAddCheck as IcoLibraryAddCheckOutline } from "react-icons/md";
+export { MdSunny as IcoLightMode } from "react-icons/md";
+export { MdWaves as IcoWaves } from "react-icons/md";
+
+// pi
+export { PiSealCheckFill as IcoSealCheck } from "react-icons/pi";
+export { PiSelectionFill as IcoSelection } from "react-icons/pi";
+
+// ri
+export { RiCloseFill as IcoCloseFill } from "react-icons/ri";
+export { RiFileEditFill as IcoFileEdit } from "react-icons/ri";
+export { RiLayoutMasonryLine as IcoLayoutMasonry } from "react-icons/ri";
+export { RiMenuFoldFill as IcoMenuFold } from "react-icons/ri";
+export { RiMenuUnfoldFill as IcoMenuUnfold } from "react-icons/ri";
+export { RiNodeTree as IcoNodeTree } from "react-icons/ri";
+export { RiRotateLockLine as IcoRotateLock } from "react-icons/ri";
+export { RiTimeLine as IcoTimeline } from "react-icons/ri";
+
+// rx
+export { RxFileText as IcoFileText } from "react-icons/rx";
+
+// tb
+export { TbAnchor as IcoAnchorTb } from "react-icons/tb";
+export { TbAnchorOff as IcoAnchorOff } from "react-icons/tb";
+export { TbArrowForwardUp as IcoArrowForwardUp } from "react-icons/tb";
+export { TbArrowNarrowRight as IcoArrowNarrowRight } from "react-icons/tb";
+export { TbArrowsHorizontal as IcoArrowsHorizontal } from "react-icons/tb";
+export { TbArrowsSort as IcoSort } from "react-icons/tb";
+export { TbColumnInsertRight as IcoColumnInsert } from "react-icons/tb";
+export { TbHomeMove as IcoHomeMove } from "react-icons/tb";
+export { TbLockExclamation as IcoLockWarning } from "react-icons/tb";
+export { TbLockPlus as IcoLockAdd } from "react-icons/tb";
+export { TbMailFilled as IcoMailFilled } from "react-icons/tb";
+export { TbReplace as IcoReplaceTb } from "react-icons/tb";
+export { TbSettings as IcoSettings } from "react-icons/tb";
+
+// ti
+export { TiDocumentText as IcoDocumentText } from "react-icons/ti";
+export { TiPlus as IcoPlusTi } from "react-icons/ti";
+export { TiWarning as IcoWarning } from "react-icons/ti";
+export { TiWarningOutline as IcoWarningTiOutline } from "react-icons/ti";
+
+// vsc
+export { VscClose as IcoCloseVsc } from "react-icons/vsc";
+export { VscCloseAll as IcoCloseAll } from "react-icons/vsc";
+export { VscCommentDiscussion as IcoCommentDiscussion } from "react-icons/vsc";
+export { VscDebugDisconnect as IcoDisconnect } from "react-icons/vsc";

--- a/packages/client/src/Theme/icons.ts
+++ b/packages/client/src/Theme/icons.ts
@@ -109,6 +109,8 @@ export { FaUserTag as IcoUserTag } from "react-icons/fa";
 
 // fa6 — IcoTrash is the canonical trash icon; change here to swap everywhere
 export { FaTrashCan as IcoTrash } from "react-icons/fa6";
+// simpler outline variant (no lid detail) — used where a lighter icon fits better
+export { FaTrash as IcoTrashSimple } from "react-icons/fa";
 export { FaAnchorCircleCheck as IcoAnchorCheck } from "react-icons/fa6";
 export { FaArrowDownShortWide as IcoSortDown } from "react-icons/fa6";
 export { FaArrowDownLong as IcoArrowDownLong } from "react-icons/fa6";

--- a/packages/client/src/Theme/icons.ts
+++ b/packages/client/src/Theme/icons.ts
@@ -67,7 +67,7 @@ export { FaClipboard as IcoClipboardFilled } from "react-icons/fa";
 export { FaClone as IcoClone } from "react-icons/fa";
 export { FaDotCircle as IcoDotCircle } from "react-icons/fa";
 export { FaDownload as IcoDownload } from "react-icons/fa";
-export { FaEdit as IcoEdit } from "react-icons/fa";
+// export { FaEdit as IcoEdit } from "react-icons/fa";
 export { FaExchangeAlt as IcoExchange } from "react-icons/fa";
 export { FaExclamationTriangle as IcoExclamation } from "react-icons/fa";
 export { FaExternalLinkAlt as IcoExternalLink } from "react-icons/fa";
@@ -228,6 +228,9 @@ export { TiWarning as IcoWarning } from "react-icons/ti";
 export { TiWarningOutline as IcoWarningTiOutline } from "react-icons/ti";
 
 // vsc
+export { VscEditCompact as IcoEdit } from "react-icons/vsc";
+// export { VscEditCompact as IcoEditMd } from "react-icons/vsc";
+// export { VscEditCompact as IcoEditOutline } from "react-icons/vsc";
 export { VscClose as IcoCloseVsc } from "react-icons/vsc";
 export { VscCloseAll as IcoCloseAll } from "react-icons/vsc";
 export { VscCommentDiscussion as IcoCommentDiscussion } from "react-icons/vsc";

--- a/packages/client/src/Theme/theme.ts
+++ b/packages/client/src/Theme/theme.ts
@@ -263,6 +263,11 @@ const theme = {
 
 export type ThemeType = typeof theme;
 export type ThemeColor = typeof theme.color;
+// keys of ThemeColor whose value is a plain color string, excluding the
+// nested groups (gray, blue, invertedBg, ...)
+export type FlatThemeColor = {
+  [K in keyof ThemeColor]: ThemeColor[K] extends string ? K : never;
+}[keyof ThemeColor];
 export type ThemeBorderWidth = typeof theme.borderWidth;
 export type InvertedBgColor = typeof theme.color.invertedBg;
 export type ElementTypeColor = typeof theme.color.elementType;

--- a/packages/client/src/Theme/theme.ts
+++ b/packages/client/src/Theme/theme.ts
@@ -54,7 +54,7 @@ const theme = {
     info: "#324185",
     plain: "#4a5568", // gray 700
     primaryTransparent: "rgba(9,16,52,0.2)",
-    modalBg: "rgba(9,16,52,0.3)",
+    modalBg: "rgba(9,16,52,0.4)",
     backupDownloadOverlay: "rgba(237, 242, 247, 0.8)",
 
     tagBackground: "#fff",

--- a/packages/client/src/api.tsx
+++ b/packages/client/src/api.tsx
@@ -260,20 +260,12 @@ class Api {
       };
 
       // eslint-disable-next-line no-console
-      console.error(
-        "[html-instead-of-json] non-JSON API response captured:",
-        record
-      );
+      console.error("[html-instead-of-json] non-JSON API response captured:", record);
 
       try {
-        const prev = JSON.parse(
-          localStorage.getItem(HTML_CAPTURE_STORAGE_KEY) || "[]"
-        );
+        const prev = JSON.parse(localStorage.getItem(HTML_CAPTURE_STORAGE_KEY) || "[]");
         prev.push(record);
-        localStorage.setItem(
-          HTML_CAPTURE_STORAGE_KEY,
-          JSON.stringify(prev.slice(-20))
-        );
+        localStorage.setItem(HTML_CAPTURE_STORAGE_KEY, JSON.stringify(prev.slice(-20)));
         // notify the header (same-tab; native "storage" event only fires cross-tab)
         window.dispatchEvent(new Event(HTML_CAPTURE_EVENT));
       } catch {
@@ -1066,8 +1058,8 @@ class Api {
   }
 
   /**
-   * entityIdsInTerritory retieves ids of statements that are used on the territory
-   * @see Statement.findDependentStatementIds
+   * Returns unique entity IDs referenced by all statements
+   * on the given territory (actants, actions, props, tags, etc.).
    */
   async entityIdsInTerritory(
     territoryId: string,

--- a/packages/client/src/components/advanced/Annotator/Annotator.tsx
+++ b/packages/client/src/components/advanced/Annotator/Annotator.tsx
@@ -10,7 +10,8 @@ import {
 import { useMutation, UseMutationResult, useQuery, useQueryClient } from "@tanstack/react-query";
 import api from "api";
 import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
-import { FaHighlighter, FaPen, FaRegSave, FaTrash } from "react-icons/fa";
+import { FaHighlighter, FaPen, FaRegSave } from "react-icons/fa";
+import { IcoTrash } from "Theme/icons";
 import { toast } from "react-toastify";
 import { v4 as uuidv4 } from "uuid";
 
@@ -1501,7 +1502,7 @@ export const TextAnnotator = ({
                 label="discard"
                 color="greyer"
                 inverted
-                icon={<FaTrash />}
+                icon={<IcoTrash />}
                 disabled={
                   !isChangeMade || isSaving || isSavingWithoutRefresh || dataDocumentIsFetching
                 }

--- a/packages/client/src/components/advanced/Annotator/Annotator.tsx
+++ b/packages/client/src/components/advanced/Annotator/Annotator.tsx
@@ -10,7 +10,7 @@ import {
 import { useMutation, UseMutationResult, useQuery, useQueryClient } from "@tanstack/react-query";
 import api from "api";
 import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
-import { FaPen, FaRegSave, FaTrash } from "react-icons/fa";
+import { FaHighlighter, FaPen, FaRegSave, FaTrash } from "react-icons/fa";
 import { toast } from "react-toastify";
 import { v4 as uuidv4 } from "uuid";
 
@@ -1442,7 +1442,7 @@ export const TextAnnotator = ({
                 <StyledDisplayModeButtonIconWrapper
                   $annotatorWidthTooNarrow={annotatorWidthTooNarrow}
                 >
-                  <FaPen size={11} />
+                  <FaHighlighter size={11} />
                 </StyledDisplayModeButtonIconWrapper>
               }
               label={!annotatorWidthTooNarrow ? editModeDisplayLabel[EditMode.HIGHLIGHT] : ""}

--- a/packages/client/src/components/advanced/Annotator/AnnotatorMenu.tsx
+++ b/packages/client/src/components/advanced/Annotator/AnnotatorMenu.tsx
@@ -18,7 +18,7 @@ import {
   FaPlus,
 } from "react-icons/fa";
 import { MdDragIndicator, MdOutlineDone } from "react-icons/md";
-import { PiSelectionFill } from "react-icons/pi";
+import { PiCheckBold, PiSelectionFill } from "react-icons/pi";
 import { TbAnchor } from "react-icons/tb";
 import { toast } from "react-toastify";
 import { setSecondPanelExpanded } from "redux/features/layout/mainPage/secondPanelExpandedSlice";
@@ -55,6 +55,7 @@ import {
 } from "./AnnotatorStyles";
 import { AnnotatorPositionTNode, TerritoryCreateModalType } from "./types";
 import { useAnnotatorTargetPicker } from "./useAnnotatorTargetPicker";
+import { LuCheck } from "react-icons/lu";
 
 interface TextAnnotatorMenuProps {
   text: string;
@@ -319,9 +320,9 @@ export const TextAnnotatorMenu = ({
               <Button
                 color="primary"
                 inverted
-                icon={<MdOutlineDone size={25} />}
+                icon={<PiCheckBold size={25} />}
                 size={ButtonSize.ExtraLarge}
-                shape="rounded-md"
+                shape="rounded-xl"
                 noBackground
                 onClick={() => onEscapePressed()}
                 tooltipLabel="Close selection menu"

--- a/packages/client/src/components/advanced/Annotator/AnnotatorSearchLine/AnnotatorSearchLine.tsx
+++ b/packages/client/src/components/advanced/Annotator/AnnotatorSearchLine/AnnotatorSearchLine.tsx
@@ -6,7 +6,7 @@ import { Button, Checkbox, IconButton, IconWithTooltip, Input, Loader } from "co
 import { AttributeButtonGroup, EntitySuggester, EntityTag } from "components/advanced";
 import useKeypress from "hooks/useKeyPress";
 import React, { useMemo, useRef, useState } from "react";
-import { BiSearch } from "react-icons/bi";
+import { IcoSearch } from "Theme/icons";
 import { FaAnchor, FaRegArrowAltCircleDown, FaRegArrowAltCircleUp } from "react-icons/fa";
 import { FaAnchorCircleCheck, FaExpand } from "react-icons/fa6";
 import { LuCaseSensitive, LuRegex, LuReplace, LuReplaceAll, LuWholeWord } from "react-icons/lu";
@@ -326,7 +326,7 @@ export const AnnotatorSearchLine: React.FC<AnnotatorSearchLine> = ({
               roundCorners
               icon={
                 <IconWithTooltip
-                  icon={<BiSearch />}
+                  icon={<IcoSearch />}
                   tooltipLabel="ctrl+f to search"
                   tooltipPosition="top"
                   color="inherit"

--- a/packages/client/src/components/advanced/Annotator/AnnotatorStyles.tsx
+++ b/packages/client/src/components/advanced/Annotator/AnnotatorStyles.tsx
@@ -54,7 +54,7 @@ export const StyledAnnotatorDoneButton = styled.div`
   transform: translate(0, -50%);
   z-index: 101;
   color: ${({ theme }) => theme.color.primary};
-  border-radius: 7px;
+  border-radius: ${({ theme }) => theme.borderRadius["rounded-xl"]};
   background-color: ${({ theme }) => theme.color.blue[100]};
 `;
 

--- a/packages/client/src/components/advanced/Annotator/AnnotatorWarningsModal.tsx
+++ b/packages/client/src/components/advanced/Annotator/AnnotatorWarningsModal.tsx
@@ -1,8 +1,11 @@
 import { AsymmetricalAnchor } from "@inkvisitor/annotator/src/lib";
-import { ButtonGroup, Modal, ModalContent, ModalFooter, ModalHeader } from "components";
+import { IResponseEntity } from "@inkvisitor/shared/types";
+import { useQuery } from "@tanstack/react-query";
+import api from "api";
+import { ButtonGroup, Loader, Modal, ModalContent, ModalFooter, ModalHeader } from "components";
 import { Button } from "components/basic/Button/Button";
 import { EntityTagById } from "components/advanced/EntityTag/EntityTagById";
-import React from "react";
+import React, { useMemo } from "react";
 import { FaExclamationTriangle } from "react-icons/fa";
 import { FaScissors } from "react-icons/fa6";
 import { TbAnchor } from "react-icons/tb";
@@ -72,6 +75,30 @@ export const AnnotatorWarningsModal: React.FC<AnnotatorWarningsModalProps> = ({
   showChip = true,
   isLoading = false,
 }) => {
+  const anchorIds = useMemo(
+    () => [...new Set(anchors.map((a) => a.tagName))],
+    [anchors]
+  );
+
+  // Batch-fetch all anchor entities in a single request instead of letting each
+  // EntityTagById fetch on its own. Only runs while the modal is open.
+  const { data: anchorEntities, isFetching: isFetchingEntities } = useQuery({
+    queryKey: ["warning-anchor-entities", anchorIds],
+    queryFn: async () => {
+      const res = await api.entitiesGet(anchorIds);
+      return res.data ?? [];
+    },
+    enabled: open && anchorIds.length > 0 && api.isLoggedIn(),
+  });
+
+  const entityMap = useMemo(() => {
+    const map: Record<string, IResponseEntity> = {};
+    (anchorEntities ?? []).forEach((entity) => {
+      map[entity.id] = entity;
+    });
+    return map;
+  }, [anchorEntities]);
+
   if (anchors.length === 0) {
     return null;
   }
@@ -111,13 +138,18 @@ export const AnnotatorWarningsModal: React.FC<AnnotatorWarningsModalProps> = ({
                 />
                 <StyledWarningInfo>
                   <StyledWarningKind>{kindLabel(anchor.type)}</StyledWarningKind>
-                  <EntityTagById
-                    entityId={anchor.tagName}
-                    disableToast
-                    fullWidth
-                    disableTooltip={false}
-                    disableDoubleClick={false}
-                  />
+                  {isFetchingEntities && !entityMap[anchor.tagName] ? (
+                    <Loader size={12} show noBackground />
+                  ) : (
+                    <EntityTagById
+                      entityId={anchor.tagName}
+                      entity={entityMap[anchor.tagName]}
+                      disableToast
+                      fullWidth
+                      disableTooltip={false}
+                      disableDoubleClick={false}
+                    />
+                  )}
                 </StyledWarningInfo>
                 <ButtonGroup>
                   <Button

--- a/packages/client/src/components/advanced/Annotator/highlight.ts
+++ b/packages/client/src/components/advanced/Annotator/highlight.ts
@@ -12,8 +12,12 @@ export const annotatorHighlight = (
   entityId: string,
   data: annotatorHighlightData,
   hlClasses: EntityEnums.Class[],
-  theme: DefaultTheme | undefined
+  theme: DefaultTheme | undefined,
 ): HighlightSchema | undefined => {
+  if (!theme) {
+    return undefined;
+  }
+
   const dReferenceEntityIds: Record<EntityEnums.Class, string[]> =
     data.dataDocument?.entityIds ?? {};
 
@@ -21,26 +25,22 @@ export const annotatorHighlight = (
     return {
       mode: HighlightMode.FOCUS,
       style: {
-        color: theme?.color["black"],
+        color: theme.color["black"],
         opacity: 0.08,
       },
     };
   }
 
   const entityClass = Object.keys(dReferenceEntityIds).find((key) =>
-    dReferenceEntityIds[key as EntityEnums.Class].includes(entityId)
+    dReferenceEntityIds[key as EntityEnums.Class].includes(entityId),
   );
 
-  if (
-    entityClass &&
-    hlClasses &&
-    hlClasses.includes(entityClass as EntityEnums.Class)
-  ) {
+  if (entityClass && hlClasses && hlClasses.includes(entityClass as EntityEnums.Class)) {
     if (entityClass === EntityEnums.Class.Statement) {
       return {
         mode: HighlightMode.UNDERLINE,
         style: {
-          color: theme?.color.entityS as string,
+          color: theme.color.entityS,
           opacity: 1,
         },
       };
@@ -51,7 +51,7 @@ export const annotatorHighlight = (
 
     const classItem = EntityColors[entityClass];
     const colorName = classItem?.color ?? "transparent";
-    const color = theme?.color[colorName] as string;
+    const color = theme.color[colorName] as string;
 
     return {
       mode: HighlightMode.BACKGROUND,

--- a/packages/client/src/components/advanced/Annotator/highlight.ts
+++ b/packages/client/src/components/advanced/Annotator/highlight.ts
@@ -51,7 +51,7 @@ export const annotatorHighlight = (
 
     const classItem = EntityColors[entityClass];
     const colorName = classItem?.color ?? "transparent";
-    const color = theme.color[colorName] as string;
+    const color = theme.color[colorName];
 
     return {
       mode: HighlightMode.BACKGROUND,

--- a/packages/client/src/components/advanced/ApplyTemplateModal/ApplyTemplateModal.tsx
+++ b/packages/client/src/components/advanced/ApplyTemplateModal/ApplyTemplateModal.tsx
@@ -1,11 +1,7 @@
 import { entitiesDictKeys } from "@inkvisitor/shared/dictionaries";
 import { UserEnums } from "@inkvisitor/shared/enums";
 import { IEntity, IResponseGeneric, Relation } from "@inkvisitor/shared/types";
-import {
-  UseMutationResult,
-  useQuery,
-  useQueryClient,
-} from "@tanstack/react-query";
+import { UseMutationResult, useQueryClient } from "@tanstack/react-query";
 import api from "api";
 import { AxiosResponse } from "axios";
 import {
@@ -19,6 +15,7 @@ import {
 } from "components";
 import { EntityTag } from "components/advanced";
 import { applyTemplate, InstRelations } from "constructors";
+import { useDetailQuery } from "hooks/react-query";
 import React, { useEffect, useState } from "react";
 import { toast } from "react-toastify";
 import { getShortLabelByLetterCount } from "utils/utils";
@@ -46,18 +43,10 @@ export const ApplyTemplateModal: React.FC<ApplyTemplateModal> = ({
   setTemplateToApply,
 }) => {
   const {
-    status,
     data: templateDetail,
     error: templateDetailError,
     isFetching: templateDetailIsFetching,
-  } = useQuery({
-    queryKey: ["entity", templateToApply.id],
-    queryFn: async () => {
-      const res = await api.detailGet(templateToApply.id);
-      return res.data;
-    },
-    enabled: !!templateToApply.id && api.isLoggedIn(),
-  });
+  } = useDetailQuery(templateToApply.id);
 
   const [newRelations, setNewRelations] = useState<Relation.IRelation[]>([]);
 

--- a/packages/client/src/components/advanced/AuditTable/AuditTable.tsx
+++ b/packages/client/src/components/advanced/AuditTable/AuditTable.tsx
@@ -12,12 +12,7 @@ import {
 } from "./AuditTableStyles";
 import { Button } from "components/basic/Button/Button";
 
-export const AuditTable: React.FC<IResponseAudit> = ({
-  modelId,
-  auditScope,
-  last,
-  first,
-}) => {
+export const AuditTable: React.FC<IResponseAudit> = ({ modelId, auditScope, last, first }) => {
   return (
     <div>
       <StyledAuditTable>
@@ -26,12 +21,8 @@ export const AuditTable: React.FC<IResponseAudit> = ({
           .map((auditLast, ai) => (
             <AuditTableRow mode="edit" key={ai} {...auditLast}></AuditTableRow>
           ))}
-        {last && last.length > 1 && (
-          <StyledAuditEllipsis>...</StyledAuditEllipsis>
-        )}
-        {first && (
-          <AuditTableRow mode="create" key="first" {...first}></AuditTableRow>
-        )}
+        {last && last.length > 1 && <StyledAuditEllipsis>...</StyledAuditEllipsis>}
+        {first && <AuditTableRow mode="create" key="first" {...first}></AuditTableRow>}
       </StyledAuditTable>
     </div>
   );
@@ -92,13 +83,7 @@ export const AuditTableRow: React.FC<AuditTableRow> = ({
             tooltipLabel="created"
           />
         ) : (
-          <Button
-            icon={<FaExchangeAlt />}
-            noBackground
-            inverted
-            noBorder
-            tooltipLabel="edited"
-          />
+          <Button icon={<FaExchangeAlt />} noBackground inverted noBorder tooltipLabel="edited" />
         )}
         {mode === "create" ? "" : changedKeys.join(", ")}
       </StyledAuditColumn>

--- a/packages/client/src/components/advanced/AuditTable/AuditTable.tsx
+++ b/packages/client/src/components/advanced/AuditTable/AuditTable.tsx
@@ -1,10 +1,9 @@
 import { IAudit, IResponseAudit } from "@inkvisitor/shared/types";
-import api from "api";
 import React from "react";
 import { FaExchangeAlt, FaRegCalendarAlt, FaUser } from "react-icons/fa";
 import { MdAddCircleOutline } from "react-icons/md";
 import { RiTimeLine } from "react-icons/ri";
-import { useQuery } from "@tanstack/react-query";
+import { useUsersSimplifiedQuery } from "hooks/react-query";
 import {
   StyledAuditColumn,
   StyledAuditEllipsis,
@@ -48,14 +47,8 @@ export const AuditTableRow: React.FC<AuditTableRow> = ({
   changes,
   mode,
 }) => {
-  const { data: userData, isFetching: isFetchingUser } = useQuery({
-    queryKey: ["user", user],
-    queryFn: async () => {
-      const res = await api.withoutToaster().usersGet(user as string);
-      return res.data;
-    },
-    enabled: !!user,
-  });
+  const { data: users } = useUsersSimplifiedQuery();
+  const userName = users?.find((u) => u.id === user)?.name;
 
   const changedKeys =
     Object.keys(changes).length === 1 && Object.keys(changes)[0] === "data"
@@ -79,7 +72,7 @@ export const AuditTableRow: React.FC<AuditTableRow> = ({
     <StyledAuditRow>
       <StyledAuditColumn>
         <FaUser />
-        {userData ? userData.name : <i>{"removed user"}</i>}
+        {userName ? userName : <i>{"removed user"}</i>}
       </StyledAuditColumn>
       <StyledAuditColumn>
         <FaRegCalendarAlt />

--- a/packages/client/src/components/advanced/BreadcrumbItem/BreadcrumbItem.tsx
+++ b/packages/client/src/components/advanced/BreadcrumbItem/BreadcrumbItem.tsx
@@ -1,15 +1,16 @@
 import { EntityEnums } from "@inkvisitor/shared/enums";
-import { IEntity, IResponseTerritory } from "@inkvisitor/shared/types";
+import { IEntity, IResponseTerritory, IResponseTree } from "@inkvisitor/shared/types";
 import api from "api";
 import { Button, Loader } from "components";
 import { EntityTag } from "components/advanced";
 import { useSearchParams } from "hooks";
 import React from "react";
 import { BsArrow90DegLeft, BsArrowRightShort } from "react-icons/bs";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { setTreeInitialized } from "redux/features/territoryTree/treeInitializeSlice";
 import { useAppDispatch } from "redux/hooks";
 import { rootTerritoryId } from "Theme/constants";
+import { searchTree } from "utils/utils";
 import { StyledItemBox } from "./BreadcrumbItemStyles";
 
 // initalData is used in the moment of loading to show the tag with the loader
@@ -43,18 +44,29 @@ export const BreadcrumbItem: React.FC<BreadcrumbItem> = ({
 
   const dispatch = useAppDispatch();
 
+  // Reuse the territory already held in the cached ["tree"] blob instead of
+  // fetching it again. The breadcrumb path is always part of the tree, so this
+  // avoids one GET /entities/:id per breadcrumb item.
+  const queryClient = useQueryClient();
+  const treeData = queryClient.getQueryData<IResponseTree>(["tree"]);
+  const treeTerritory =
+    !territoryData && treeData
+      ? searchTree(treeData, territoryId)?.territory
+      : undefined;
+
   const { status, data, error, isFetching } = useQuery({
     queryKey: ["territory", territoryId],
     queryFn: async () => {
       const res = await api.entityGet(territoryId);
       return res.data;
     },
-    enabled: !!territoryId && !territoryData && api.isLoggedIn(),
+    enabled:
+      !!territoryId && !territoryData && !treeTerritory && api.isLoggedIn(),
   });
 
   return (
     <>
-      {(territoryData || data || (initialData && isFetching)) && (
+      {(territoryData || treeTerritory || data || (initialData && isFetching)) && (
         <>
           {territoryId !== rootTerritoryId && (
             <StyledItemBox>
@@ -63,7 +75,7 @@ export const BreadcrumbItem: React.FC<BreadcrumbItem> = ({
                 showOnly="label"
                 fullWidth={isSelected}
                 isSelected={isSelected}
-                entity={territoryData || data || initialData}
+                entity={territoryData || treeTerritory || data || initialData}
                 isFavorited={isFavorited}
                 button={
                   paramsTerritoryId !== territoryId && (

--- a/packages/client/src/components/advanced/DocumentModal/DocumentModalEdit.tsx
+++ b/packages/client/src/components/advanced/DocumentModal/DocumentModalEdit.tsx
@@ -1,9 +1,8 @@
 import React, { useEffect, useState } from "react";
 
 import { EntityEnums } from "@inkvisitor/shared/enums";
-import { useQuery } from "@tanstack/react-query";
-import api from "api";
 import { Modal, ModalContent, ModalHeader } from "components";
+import { useDocumentQuery } from "hooks/react-query";
 import { useWindowSize } from "hooks/useWindowSize";
 import { getShortLabelByLetterCount } from "utils/utils";
 import TextAnnotator from "../Annotator/Annotator";
@@ -33,14 +32,7 @@ const DocumentModalEdit: React.FC<DocumentModalEdit> = ({
     data: dataDocument,
     error: errorDocument,
     isFetching: dataDocumentIsFetching,
-  } = useQuery({
-    queryKey: ["document", documentId],
-    queryFn: async () => {
-      const res = await api.documentGet(documentId);
-      return res.data;
-    },
-    enabled: api.isLoggedIn(),
-  });
+  } = useDocumentQuery(documentId);
 
   return (
     <Modal

--- a/packages/client/src/components/advanced/Dropdowns/BasicDropdown.tsx
+++ b/packages/client/src/components/advanced/Dropdowns/BasicDropdown.tsx
@@ -17,6 +17,7 @@ interface BasicDropdown<T = string> {
   tooltipPosition?: AutoPlacement | BasePlacement | VariationPlacement;
   disableTyping?: boolean;
   disabled?: boolean;
+  onFocus?: () => void;
 
   noDropDownIndicator?: boolean;
   loggerId?: string;
@@ -32,6 +33,7 @@ export const BasicDropdown = <T extends string>({
   tooltipPosition,
   disableTyping = false,
   disabled,
+  onFocus,
   loggerId,
   noDropDownIndicator = false,
 }: BasicDropdown<T>) => {
@@ -48,6 +50,7 @@ export const BasicDropdown = <T extends string>({
       noDropDownIndicator={noDropDownIndicator}
       disableTyping={disableTyping}
       disabled={disabled}
+      onFocus={onFocus}
       loggerId={loggerId}
     />
   );

--- a/packages/client/src/components/advanced/EntityCreateModal/EntityCreateModal.tsx
+++ b/packages/client/src/components/advanced/EntityCreateModal/EntityCreateModal.tsx
@@ -6,7 +6,7 @@ import {
 import { classesAll, entitiesDictKeys } from "@inkvisitor/shared/dictionaries/entity";
 import { EntityEnums, UserEnums } from "@inkvisitor/shared/enums";
 import { DropdownItem, IEntity, IResponseEntity } from "@inkvisitor/shared/types";
-import { useMutation, useQuery } from "@tanstack/react-query";
+import { useMutation } from "@tanstack/react-query";
 import {
   MIN_LABEL_LENGTH_MESSAGE,
   excludedSuggesterEntities,
@@ -31,7 +31,7 @@ import React, { useEffect, useMemo, useState } from "react";
 import { toast } from "react-toastify";
 import { getEntityLabel, getShortLabelByLetterCount } from "utils/utils";
 import { StyledNote } from "./EntityCreateModalStyles";
-import { useUserQuery } from "hooks/react-query";
+import { useTemplatesQuery, useUserQuery } from "hooks/react-query";
 
 const defaultDropdownValue = "empty";
 interface EntityCreateModal {
@@ -229,24 +229,12 @@ export const EntityCreateModal: React.FC<EntityCreateModal> = ({
     }
   };
 
-  const { data: templates } = useQuery({
-    queryKey: ["entity-templates", "templates", selectedCategory],
-    queryFn: async () => {
-      if (selectedCategory) {
-        const res = await api.entitiesSearch({
-          onlyTemplates: true,
-          class: selectedCategory,
-        });
+  const { data: allTemplates } = useTemplatesQuery();
 
-        const templates = res.data ?? [];
-        templates.sort((a: IEntity, b: IEntity) =>
-          a.labels[0].toLocaleLowerCase() > b.labels[0].toLocaleLowerCase() ? 1 : -1
-        );
-        return templates;
-      }
-    },
-    enabled: !!selectedCategory && api.isLoggedIn(),
-  });
+  const templates = useMemo(
+    () => allTemplates?.filter((template) => template.class === selectedCategory),
+    [allTemplates, selectedCategory]
+  );
 
   const templateOptions: DropdownItem[] & { template: IEntity }[] = useMemo(() => {
     const options = templates

--- a/packages/client/src/components/advanced/EntitySuggester/EntitySuggester.tsx
+++ b/packages/client/src/components/advanced/EntitySuggester/EntitySuggester.tsx
@@ -150,6 +150,9 @@ const EntitySuggesterFull: React.FC<
 }) => {
   const [typed, setTyped] = useState<string>(initTyped ?? "");
   const debouncedTyped = useDebounce(typed, 100);
+  // becomes true once the suggester is focused, so the territory actants query
+  // runs on focus - the preSuggestions (territory-based) are shown before typing.
+  const [hasFocused, setHasFocused] = useState<boolean>(false);
   const [selectedCategory, setSelectedCategory] = useState<
     EntityEnums.Class | EntityEnums.Extension.Any
   >();
@@ -240,7 +243,7 @@ const EntitySuggesterFull: React.FC<
       }
       return [];
     },
-    enabled: !!territoryId && debouncedTyped.length > 1 && api.isLoggedIn(),
+    enabled: !!territoryId && hasFocused && api.isLoggedIn(),
     staleTime: 1000 * 60 * 5,
   });
 
@@ -281,7 +284,7 @@ const EntitySuggesterFull: React.FC<
           const icons: React.ReactNode[] = [];
 
           if (territoryActantIds?.includes(entity.id)) {
-            icons.push(<FaHome key={entity.id} color="" />);
+            icons.push(<FaHome key={entity.id} size={12} />);
           }
 
           return {
@@ -477,6 +480,7 @@ const EntitySuggesterFull: React.FC<
         category={selectedCategory} // selected category
         categories={allCategories} // all possible categories
         onCancel={handleClean}
+        onFocus={() => setHasFocused(true)}
         onType={(newType: string) => {
           setTyped(newType);
           onTyped && onTyped(newType);

--- a/packages/client/src/components/advanced/EntitySuggester/EntitySuggester.tsx
+++ b/packages/client/src/components/advanced/EntitySuggester/EntitySuggester.tsx
@@ -35,7 +35,10 @@ interface EntitySuggesterProps {
   placeholder?: string;
   inputWidth?: number | "full";
   openDetailOnCreate?: boolean;
-  territoryActants?: string[];
+  // territoryId of the territory whose actant entity ids are fetched (lazily,
+  // only once the suggester is actively searching) to render the home icon next
+  // to suggestion list items in the StatementEditor.
+  territoryId?: string;
   excludedEntityClasses?: EntityEnums.Class[];
   excludedActantIds?: string[];
   filterEditorRights?: boolean;
@@ -105,7 +108,7 @@ const EntitySuggesterFull: React.FC<
   placeholder = "",
   inputWidth,
   openDetailOnCreate = false,
-  territoryActants,
+  territoryId,
   excludedEntityClasses = [],
   filterEditorRights = false,
   excludedActantIds = [],
@@ -226,6 +229,23 @@ const EntitySuggesterFull: React.FC<
       api.isLoggedIn(),
   });
 
+  // territory actants query - fetched lazily, only once the suggester is
+  // actively searching, to mark suggestions already present in the territory.
+  const { data: fetchedTerritoryActants } = useQuery({
+    queryKey: ["territoryActants", territoryId],
+    queryFn: async () => {
+      if (territoryId) {
+        const res = await api.entityIdsInTerritory(territoryId);
+        return res.data ?? [];
+      }
+      return [];
+    },
+    enabled: !!territoryId && debouncedTyped.length > 1 && api.isLoggedIn(),
+    staleTime: 1000 * 60 * 5,
+  });
+
+  const territoryActantIds = fetchedTerritoryActants;
+
   const filterSuggestions = (suggestions: IResponseEntity[]) => {
     return (
       deepCopy(suggestions)
@@ -260,7 +280,7 @@ const EntitySuggesterFull: React.FC<
         .map((entity: IEntity) => {
           const icons: React.ReactNode[] = [];
 
-          if (territoryActants?.includes(entity.id)) {
+          if (territoryActantIds?.includes(entity.id)) {
             icons.push(<FaHome key={entity.id} color="" />);
           }
 

--- a/packages/client/src/components/advanced/EntitySuggester/EntitySuggester.tsx
+++ b/packages/client/src/components/advanced/EntitySuggester/EntitySuggester.tsx
@@ -35,9 +35,10 @@ interface EntitySuggesterProps {
   placeholder?: string;
   inputWidth?: number | "full";
   openDetailOnCreate?: boolean;
-  // territoryId of the territory whose actant entity ids are fetched (lazily,
-  // only once the suggester is actively searching) to render the home icon next
-  // to suggestion list items in the StatementEditor.
+  // territoryId keys the cached set of entity ids already used in the territory,
+  // used to render the home icon next to suggestion list items. The cache is
+  // seeded by the StatementEditor from its territoryData - this component never
+  // fetches it, so the icon only appears where that seed exists (StatementEditor).
   territoryId?: string;
   excludedEntityClasses?: EntityEnums.Class[];
   excludedActantIds?: string[];
@@ -150,9 +151,6 @@ const EntitySuggesterFull: React.FC<
 }) => {
   const [typed, setTyped] = useState<string>(initTyped ?? "");
   const debouncedTyped = useDebounce(typed, 100);
-  // becomes true once the suggester is focused, so the territory actants query
-  // runs on focus - the preSuggestions (territory-based) are shown before typing.
-  const [hasFocused, setHasFocused] = useState<boolean>(false);
   const [selectedCategory, setSelectedCategory] = useState<
     EntityEnums.Class | EntityEnums.Extension.Any
   >();
@@ -232,22 +230,17 @@ const EntitySuggesterFull: React.FC<
       api.isLoggedIn(),
   });
 
-  // territory actants query - fetched lazily, only once the suggester is
-  // actively searching, to mark suggestions already present in the territory.
-  const { data: fetchedTerritoryActants } = useQuery({
+  // territory actants - the ids of entities already used in the territory, used
+  // to mark such suggestions with a home icon. This never fetches: the StatementEditor
+  // seeds this cache from its already-loaded territoryData (same id set as
+  // api.entityIdsInTerritory). Elsewhere (e.g. entity detail) nothing seeds it,
+  // so it resolves to [] and no home icon is shown - it is only relevant there.
+  const { data: territoryActantIds } = useQuery<string[]>({
     queryKey: ["territoryActants", territoryId],
-    queryFn: async () => {
-      if (territoryId) {
-        const res = await api.entityIdsInTerritory(territoryId);
-        return res.data ?? [];
-      }
-      return [];
-    },
-    enabled: !!territoryId && hasFocused && api.isLoggedIn(),
-    staleTime: 1000 * 60 * 5,
+    queryFn: async () => [],
+    enabled: !!territoryId,
+    staleTime: Infinity,
   });
-
-  const territoryActantIds = fetchedTerritoryActants;
 
   const filterSuggestions = (suggestions: IResponseEntity[]) => {
     return (
@@ -480,7 +473,6 @@ const EntitySuggesterFull: React.FC<
         category={selectedCategory} // selected category
         categories={allCategories} // all possible categories
         onCancel={handleClean}
-        onFocus={() => setHasFocused(true)}
         onType={(newType: string) => {
           setTyped(newType);
           onTyped && onTyped(newType);

--- a/packages/client/src/components/advanced/UserCustomizationModal/UserCustomizationModal.tsx
+++ b/packages/client/src/components/advanced/UserCustomizationModal/UserCustomizationModal.tsx
@@ -86,7 +86,6 @@ export const UserCustomizationModal: React.FC<UserCustomizationModal> = ({
     setData(initialValues);
   }, [initialValues]);
 
-
   const handleChange = (key: string, value: string | true | false | DropdownItem) => {
     setData({
       ...data,
@@ -356,13 +355,14 @@ export const UserCustomizationModal: React.FC<UserCustomizationModal> = ({
                   <EntityTag
                     entity={defaultTerritory}
                     tooltipPosition="left"
-                  unlinkButton={{
-                    onClick: () => {
-                      setDefaultTerritory(null);
-                      setData((prev) => ({ ...prev, defaultTerritory: "" }));
-                    },
+                    unlinkButton={{
+                      onClick: () => {
+                        setDefaultTerritory(null);
+                        setData((prev) => ({ ...prev, defaultTerritory: "" }));
+                      },
                       color: "danger",
                     }}
+                    fullWidth
                   />
                 ) : (
                   <div>

--- a/packages/client/src/components/advanced/UserCustomizationModal/UserCustomizationModal.tsx
+++ b/packages/client/src/components/advanced/UserCustomizationModal/UserCustomizationModal.tsx
@@ -29,6 +29,8 @@ import {
   StyledButtonWrap,
   StyledRightsHeading,
   StyledRightsWrap,
+  StyledUserCustomization,
+  StyledUserCustomizationSection,
   StyledUserRightHeading,
   StyledUserRightItem,
   StyledUserRights,
@@ -171,171 +173,173 @@ export const UserCustomizationModal: React.FC<UserCustomizationModal> = ({
       >
         <ModalHeader title="User customization" />
         <ModalContent column enableScroll>
-          <div style={{ position: "relative" }}>
-            <StyledRightsHeading>
-              <b>{"User information"}</b>
-            </StyledRightsHeading>
-            <ModalInputForm>
-              <ModalInputLabel>{"name"}</ModalInputLabel>
-              <ModalInputWrap width={165}>
-                <Input
-                  width="full"
-                  changeOnType
-                  value={name}
-                  onChangeFn={(value: string) => handleChange("name", value)}
-                />
-              </ModalInputWrap>
-              <ModalInputLabel>{"email"}</ModalInputLabel>
-              <ModalInputWrap width={165}>
-                <Input
-                  width="full"
-                  changeOnType
-                  value={email}
-                  onChangeFn={(value: string) => handleChange("email", value)}
-                />
-              </ModalInputWrap>
-            </ModalInputForm>
+          <StyledUserCustomization>
+            <StyledUserCustomizationSection>
+              <StyledRightsHeading>
+                <b>{"User information"}</b>
+              </StyledRightsHeading>
+              <ModalInputForm>
+                <ModalInputLabel>{"name"}</ModalInputLabel>
+                <ModalInputWrap width={165}>
+                  <Input
+                    width="full"
+                    changeOnType
+                    value={name}
+                    onChangeFn={(value: string) => handleChange("name", value)}
+                  />
+                </ModalInputWrap>
+                <ModalInputLabel>{"email"}</ModalInputLabel>
+                <ModalInputWrap width={165}>
+                  <Input
+                    width="full"
+                    changeOnType
+                    value={email}
+                    onChangeFn={(value: string) => handleChange("email", value)}
+                  />
+                </ModalInputWrap>
+              </ModalInputForm>
 
-            {!showPasswordChange && (
-              <div
-                style={{
-                  display: "flex",
-                  width: "100%",
-                  justifyContent: "center",
-                }}
-              >
-                <Button
-                  label="change password"
-                  noBorder
-                  color="warning"
-                  inverted
-                  noBackground
-                  onClick={() => setShowPasswordChange(!showPasswordChange)}
-                />
-              </div>
-            )}
-
-            {showPasswordChange && (
-              <>
-                <StyledRightsHeading>
-                  <b>{"Change password"}</b>
-                </StyledRightsHeading>
-
-                <ModalInputForm>
-                  <ModalInputLabel>{"new password"}</ModalInputLabel>
-                  <ModalInputWrap width={165}>
-                    <Input
-                      type="password"
-                      width="full"
-                      changeOnType
-                      value={newPassword}
-                      onChangeFn={(value: string) => setNewPassword(value)}
-                    />
-                  </ModalInputWrap>
-                  <ModalInputLabel>{"repeat password"}</ModalInputLabel>
-                  <ModalInputWrap width={165}>
-                    <Input
-                      type="password"
-                      width="full"
-                      changeOnType
-                      value={repeatPassword}
-                      onChangeFn={(value: string) => setRepeatPassword(value)}
-                    />
-                  </ModalInputWrap>
-                </ModalInputForm>
-
-                <div style={{ maxWidth: "31rem" }}>
-                  <StyledDescription>{SAFE_PASSWORD_DESCRIPTION}</StyledDescription>
+              {!showPasswordChange && (
+                <div
+                  style={{
+                    display: "flex",
+                    width: "100%",
+                    justifyContent: "center",
+                  }}
+                >
+                  <Button
+                    label="change password"
+                    noBorder
+                    color="warning"
+                    inverted
+                    noBackground
+                    onClick={() => setShowPasswordChange(!showPasswordChange)}
+                  />
                 </div>
+              )}
 
-                <StyledButtonWrap>
-                  <ButtonGroup>
-                    <Button
-                      color="warning"
-                      label="Cancel"
-                      inverted
-                      onClick={() => {
-                        setShowPasswordChange(false);
-                        setNewPassword("");
-                        setRepeatPassword("");
-                      }}
-                    />
-                    <Button
-                      color="danger"
-                      label="Submit"
-                      inverted
-                      onClick={() => {
-                        if (newPassword.length > 0 && !isSafePassword(newPassword)) {
-                          toast.warning(UnsafePasswordError.message);
-                        } else {
-                          if (newPassword === repeatPassword) {
-                            passwordUpdateMutation.mutate();
-                            setShowPasswordChange(false);
-                            setNewPassword("");
-                            setRepeatPassword("");
+              {showPasswordChange && (
+                <>
+                  <StyledRightsHeading>
+                    <b>{"Change password"}</b>
+                  </StyledRightsHeading>
+
+                  <ModalInputForm>
+                    <ModalInputLabel>{"new password"}</ModalInputLabel>
+                    <ModalInputWrap width={165}>
+                      <Input
+                        type="password"
+                        width="full"
+                        changeOnType
+                        value={newPassword}
+                        onChangeFn={(value: string) => setNewPassword(value)}
+                      />
+                    </ModalInputWrap>
+                    <ModalInputLabel>{"repeat password"}</ModalInputLabel>
+                    <ModalInputWrap width={165}>
+                      <Input
+                        type="password"
+                        width="full"
+                        changeOnType
+                        value={repeatPassword}
+                        onChangeFn={(value: string) => setRepeatPassword(value)}
+                      />
+                    </ModalInputWrap>
+                  </ModalInputForm>
+
+                  <div style={{ maxWidth: "31rem" }}>
+                    <StyledDescription>{SAFE_PASSWORD_DESCRIPTION}</StyledDescription>
+                  </div>
+
+                  <StyledButtonWrap>
+                    <ButtonGroup>
+                      <Button
+                        color="warning"
+                        label="Cancel"
+                        inverted
+                        onClick={() => {
+                          setShowPasswordChange(false);
+                          setNewPassword("");
+                          setRepeatPassword("");
+                        }}
+                      />
+                      <Button
+                        color="danger"
+                        label="Submit"
+                        inverted
+                        onClick={() => {
+                          if (newPassword.length > 0 && !isSafePassword(newPassword)) {
+                            toast.warning(UnsafePasswordError.message);
                           } else {
-                            toast.warning("Passwords are not matching");
+                            if (newPassword === repeatPassword) {
+                              passwordUpdateMutation.mutate();
+                              setShowPasswordChange(false);
+                              setNewPassword("");
+                              setRepeatPassword("");
+                            } else {
+                              toast.warning("Passwords are not matching");
+                            }
                           }
-                        }
-                      }}
+                        }}
+                      />
+                    </ButtonGroup>
+                  </StyledButtonWrap>
+                </>
+              )}
+            </StyledUserCustomizationSection>
+            <StyledUserCustomizationSection>
+              <StyledRightsHeading>
+                <b>{"Customization"}</b>
+              </StyledRightsHeading>
+
+              <ModalInputForm>
+                <ModalInputLabel>default entity label language</ModalInputLabel>
+                <ModalInputWrap width={165}>
+                  <div
+                    style={{
+                      display: "flex",
+                      alignItems: "center",
+                      gap: "6px",
+                    }}
+                  >
+                    <Dropdown.Single.Basic
+                      width="full"
+                      value={defaultLanguage}
+                      onChange={(newValue) => handleChange("defaultLanguage", newValue)}
+                      options={languageDict}
                     />
-                  </ButtonGroup>
-                </StyledButtonWrap>
-              </>
-            )}
+                    <IconWithTooltip
+                      color="success"
+                      icon={<FaQuestion />}
+                      tooltipLabel="Default language used for labeling entities."
+                    />
+                  </div>
+                </ModalInputWrap>
+                <ModalInputLabel>default source language</ModalInputLabel>
+                <ModalInputWrap width={165}>
+                  <div
+                    style={{
+                      display: "flex",
+                      alignItems: "center",
+                      gap: "6px",
+                    }}
+                  >
+                    <Dropdown.Single.Basic
+                      width="full"
+                      value={defaultStatementLanguage}
+                      onChange={(newValue) => handleChange("defaultStatementLanguage", newValue)}
+                      options={languageDict}
+                    />
+                    <IconWithTooltip
+                      color="success"
+                      icon={<FaQuestion />}
+                      tooltipLabel="Dominant language of the source texts being coded into statements"
+                    />
+                  </div>
+                </ModalInputWrap>
 
-            <StyledRightsHeading>
-              <b>{"Customization"}</b>
-            </StyledRightsHeading>
-
-            <ModalInputForm>
-              <ModalInputLabel>default entity label language</ModalInputLabel>
-              <ModalInputWrap width={165}>
-                <div
-                  style={{
-                    display: "flex",
-                    alignItems: "center",
-                    gap: "6px",
-                  }}
-                >
-                  <Dropdown.Single.Basic
-                    width="full"
-                    value={defaultLanguage}
-                    onChange={(newValue) => handleChange("defaultLanguage", newValue)}
-                    options={languageDict}
-                  />
-                  <IconWithTooltip
-                    color="success"
-                    icon={<FaQuestion />}
-                    tooltipLabel="Default language used for labeling entities."
-                  />
-                </div>
-              </ModalInputWrap>
-              <ModalInputLabel>default source language</ModalInputLabel>
-              <ModalInputWrap width={165}>
-                <div
-                  style={{
-                    display: "flex",
-                    alignItems: "center",
-                    gap: "6px",
-                  }}
-                >
-                  <Dropdown.Single.Basic
-                    width="full"
-                    value={defaultStatementLanguage}
-                    onChange={(newValue) => handleChange("defaultStatementLanguage", newValue)}
-                    options={languageDict}
-                  />
-                  <IconWithTooltip
-                    color="success"
-                    icon={<FaQuestion />}
-                    tooltipLabel="Dominant language of the source texts being coded into statements"
-                  />
-                </div>
-              </ModalInputWrap>
-
-              {/* NOT USED NOW */}
-              {/* <ModalInputLabel>{"search languages"}</ModalInputLabel>
+                {/* NOT USED NOW */}
+                {/* <ModalInputLabel>{"search languages"}</ModalInputLabel>
                 <ModalInputWrap width={165}>
                   <Dropdown.Multi.Attribute
                     value={data.searchLanguages}
@@ -349,110 +353,116 @@ export const UserCustomizationModal: React.FC<UserCustomizationModal> = ({
                   />
                 </ModalInputWrap> */}
 
-              <ModalInputLabel>{"default territory"}</ModalInputLabel>
-              <ModalInputWrap width={165}>
-                {defaultTerritory ? (
-                  <EntityTag
-                    entity={defaultTerritory}
-                    tooltipPosition="left"
-                    unlinkButton={{
-                      onClick: () => {
-                        setDefaultTerritory(null);
-                        setData((prev) => ({ ...prev, defaultTerritory: "" }));
-                      },
-                      color: "danger",
-                    }}
-                    fullWidth
-                  />
-                ) : (
-                  <div>
-                    <EntitySuggester
-                      categoryTypes={[EntityEnums.Class.Territory]}
-                      onPicked={(entity) => {
-                        setDefaultTerritory(entity);
-                        setData((prev) => ({ ...prev, defaultTerritory: entity.id }));
+                <ModalInputLabel>{"default territory"}</ModalInputLabel>
+                <ModalInputWrap width={165}>
+                  {defaultTerritory ? (
+                    <EntityTag
+                      entity={defaultTerritory}
+                      tooltipPosition="left"
+                      unlinkButton={{
+                        onClick: () => {
+                          setDefaultTerritory(null);
+                          setData((prev) => ({ ...prev, defaultTerritory: "" }));
+                        },
+                        color: "danger",
                       }}
-                      inputWidth={104}
-                      disableTemplatesAccept
+                      fullWidth
+                    />
+                  ) : (
+                    <div>
+                      <EntitySuggester
+                        categoryTypes={[EntityEnums.Class.Territory]}
+                        onPicked={(entity) => {
+                          setDefaultTerritory(entity);
+                          setData((prev) => ({ ...prev, defaultTerritory: entity.id }));
+                        }}
+                        inputWidth={104}
+                        disableTemplatesAccept
+                      />
+                    </div>
+                  )}
+                </ModalInputWrap>
+              </ModalInputForm>
+            </StyledUserCustomizationSection>
+            <StyledUserCustomizationSection>
+              <StyledRightsHeading>
+                <b>{"User rights"}</b>
+              </StyledRightsHeading>
+              <StyledUserRights>
+                <StyledUserRightHeading>{"role"}</StyledUserRightHeading>
+                <StyledUserRightItem>
+                  <div>
+                    <AttributeButtonGroup
+                      disabled
+                      options={[
+                        {
+                          longValue: userRoleDict[0].label,
+                          shortValue: userRoleDict[0].label,
+                          selected: role === userRoleDict[0].value,
+                          onClick: () => {},
+                        },
+                        {
+                          longValue: userRoleDict[1].label,
+                          shortValue: userRoleDict[1].label,
+                          selected: role === userRoleDict[1].value,
+                          onClick: () => {},
+                        },
+                        {
+                          longValue: userRoleDict[2].label,
+                          shortValue: userRoleDict[2].label,
+                          selected: role === userRoleDict[2].value,
+                          onClick: () => {},
+                        },
+                        {
+                          longValue: userRoleDict[3].label,
+                          shortValue: userRoleDict[3].label,
+                          selected: role === userRoleDict[3].value,
+                          onClick: () => {},
+                        },
+                      ]}
                     />
                   </div>
-                )}
-              </ModalInputWrap>
-            </ModalInputForm>
-
-            <StyledRightsHeading>
-              <b>{"User rights"}</b>
-            </StyledRightsHeading>
-            <StyledUserRights>
-              <StyledUserRightHeading>{"role"}</StyledUserRightHeading>
-              <StyledUserRightItem>
-                <div>
-                  <AttributeButtonGroup
-                    disabled
-                    options={[
-                      {
-                        longValue: userRoleDict[0].label,
-                        shortValue: userRoleDict[0].label,
-                        selected: role === userRoleDict[0].value,
-                        onClick: () => {},
-                      },
-                      {
-                        longValue: userRoleDict[1].label,
-                        shortValue: userRoleDict[1].label,
-                        selected: role === userRoleDict[1].value,
-                        onClick: () => {},
-                      },
-                      {
-                        longValue: userRoleDict[2].label,
-                        shortValue: userRoleDict[2].label,
-                        selected: role === userRoleDict[2].value,
-                        onClick: () => {},
-                      },
-                      {
-                        longValue: userRoleDict[3].label,
-                        shortValue: userRoleDict[3].label,
-                        selected: role === userRoleDict[3].value,
-                        onClick: () => {},
-                      },
-                    ]}
-                  />
-                </div>
-              </StyledUserRightItem>
-              <StyledUserRightHeading>{"read"}</StyledUserRightHeading>
-              <StyledUserRightItem>
-                <StyledRightsWrap>
-                  {role !== UserEnums.Role.Admin && role !== UserEnums.Role.Owner
-                    ? readRights.map((right, key) => (
-                        <UserRightItem key={key} territoryId={right.territory} />
-                      ))
-                    : "all"}
-                </StyledRightsWrap>
-              </StyledUserRightItem>
-              <StyledUserRightHeading>{"write"}</StyledUserRightHeading>
-              <StyledUserRightItem>
-                <StyledRightsWrap>
-                  {role !== UserEnums.Role.Admin && role !== UserEnums.Role.Owner
-                    ? writeRights.map((right, key) => (
-                        <UserRightItem key={key} territoryId={right.territory} />
-                      ))
-                    : "all"}
-                </StyledRightsWrap>
-              </StyledUserRightItem>
-            </StyledUserRights>
+                </StyledUserRightItem>
+                <StyledUserRightHeading>{"read"}</StyledUserRightHeading>
+                <StyledUserRightItem>
+                  <StyledRightsWrap>
+                    {role !== UserEnums.Role.Admin && role !== UserEnums.Role.Owner
+                      ? readRights.map((right, key) => (
+                          <UserRightItem key={key} territoryId={right.territory} />
+                        ))
+                      : "all"}
+                  </StyledRightsWrap>
+                </StyledUserRightItem>
+                <StyledUserRightHeading>{"write"}</StyledUserRightHeading>
+                <StyledUserRightItem>
+                  <StyledRightsWrap>
+                    {role !== UserEnums.Role.Admin && role !== UserEnums.Role.Owner
+                      ? writeRights.map((right, key) => (
+                          <UserRightItem key={key} territoryId={right.territory} />
+                        ))
+                      : "all"}
+                  </StyledRightsWrap>
+                </StyledUserRightItem>
+              </StyledUserRights>
+            </StyledUserCustomizationSection>
 
             {process.env.NODE_ENV === "development" && (
-              <Button
-                label="Simulate HTML API response"
-                color="warning"
-                onClick={async () => {
-                  const response = await api.devSimulateHtmlError({ ignoreErrorToast: true });
-                  console.log("response", response);
-                }}
-              />
+              <StyledUserCustomizationSection>
+                <div>
+                  <Button
+                    label="Simulate HTML API response"
+                    color="danger"
+                    onClick={async () => {
+                      const response = await api.devSimulateHtmlError({ ignoreErrorToast: true });
+                      console.log("response", response);
+                    }}
+                  />
+                </div>
+              </StyledUserCustomizationSection>
             )}
 
             <Loader show={passwordUpdateMutation.isPending} />
-          </div>
+          </StyledUserCustomization>
         </ModalContent>
 
         <ModalFooter>

--- a/packages/client/src/components/advanced/UserCustomizationModal/UserCustomizationModal.tsx
+++ b/packages/client/src/components/advanced/UserCustomizationModal/UserCustomizationModal.tsx
@@ -27,6 +27,8 @@ import { toast } from "react-toastify";
 import { isSafePassword } from "utils/utils";
 import {
   StyledButtonWrap,
+  StyledDropdownWrap,
+  StyledPasswordDescriptionWrap,
   StyledRightsHeading,
   StyledRightsWrap,
   StyledUserCustomization,
@@ -247,9 +249,9 @@ export const UserCustomizationModal: React.FC<UserCustomizationModal> = ({
                     </ModalInputWrap>
                   </ModalInputForm>
 
-                  <div style={{ maxWidth: "31rem" }}>
+                  <StyledPasswordDescriptionWrap>
                     <StyledDescription>{SAFE_PASSWORD_DESCRIPTION}</StyledDescription>
-                  </div>
+                  </StyledPasswordDescriptionWrap>
 
                   <StyledButtonWrap>
                     <ButtonGroup>
@@ -295,13 +297,7 @@ export const UserCustomizationModal: React.FC<UserCustomizationModal> = ({
               <ModalInputForm>
                 <ModalInputLabel>default entity label language</ModalInputLabel>
                 <ModalInputWrap width={165}>
-                  <div
-                    style={{
-                      display: "flex",
-                      alignItems: "center",
-                      gap: "6px",
-                    }}
-                  >
+                  <StyledDropdownWrap>
                     <Dropdown.Single.Basic
                       width="full"
                       value={defaultLanguage}
@@ -313,17 +309,11 @@ export const UserCustomizationModal: React.FC<UserCustomizationModal> = ({
                       icon={<FaQuestion />}
                       tooltipLabel="Default language used for labeling entities."
                     />
-                  </div>
+                  </StyledDropdownWrap>
                 </ModalInputWrap>
                 <ModalInputLabel>default source language</ModalInputLabel>
                 <ModalInputWrap width={165}>
-                  <div
-                    style={{
-                      display: "flex",
-                      alignItems: "center",
-                      gap: "6px",
-                    }}
-                  >
+                  <StyledDropdownWrap>
                     <Dropdown.Single.Basic
                       width="full"
                       value={defaultStatementLanguage}
@@ -335,7 +325,7 @@ export const UserCustomizationModal: React.FC<UserCustomizationModal> = ({
                       icon={<FaQuestion />}
                       tooltipLabel="Dominant language of the source texts being coded into statements"
                     />
-                  </div>
+                  </StyledDropdownWrap>
                 </ModalInputWrap>
 
                 {/* NOT USED NOW */}

--- a/packages/client/src/components/advanced/UserCustomizationModal/UserCustomizationModal.tsx
+++ b/packages/client/src/components/advanced/UserCustomizationModal/UserCustomizationModal.tsx
@@ -21,7 +21,7 @@ import {
 } from "components";
 import Dropdown, { AttributeButtonGroup, EntitySuggester, EntityTag } from "components/advanced";
 import { StyledDescription } from "pages/AuthModalSharedStyles";
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import { FaQuestion } from "react-icons/fa";
 import { toast } from "react-toastify";
 import { isSafePassword } from "utils/utils";
@@ -86,7 +86,12 @@ export const UserCustomizationModal: React.FC<UserCustomizationModal> = ({
     setData(initialValues);
   }, [initialValues]);
 
+  const isTerritoryMounted = useRef(false);
   useEffect(() => {
+    if (!isTerritoryMounted.current) {
+      isTerritoryMounted.current = true;
+      return;
+    }
     // territory is selected in the suggester
     if (defaultTerritory) {
       setData({
@@ -166,11 +171,11 @@ export const UserCustomizationModal: React.FC<UserCustomizationModal> = ({
 
   const readRights = useMemo(
     () => rights.filter((r) => r.mode === UserEnums.RoleMode.Read),
-    [rights]
+    [rights],
   );
   const writeRights = useMemo(
     () => rights.filter((r) => r.mode === UserEnums.RoleMode.Write),
-    [rights]
+    [rights],
   );
 
   const [showPasswordChange, setShowPasswordChange] = useState(false);

--- a/packages/client/src/components/advanced/UserCustomizationModal/UserCustomizationModal.tsx
+++ b/packages/client/src/components/advanced/UserCustomizationModal/UserCustomizationModal.tsx
@@ -21,7 +21,7 @@ import {
 } from "components";
 import Dropdown, { AttributeButtonGroup, EntitySuggester, EntityTag } from "components/advanced";
 import { StyledDescription } from "pages/AuthModalSharedStyles";
-import React, { useEffect, useMemo, useRef, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import { FaQuestion } from "react-icons/fa";
 import { toast } from "react-toastify";
 import { isSafePassword } from "utils/utils";
@@ -86,22 +86,6 @@ export const UserCustomizationModal: React.FC<UserCustomizationModal> = ({
     setData(initialValues);
   }, [initialValues]);
 
-  const isTerritoryMounted = useRef(false);
-  useEffect(() => {
-    if (!isTerritoryMounted.current) {
-      isTerritoryMounted.current = true;
-      return;
-    }
-    // territory is selected in the suggester
-    if (defaultTerritory) {
-      setData({
-        ...data,
-        defaultTerritory: defaultTerritory.id,
-      });
-    } else {
-      handleChange("defaultTerritory", "");
-    }
-  }, [defaultTerritory]);
 
   const handleChange = (key: string, value: string | true | false | DropdownItem) => {
     setData({
@@ -117,12 +101,7 @@ export const UserCustomizationModal: React.FC<UserCustomizationModal> = ({
     },
   });
 
-  const {
-    status,
-    data: territory,
-    error,
-    isFetching,
-  } = useQuery({
+  const {} = useQuery({
     queryKey: ["territory", data.defaultTerritory],
     queryFn: async () => {
       // defaultTerritory is set but is not loaded in local state
@@ -377,10 +356,11 @@ export const UserCustomizationModal: React.FC<UserCustomizationModal> = ({
                   <EntityTag
                     entity={defaultTerritory}
                     tooltipPosition="left"
-                    unlinkButton={{
-                      onClick: () => {
-                        setDefaultTerritory(null);
-                      },
+                  unlinkButton={{
+                    onClick: () => {
+                      setDefaultTerritory(null);
+                      setData((prev) => ({ ...prev, defaultTerritory: "" }));
+                    },
                       color: "danger",
                     }}
                   />
@@ -390,6 +370,7 @@ export const UserCustomizationModal: React.FC<UserCustomizationModal> = ({
                       categoryTypes={[EntityEnums.Class.Territory]}
                       onPicked={(entity) => {
                         setDefaultTerritory(entity);
+                        setData((prev) => ({ ...prev, defaultTerritory: entity.id }));
                       }}
                       inputWidth={104}
                       disableTemplatesAccept

--- a/packages/client/src/components/advanced/UserCustomizationModal/UserCustomizationModalStyles.tsx
+++ b/packages/client/src/components/advanced/UserCustomizationModal/UserCustomizationModalStyles.tsx
@@ -39,3 +39,11 @@ export const StyledButtonWrap = styled.div`
   justify-content: center;
   margin-top: 0.5rem;
 `;
+export const StyledPasswordDescriptionWrap = styled.div`
+  max-width: 31rem;
+`;
+export const StyledDropdownWrap = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+`;

--- a/packages/client/src/components/advanced/UserCustomizationModal/UserCustomizationModalStyles.tsx
+++ b/packages/client/src/components/advanced/UserCustomizationModal/UserCustomizationModalStyles.tsx
@@ -9,7 +9,6 @@ export const StyledUserCustomization = styled.div`
 export const StyledUserCustomizationSection = styled.div`
   display: flex;
   flex-direction: column;
-  /* gap: 1rem; */
 `;
 export const StyledRightsWrap = styled.div`
   display: flex;

--- a/packages/client/src/components/advanced/UserCustomizationModal/UserCustomizationModalStyles.tsx
+++ b/packages/client/src/components/advanced/UserCustomizationModal/UserCustomizationModalStyles.tsx
@@ -1,5 +1,16 @@
 import styled from "styled-components";
 
+export const StyledUserCustomization = styled.div`
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+`;
+export const StyledUserCustomizationSection = styled.div`
+  display: flex;
+  flex-direction: column;
+  /* gap: 1rem; */
+`;
 export const StyledRightsWrap = styled.div`
   display: flex;
   flex-wrap: wrap;
@@ -7,11 +18,9 @@ export const StyledRightsWrap = styled.div`
 export const StyledUserRights = styled.div`
   display: grid;
   grid-template-columns: auto auto;
-  margin-top: ${({ theme }) => theme.space[2]};
   width: 28rem;
 `;
 export const StyledRightsHeading = styled.div`
-  margin-top: ${({ theme }) => theme.space[4]};
   margin-bottom: ${({ theme }) => theme.space[2]};
   width: 100%;
   text-align: center;

--- a/packages/client/src/components/advanced/ValidationRule/ValidationRule.tsx
+++ b/packages/client/src/components/advanced/ValidationRule/ValidationRule.tsx
@@ -6,7 +6,7 @@ import { EProtocolTieType, ITerritoryValidation } from "@inkvisitor/shared/types
 import { Button, Input } from "components";
 import Dropdown, { AttributeButtonGroup, EntitySuggester, EntityTag } from "components/advanced";
 import React, { useMemo } from "react";
-import { FaTrashAlt } from "react-icons/fa";
+import { IcoTrash } from "Theme/icons";
 import {
   StyledBorderLeft,
   StyledValue,
@@ -437,7 +437,7 @@ export const ValidationRule: React.FC<ValidationRule> = ({
           />
           <Button
             color="danger"
-            icon={<FaTrashAlt />}
+            icon={<IcoTrash />}
             onClick={removeValidationRule}
             inverted
             label="remove validation rule"

--- a/packages/client/src/components/basic/Button/ButtonStyles.tsx
+++ b/packages/client/src/components/basic/Button/ButtonStyles.tsx
@@ -44,7 +44,7 @@ const getVerticalMargin = ($size: ButtonSize) => {
     case ButtonSize.Large:
       return "0.45rem";
     case ButtonSize.ExtraLarge:
-      return "0.6rem";
+      return "0.8rem";
   }
 };
 const getHorizontalMargin = ($size: ButtonSize, $iconButton?: boolean) => {
@@ -56,7 +56,7 @@ const getHorizontalMargin = ($size: ButtonSize, $iconButton?: boolean) => {
     case ButtonSize.Large:
       return $iconButton ? "0.45rem" : "0.7rem";
     case ButtonSize.ExtraLarge:
-      return $iconButton ? "0.6rem" : "0.9rem";
+      return $iconButton ? "0.8rem" : "0.9rem";
   }
 };
 interface IButtonStyle {

--- a/packages/client/src/components/basic/ButtonGroup/ButtonGroup.tsx
+++ b/packages/client/src/components/basic/ButtonGroup/ButtonGroup.tsx
@@ -2,6 +2,7 @@ import styled from "styled-components";
 
 interface ButtonGroup {
   $noMarginRight?: boolean;
+  $smallGap?: boolean;
   $column?: boolean;
   $marginBottom?: boolean;
   $marginTop?: boolean;
@@ -17,7 +18,8 @@ export const ButtonGroup = styled.div.attrs({
   margin-bottom: ${({ $marginBottom, theme }) => ($marginBottom ? theme.space[2] : "")};
   > button:not(:last-child),
   > span:not(:last-child) {
-    margin-right: ${({ $noMarginRight }) => ($noMarginRight ? 0 : "0.5rem")};
+    margin-right: ${({ $noMarginRight, $smallGap }) =>
+      $noMarginRight ? 0 : $smallGap ? "0.2rem" : "0.5rem"};
   }
 `;
 

--- a/packages/client/src/components/basic/Checkbox/Checkbox.tsx
+++ b/packages/client/src/components/basic/Checkbox/Checkbox.tsx
@@ -31,7 +31,7 @@ export const Checkbox: React.FC<Checkbox> = ({
   onChangeFn = () => {},
   label,
   icon,
-  size = 16,
+  size = 15,
   tooltipLabel,
   tooltipContent,
   iconOnly = false,

--- a/packages/client/src/components/basic/Input/Input.tsx
+++ b/packages/client/src/components/basic/Input/Input.tsx
@@ -91,7 +91,6 @@ export const Input: React.FC<Input> = ({
   borderColor,
   onFocus = () => {},
   onBlur = () => {},
-
   fullHeightTextArea = false,
   fontSizeTextArea = "xs",
   roundCorners = true,

--- a/packages/client/src/components/basic/Input/InputStyles.tsx
+++ b/packages/client/src/components/basic/Input/InputStyles.tsx
@@ -160,7 +160,8 @@ export const StyledTextArea = styled.textarea<StyledTextArea>`
     border-width: ${({ theme, $noBorder }) => ($noBorder ? 0 : theme.borderWidth[1])};
     &:focus {
       border-color: ${({ theme }) => theme.color["info"]};
-      box-shadow: ${({ theme }) => `inset 0 0 0 0.1rem ${theme.color["info"]}`};
+      box-shadow: ${({ theme, $noBorder }) =>
+        $noBorder ? "none" : `inset 0 0 0 0.1rem ${theme.color["info"]}`};
     }
   }
   &:hover {

--- a/packages/client/src/components/basic/Message/Message.tsx
+++ b/packages/client/src/components/basic/Message/Message.tsx
@@ -1,7 +1,8 @@
-import React, { useEffect, useState } from "react";
+import React, { useMemo } from "react";
 
 import { WarningTypeEnums } from "@inkvisitor/shared/enums";
 import { IEntity, IWarning } from "@inkvisitor/shared/types";
+import { useQuery } from "@tanstack/react-query";
 import { WarningIcon } from "./WarningIcon";
 import api from "api";
 import { EntityTag } from "components/advanced";
@@ -34,69 +35,49 @@ export const Message: React.FC<Message> = ({ warning, entities }) => {
     pa: "Pseudo-Actant",
   };
 
-  const [extendedEntities, setExtendedEntities] = useState<
-    Record<string, IEntity>
-  >(entities ?? {});
-
   const originId = warning.origin;
-  const originEntity = entities?.[originId];
 
-  useEffect((): void => {
-    const entitiesOut = [];
-    const newEntityIds: string[] = [];
-
-    async function getEntities(eids: string[]) {
-      const extractedEntities: Record<string, IEntity> = { ...entities };
-      const entitiesRes = await api.entitiesGet(eids).catch(() => undefined);
-      entitiesRes?.data?.forEach((fetchedEntity) => {
-        if (!entities?.[fetchedEntity.id]) {
-          extractedEntities[fetchedEntity.id] = fetchedEntity;
-        }
-      });
-      setExtendedEntities(extractedEntities);
-    }
-
-    const isInEntities = (eid: string) => {
-      return entities && entities[eid] ? true : false;
+  // Warning-referenced ids not already present in the provided entities map.
+  const missingEntityIds = useMemo(() => {
+    const ids = new Set<string>();
+    const addMissing = (eid?: string) => {
+      if (eid && !entities?.[eid]) {
+        ids.add(eid);
+      }
     };
-
-    warning?.validation?.propType?.forEach((eid) => {
-      if (eid && !isInEntities(eid)) {
-        newEntityIds.push(eid);
-      }
+    warning.validation?.propType?.forEach(addMissing);
+    warning.validation?.allowedEntities?.forEach(addMissing);
+    warning.details?.forEach((detail) => {
+      addMissing(detail.entityId);
+      detail.relatedEntityIds?.forEach(addMissing);
     });
-
-    warning?.validation?.allowedEntities?.forEach((eid) => {
-      if (eid && !isInEntities(eid)) {
-        newEntityIds.push(eid);
-      }
-    });
-
-    warning?.details?.forEach((detail) => {
-      [detail.entityId, ...(detail.relatedEntityIds ?? [])].forEach((eid) => {
-        if (eid && !isInEntities(eid) && !newEntityIds.includes(eid)) {
-          newEntityIds.push(eid);
-        }
-      });
-    });
-
-    if (newEntityIds.length > 0) {
-      getEntities(newEntityIds);
-    }
+    return [...ids];
   }, [warning, entities]);
 
-  const [entity, setEntity] = useState<IEntity | undefined>(undefined);
+  // Single batched fallback for ids missing from the provided map. The shared
+  // cache key lets multiple warnings referencing the same entities dedupe.
+  const { data: fetchedEntities } = useQuery({
+    queryKey: ["message-warning-entities", missingEntityIds],
+    queryFn: async () => {
+      const res = await api.entitiesGet(missingEntityIds);
+      return res.data ?? [];
+    },
+    enabled: missingEntityIds.length > 0 && api.isLoggedIn(),
+  });
 
-  useEffect(() => {
-    if (warning.position?.entityId && entities) {
-      const entity = entities[warning.position.entityId];
-      if (entity) {
-        setEntity(entity);
-      } else {
-        setEntity(undefined);
-      }
-    }
-  }, [warning, entities]);
+  // Provided entities plus any fetched fallbacks.
+  const extendedEntities = useMemo(() => {
+    const map: Record<string, IEntity> = { ...entities };
+    fetchedEntities?.forEach((fetchedEntity) => {
+      map[fetchedEntity.id] = fetchedEntity;
+    });
+    return map;
+  }, [entities, fetchedEntities]);
+
+  const originEntity = extendedEntities[originId];
+  const entity = warning.position?.entityId
+    ? extendedEntities[warning.position.entityId]
+    : undefined;
 
   function renderEntityTags(
     entityIds: (string | undefined)[]

--- a/packages/client/src/components/basic/Message/Message.tsx
+++ b/packages/client/src/components/basic/Message/Message.tsx
@@ -47,12 +47,12 @@ export const Message: React.FC<Message> = ({ warning, entities }) => {
 
     async function getEntities(eids: string[]) {
       const extractedEntities: Record<string, IEntity> = { ...entities };
-      for (const eid of eids) {
-        const entityRes = await api.entityGet(eid).catch(() => undefined);
-        if (entityRes?.data && !entities?.[eid]) {
-          extractedEntities[eid] = entityRes.data;
+      const entitiesRes = await api.entitiesGet(eids).catch(() => undefined);
+      entitiesRes?.data?.forEach((fetchedEntity) => {
+        if (!entities?.[fetchedEntity.id]) {
+          extractedEntities[fetchedEntity.id] = fetchedEntity;
         }
-      }
+      });
       setExtendedEntities(extractedEntities);
     }
 

--- a/packages/client/src/components/basic/Message/WarningIconStyles.tsx
+++ b/packages/client/src/components/basic/Message/WarningIconStyles.tsx
@@ -4,8 +4,8 @@ export const StyledWarningIcon = styled.div`
   display: inline-flex;
   align-items: center;
   gap: 0.15rem;
-  padding: 0.1rem 0.35rem;
-  border-radius: ${({ theme }) => theme.borderRadius["sm"]};
+  padding: 0.1rem 0.45rem;
+  border-radius: ${({ theme }) => theme.borderRadius.default};
   color: ${({ theme }) => theme.color["warningText"]};
   /* very light tint of the warning color to group icon + code together */
   background-color: ${({ theme }) => theme.color["warningText"]}14;

--- a/packages/client/src/components/basic/Modal/ModalStyles.tsx
+++ b/packages/client/src/components/basic/Modal/ModalStyles.tsx
@@ -153,15 +153,16 @@ interface StyledModalInputForm {
 export const StyledModalInputForm = styled.div<StyledModalInputForm>`
   display: grid;
   grid-template-columns: ${({ $alignLeft }) => ($alignLeft ? "auto 1fr" : "auto auto")};
-  grid-row-gap: ${({ theme }) => theme.space[1]};
+  grid-row-gap: 0.5rem;
+  grid-column-gap: 0.5rem;
   width: 100%;
 `;
 export const StyledModalInputLabel = styled.p`
   display: grid;
   justify-content: flex-end;
   align-items: center;
-  margin-right: ${({ theme }) => theme.space[4]};
   white-space: nowrap;
+  font-size: 1.3rem;
 `;
 interface StyledModalInputWrap {
   width?: number;
@@ -170,7 +171,6 @@ export const StyledModalInputWrap = styled.div<StyledModalInputWrap>`
   width: ${({ width }) => (width ? `${width / 10}rem` : "auto")};
   display: grid;
   position: relative;
-  margin-bottom: ${({ theme }) => theme.space[1]};
 `;
 
 export const StyledCloseIconWrap = styled.span`

--- a/packages/client/src/components/basic/Modal/ModalStyles.tsx
+++ b/packages/client/src/components/basic/Modal/ModalStyles.tsx
@@ -88,8 +88,9 @@ export const StyledCardHeader = styled.header<StyledCardHeader>`
 export const StyledCardIcon = styled.div<{ $color?: keyof ThemeColor }>`
   display: flex;
   flex-shrink: 0;
-  font-size: 1.7rem;
+  font-size: 1.8rem;
   margin-right: 0.2rem;
+  margin-bottom: 0.1rem;
   color: ${({ theme, $color }) => ($color ? theme.color[$color] : "inherit")};
 `;
 interface StyledCardTitle {

--- a/packages/client/src/components/basic/MultiInput/MultiInput.tsx
+++ b/packages/client/src/components/basic/MultiInput/MultiInput.tsx
@@ -1,6 +1,7 @@
 import { Button, Input } from "components";
 import React, { useEffect, useState } from "react";
-import { FaPlus, FaTrashAlt } from "react-icons/fa";
+import { FaPlus } from "react-icons/fa";
+import { IcoTrash } from "Theme/icons";
 import { ButtonSize } from "types";
 import { StyledDeleteButton, StyledRow } from "./MultiInputStyles";
 
@@ -66,7 +67,7 @@ export const MultiInput: React.FC<MultiInput> = ({ values, onChange, width, disa
                   noBorder
                   noBackground
                   size={ButtonSize.Small}
-                  icon={<FaTrashAlt />}
+                  icon={<IcoTrash />}
                   tooltipLabel="delete note"
                   onClick={() => handleDelete(key)}
                 />

--- a/packages/client/src/components/basic/Submit/Submit.tsx
+++ b/packages/client/src/components/basic/Submit/Submit.tsx
@@ -1,12 +1,5 @@
 import { IEntity } from "@inkvisitor/shared/types";
-import {
-  Button,
-  ButtonGroup,
-  Modal,
-  ModalContent,
-  ModalFooter,
-  ModalHeader,
-} from "components";
+import { Button, ButtonGroup, Modal, ModalContent, ModalFooter, ModalHeader } from "components";
 import { EntityTag } from "components/advanced";
 import React from "react";
 
@@ -19,6 +12,7 @@ interface Submit {
   onCancel: () => void;
   loading?: boolean;
   submitLabel?: string;
+  headerIcon?: React.ReactNode;
 }
 export const Submit: React.FC<Submit> = ({
   title,
@@ -29,6 +23,7 @@ export const Submit: React.FC<Submit> = ({
   onCancel,
   loading = false,
   submitLabel = "Submit",
+  headerIcon,
 }) => {
   return (
     <>
@@ -40,17 +35,11 @@ export const Submit: React.FC<Submit> = ({
         isLoading={loading}
         width="auto"
       >
-        <ModalHeader title={title} />
+        <ModalHeader title={title} icon={headerIcon} />
         <ModalContent>
           <div>
             {text}{" "}
-            {entityToSubmit && (
-              <EntityTag
-                entity={entityToSubmit}
-                disableDoubleClick
-                disableDrag
-              />
-            )}
+            {entityToSubmit && <EntityTag entity={entityToSubmit} disableDoubleClick disableDrag />}
           </div>
         </ModalContent>
         <ModalFooter>

--- a/packages/client/src/components/basic/Suggester/Suggester.tsx
+++ b/packages/client/src/components/basic/Suggester/Suggester.tsx
@@ -55,7 +55,6 @@ interface Suggester {
   onDrop: (item: EntityDragItem, instantiateTemplate?: boolean) => void;
   onHover: (item: EntityDragItem) => void;
   onCancel: () => void;
-  onFocus?: () => void;
   cleanOnSelect?: boolean;
   isWrongDropCategory?: boolean;
   isInsideTemplate: boolean;
@@ -101,7 +100,6 @@ export const Suggester: React.FC<Suggester> = ({
   onDrop,
   onHover,
   onCancel,
-  onFocus,
   isFetching,
   isWrongDropCategory,
   isInsideTemplate = false,
@@ -363,7 +361,6 @@ export const Suggester: React.FC<Suggester> = ({
             onFocus={() => {
               setSelected(-1);
               setIsFocused(true);
-              onFocus?.();
             }}
             onBlur={() => setIsFocused(false)}
             disableTyping
@@ -393,7 +390,6 @@ export const Suggester: React.FC<Suggester> = ({
               roundCorners={false}
               onFocus={() => {
                 setIsFocused(true);
-                onFocus?.();
               }}
               onBlur={() => {
                 // Comment this for debug

--- a/packages/client/src/components/basic/Suggester/Suggester.tsx
+++ b/packages/client/src/components/basic/Suggester/Suggester.tsx
@@ -55,6 +55,7 @@ interface Suggester {
   onDrop: (item: EntityDragItem, instantiateTemplate?: boolean) => void;
   onHover: (item: EntityDragItem) => void;
   onCancel: () => void;
+  onFocus?: () => void;
   cleanOnSelect?: boolean;
   isWrongDropCategory?: boolean;
   isInsideTemplate: boolean;
@@ -100,6 +101,7 @@ export const Suggester: React.FC<Suggester> = ({
   onDrop,
   onHover,
   onCancel,
+  onFocus,
   isFetching,
   isWrongDropCategory,
   isInsideTemplate = false,
@@ -281,11 +283,6 @@ export const Suggester: React.FC<Suggester> = ({
 
     return (
       <List<SuggestionRowEntityItemData>
-        // height={
-        //   suggestions.length > 7
-        //     ? rowHeight * 8
-        //     : rowHeight * suggestions.length
-        // }
         rowProps={{ items: suggestions }}
         rowCount={suggestions.length}
         rowHeight={rowHeight}
@@ -366,6 +363,7 @@ export const Suggester: React.FC<Suggester> = ({
             onFocus={() => {
               setSelected(-1);
               setIsFocused(true);
+              onFocus?.();
             }}
             onBlur={() => setIsFocused(false)}
             disableTyping
@@ -395,6 +393,7 @@ export const Suggester: React.FC<Suggester> = ({
               roundCorners={false}
               onFocus={() => {
                 setIsFocused(true);
+                onFocus?.();
               }}
               onBlur={() => {
                 // Comment this for debug

--- a/packages/client/src/components/basic/Tooltip/Tooltip.tsx
+++ b/packages/client/src/components/basic/Tooltip/Tooltip.tsx
@@ -28,6 +28,7 @@ interface Tooltip {
   // style
   color?: keyof ThemeColor;
   position?: AutoPlacement | BasePlacement | VariationPlacement;
+  fallbackPlacements?: (AutoPlacement | BasePlacement | VariationPlacement)[];
   noArrow?: boolean;
   offsetX?: number;
   offsetY?: number;
@@ -47,6 +48,7 @@ export const Tooltip: React.FC<Tooltip> = ({
   // style
   color = "tooltipBackground",
   position = "bottom",
+  fallbackPlacements = ["auto"],
   noArrow = false,
   offsetX = 0,
   offsetY = 7,
@@ -76,7 +78,7 @@ export const Tooltip: React.FC<Tooltip> = ({
           name: "flip",
           enabled: !disableAutoPosition,
           options: {
-            fallbackPlacements: ["auto"],
+            fallbackPlacements: fallbackPlacements,
           },
         },
       ],

--- a/packages/client/src/hooks/index.tsx
+++ b/packages/client/src/hooks/index.tsx
@@ -1,6 +1,7 @@
 import { useContainerDimensions } from "./useContainerDimensions";
 import useDebounce from "./useDebounce";
 import useDebouncedCallback from "./useDebouncedCallback";
+import { useIsInViewport } from "./useIsInViewport";
 import useKeyLift from "./useKeyLift";
 import useKeyPress from "./useKeyPress";
 import { useResizeObserver } from "./useResizeObserver";
@@ -14,6 +15,7 @@ export {
   useKeyPress,
   useKeyLift,
   useContainerDimensions,
+  useIsInViewport,
   useSearchParams,
   useDebouncedCallback,
   useResizeObserver,

--- a/packages/client/src/hooks/react-query/index.tsx
+++ b/packages/client/src/hooks/react-query/index.tsx
@@ -1,3 +1,5 @@
+import { useDocumentsQuery } from "./useDocumentsQuery";
+import { useResourcesWithDocumentsQuery } from "./useResourcesWithDocumentsQuery";
 import { useTemplatesQuery } from "./useTemplatesQuery";
 import { useTreeQuery } from "./useTreeQuery";
 import { useUserQuery } from "./useUserQuery";
@@ -5,6 +7,8 @@ import { useUsersGetMoreQuery } from "./useUsersGetMoreQuery";
 import { useUsersSimplifiedQuery } from "./useUsersSimplifiedQuery";
 
 export {
+  useDocumentsQuery,
+  useResourcesWithDocumentsQuery,
   useTemplatesQuery,
   useTreeQuery,
   useUserQuery,

--- a/packages/client/src/hooks/react-query/index.tsx
+++ b/packages/client/src/hooks/react-query/index.tsx
@@ -1,5 +1,7 @@
+import { useDocumentQuery } from "./useDocumentQuery";
 import { useDocumentsQuery } from "./useDocumentsQuery";
 import { useResourcesWithDocumentsQuery } from "./useResourcesWithDocumentsQuery";
+import { useStatementQuery } from "./useStatementQuery";
 import { useTemplatesQuery } from "./useTemplatesQuery";
 import { useTreeQuery } from "./useTreeQuery";
 import { useUserQuery } from "./useUserQuery";
@@ -7,8 +9,10 @@ import { useUsersGetMoreQuery } from "./useUsersGetMoreQuery";
 import { useUsersSimplifiedQuery } from "./useUsersSimplifiedQuery";
 
 export {
+  useDocumentQuery,
   useDocumentsQuery,
   useResourcesWithDocumentsQuery,
+  useStatementQuery,
   useTemplatesQuery,
   useTreeQuery,
   useUserQuery,

--- a/packages/client/src/hooks/react-query/index.tsx
+++ b/packages/client/src/hooks/react-query/index.tsx
@@ -1,3 +1,4 @@
+import { useAuditQuery } from "./useAuditQuery";
 import { useBookmarksQuery } from "./useBookmarksQuery";
 import { useDetailQuery } from "./useDetailQuery";
 import { useDocumentQuery } from "./useDocumentQuery";
@@ -11,6 +12,7 @@ import { useUsersGetMoreQuery } from "./useUsersGetMoreQuery";
 import { useUsersSimplifiedQuery } from "./useUsersSimplifiedQuery";
 
 export {
+  useAuditQuery,
   useBookmarksQuery,
   useDetailQuery,
   useDocumentQuery,

--- a/packages/client/src/hooks/react-query/index.tsx
+++ b/packages/client/src/hooks/react-query/index.tsx
@@ -1,6 +1,13 @@
+import { useTemplatesQuery } from "./useTemplatesQuery";
 import { useTreeQuery } from "./useTreeQuery";
 import { useUserQuery } from "./useUserQuery";
 import { useUsersGetMoreQuery } from "./useUsersGetMoreQuery";
 import { useUsersSimplifiedQuery } from "./useUsersSimplifiedQuery";
 
-export { useTreeQuery, useUserQuery, useUsersGetMoreQuery, useUsersSimplifiedQuery };
+export {
+  useTemplatesQuery,
+  useTreeQuery,
+  useUserQuery,
+  useUsersGetMoreQuery,
+  useUsersSimplifiedQuery,
+};

--- a/packages/client/src/hooks/react-query/index.tsx
+++ b/packages/client/src/hooks/react-query/index.tsx
@@ -1,3 +1,5 @@
+import { useBookmarksQuery } from "./useBookmarksQuery";
+import { useDetailQuery } from "./useDetailQuery";
 import { useDocumentQuery } from "./useDocumentQuery";
 import { useDocumentsQuery } from "./useDocumentsQuery";
 import { useResourcesWithDocumentsQuery } from "./useResourcesWithDocumentsQuery";
@@ -9,6 +11,8 @@ import { useUsersGetMoreQuery } from "./useUsersGetMoreQuery";
 import { useUsersSimplifiedQuery } from "./useUsersSimplifiedQuery";
 
 export {
+  useBookmarksQuery,
+  useDetailQuery,
   useDocumentQuery,
   useDocumentsQuery,
   useResourcesWithDocumentsQuery,

--- a/packages/client/src/hooks/react-query/useAuditQuery.tsx
+++ b/packages/client/src/hooks/react-query/useAuditQuery.tsx
@@ -1,0 +1,14 @@
+import { useQuery } from "@tanstack/react-query";
+import api from "api";
+
+export function useAuditQuery(entityId: string, enabled = true) {
+  return useQuery({
+    queryKey: ["audit", entityId],
+    queryFn: async () => {
+      const res = await api.auditGet(entityId);
+      return res.data;
+    },
+    enabled: !!entityId && api.isLoggedIn() && enabled,
+    staleTime: 5 * 60 * 1000,
+  });
+}

--- a/packages/client/src/hooks/react-query/useBookmarksQuery.tsx
+++ b/packages/client/src/hooks/react-query/useBookmarksQuery.tsx
@@ -11,5 +11,9 @@ export function useBookmarksQuery(enabled = true) {
       return data;
     },
     enabled: api.isLoggedIn() && enabled,
+    // no need to fetch from other users, could be even infinity
+    // (this stale time only counts on having app opened in two browsers
+    // or switching to different computer without app reload)
+    staleTime: 60 * 60 * 1000,
   });
 }

--- a/packages/client/src/hooks/react-query/useBookmarksQuery.tsx
+++ b/packages/client/src/hooks/react-query/useBookmarksQuery.tsx
@@ -1,0 +1,15 @@
+import { useQuery } from "@tanstack/react-query";
+import api from "api";
+
+export function useBookmarksQuery(enabled = true) {
+  return useQuery({
+    queryKey: ["bookmarks"],
+    queryFn: async () => {
+      const res = await api.bookmarksGet("me");
+      const data = res.data ?? [];
+      data.sort((a, b) => (a.name > b.name ? 1 : -1));
+      return data;
+    },
+    enabled: api.isLoggedIn() && enabled,
+  });
+}

--- a/packages/client/src/hooks/react-query/useBookmarksQuery.tsx
+++ b/packages/client/src/hooks/react-query/useBookmarksQuery.tsx
@@ -14,6 +14,7 @@ export function useBookmarksQuery(enabled = true) {
     // no need to fetch from other users, could be even infinity
     // (this stale time only counts on having app opened in two browsers
     // or switching to different computer without app reload)
-    staleTime: 60 * 60 * 1000,
+    staleTime: 30 * 60 * 1000,
+    refetchOnWindowFocus: true,
   });
 }

--- a/packages/client/src/hooks/react-query/useDetailQuery.tsx
+++ b/packages/client/src/hooks/react-query/useDetailQuery.tsx
@@ -9,6 +9,6 @@ export function useDetailQuery(entityId: string) {
       return res.data;
     },
     enabled: !!entityId && api.isLoggedIn(),
-    staleTime: 1.5 * 60 * 1000,
+    staleTime: 1 * 60 * 1000,
   });
 }

--- a/packages/client/src/hooks/react-query/useDetailQuery.tsx
+++ b/packages/client/src/hooks/react-query/useDetailQuery.tsx
@@ -9,5 +9,6 @@ export function useDetailQuery(entityId: string) {
       return res.data;
     },
     enabled: !!entityId && api.isLoggedIn(),
+    staleTime: 2 * 60 * 1000,
   });
 }

--- a/packages/client/src/hooks/react-query/useDetailQuery.tsx
+++ b/packages/client/src/hooks/react-query/useDetailQuery.tsx
@@ -9,6 +9,6 @@ export function useDetailQuery(entityId: string) {
       return res.data;
     },
     enabled: !!entityId && api.isLoggedIn(),
-    staleTime: 2 * 60 * 1000,
+    staleTime: 1.5 * 60 * 1000,
   });
 }

--- a/packages/client/src/hooks/react-query/useDetailQuery.tsx
+++ b/packages/client/src/hooks/react-query/useDetailQuery.tsx
@@ -1,0 +1,13 @@
+import { useQuery } from "@tanstack/react-query";
+import api from "api";
+
+export function useDetailQuery(entityId: string) {
+  return useQuery({
+    queryKey: ["entity", entityId],
+    queryFn: async () => {
+      const res = await api.detailGet(entityId);
+      return res.data;
+    },
+    enabled: !!entityId && api.isLoggedIn(),
+  });
+}

--- a/packages/client/src/hooks/react-query/useDetailQuery.tsx
+++ b/packages/client/src/hooks/react-query/useDetailQuery.tsx
@@ -9,6 +9,5 @@ export function useDetailQuery(entityId: string) {
       return res.data;
     },
     enabled: !!entityId && api.isLoggedIn(),
-    staleTime: 1 * 60 * 1000,
   });
 }

--- a/packages/client/src/hooks/react-query/useDocumentQuery.tsx
+++ b/packages/client/src/hooks/react-query/useDocumentQuery.tsx
@@ -12,5 +12,6 @@ export function useDocumentQuery(documentId?: string) {
       return res.data ?? undefined;
     },
     enabled: !!documentId && api.isLoggedIn(),
+    refetchOnWindowFocus: true,
   });
 }

--- a/packages/client/src/hooks/react-query/useDocumentQuery.tsx
+++ b/packages/client/src/hooks/react-query/useDocumentQuery.tsx
@@ -1,0 +1,16 @@
+import { useQuery } from "@tanstack/react-query";
+import api from "api";
+
+export function useDocumentQuery(documentId?: string) {
+  return useQuery({
+    queryKey: ["document", documentId],
+    queryFn: async () => {
+      if (!documentId) {
+        return undefined;
+      }
+      const res = await api.documentGet(documentId);
+      return res.data ?? undefined;
+    },
+    enabled: !!documentId && api.isLoggedIn(),
+  });
+}

--- a/packages/client/src/hooks/react-query/useDocumentsQuery.tsx
+++ b/packages/client/src/hooks/react-query/useDocumentsQuery.tsx
@@ -1,0 +1,14 @@
+import { IDocument } from "@inkvisitor/shared/types";
+import { useQuery } from "@tanstack/react-query";
+import api from "api";
+
+export function useDocumentsQuery(enabled = true) {
+  return useQuery({
+    queryKey: ["documents"],
+    queryFn: async () => {
+      const res = await api.documentsGet({});
+      return (res.data ?? []) as IDocument[];
+    },
+    enabled: api.isLoggedIn() && enabled,
+  });
+}

--- a/packages/client/src/hooks/react-query/useDocumentsQuery.tsx
+++ b/packages/client/src/hooks/react-query/useDocumentsQuery.tsx
@@ -2,10 +2,7 @@ import { IDocument } from "@inkvisitor/shared/types";
 import { useQuery } from "@tanstack/react-query";
 import api from "api";
 
-export function useDocumentsQuery(
-  enabled = true,
-  refetchOnMount: boolean | "always" = true,
-) {
+export function useDocumentsQuery(enabled = true, refetchOnMount: boolean | "always" = true) {
   return useQuery({
     queryKey: ["documents"],
     queryFn: async () => {
@@ -13,6 +10,8 @@ export function useDocumentsQuery(
       return (res.data ?? []) as IDocument[];
     },
     enabled: api.isLoggedIn() && enabled,
+    // stale time is 5 minutes because documents are refetched on Documents page load
+    // and click on the document dropdown in Resource detail
     staleTime: 5 * 60 * 1000,
     refetchOnMount,
   });

--- a/packages/client/src/hooks/react-query/useDocumentsQuery.tsx
+++ b/packages/client/src/hooks/react-query/useDocumentsQuery.tsx
@@ -2,7 +2,10 @@ import { IDocument } from "@inkvisitor/shared/types";
 import { useQuery } from "@tanstack/react-query";
 import api from "api";
 
-export function useDocumentsQuery(enabled = true) {
+export function useDocumentsQuery(
+  enabled = true,
+  refetchOnMount: boolean | "always" = true,
+) {
   return useQuery({
     queryKey: ["documents"],
     queryFn: async () => {
@@ -10,5 +13,7 @@ export function useDocumentsQuery(enabled = true) {
       return (res.data ?? []) as IDocument[];
     },
     enabled: api.isLoggedIn() && enabled,
+    staleTime: 5 * 60 * 1000,
+    refetchOnMount,
   });
 }

--- a/packages/client/src/hooks/react-query/useResourcesWithDocumentsQuery.tsx
+++ b/packages/client/src/hooks/react-query/useResourcesWithDocumentsQuery.tsx
@@ -2,7 +2,10 @@ import { IResponseEntity } from "@inkvisitor/shared/types";
 import { useQuery } from "@tanstack/react-query";
 import api from "api";
 
-export function useResourcesWithDocumentsQuery(enabled = true) {
+export function useResourcesWithDocumentsQuery(
+  enabled = true,
+  refetchOnMount: boolean | "always" = true,
+) {
   return useQuery({
     queryKey: ["resourcesWithDocuments"],
     queryFn: async () => {
@@ -10,5 +13,7 @@ export function useResourcesWithDocumentsQuery(enabled = true) {
       return (res.data ?? []) as IResponseEntity[];
     },
     enabled: api.isLoggedIn() && enabled,
+    staleTime: 5 * 60 * 1000,
+    refetchOnMount,
   });
 }

--- a/packages/client/src/hooks/react-query/useResourcesWithDocumentsQuery.tsx
+++ b/packages/client/src/hooks/react-query/useResourcesWithDocumentsQuery.tsx
@@ -1,0 +1,14 @@
+import { IResponseEntity } from "@inkvisitor/shared/types";
+import { useQuery } from "@tanstack/react-query";
+import api from "api";
+
+export function useResourcesWithDocumentsQuery(enabled = true) {
+  return useQuery({
+    queryKey: ["resourcesWithDocuments"],
+    queryFn: async () => {
+      const res = await api.entitiesSearch({ resourceHasDocument: true });
+      return (res.data ?? []) as IResponseEntity[];
+    },
+    enabled: api.isLoggedIn() && enabled,
+  });
+}

--- a/packages/client/src/hooks/react-query/useResourcesWithDocumentsQuery.tsx
+++ b/packages/client/src/hooks/react-query/useResourcesWithDocumentsQuery.tsx
@@ -13,6 +13,8 @@ export function useResourcesWithDocumentsQuery(
       return (res.data ?? []) as IResponseEntity[];
     },
     enabled: api.isLoggedIn() && enabled,
+    // stale time is 5 minutes because Rs with Documents are refetched on Documents page load
+    // and click on the resource dropdown in Annotator header
     staleTime: 5 * 60 * 1000,
     refetchOnMount,
   });

--- a/packages/client/src/hooks/react-query/useStatementQuery.tsx
+++ b/packages/client/src/hooks/react-query/useStatementQuery.tsx
@@ -9,6 +9,6 @@ export function useStatementQuery(statementId: string) {
       return res.data;
     },
     enabled: !!statementId && api.isLoggedIn(),
-    staleTime: 2 * 60 * 1000,
+    staleTime: 1.5 * 60 * 1000,
   });
 }

--- a/packages/client/src/hooks/react-query/useStatementQuery.tsx
+++ b/packages/client/src/hooks/react-query/useStatementQuery.tsx
@@ -9,6 +9,5 @@ export function useStatementQuery(statementId: string) {
       return res.data;
     },
     enabled: !!statementId && api.isLoggedIn(),
-    staleTime: 1 * 60 * 1000,
   });
 }

--- a/packages/client/src/hooks/react-query/useStatementQuery.tsx
+++ b/packages/client/src/hooks/react-query/useStatementQuery.tsx
@@ -1,0 +1,13 @@
+import { useQuery } from "@tanstack/react-query";
+import api from "api";
+
+export function useStatementQuery(statementId: string) {
+  return useQuery({
+    queryKey: ["statement", statementId],
+    queryFn: async () => {
+      const res = await api.statementGet(statementId);
+      return res.data;
+    },
+    enabled: !!statementId && api.isLoggedIn(),
+  });
+}

--- a/packages/client/src/hooks/react-query/useStatementQuery.tsx
+++ b/packages/client/src/hooks/react-query/useStatementQuery.tsx
@@ -9,6 +9,6 @@ export function useStatementQuery(statementId: string) {
       return res.data;
     },
     enabled: !!statementId && api.isLoggedIn(),
-    staleTime: 1.5 * 60 * 1000,
+    staleTime: 1 * 60 * 1000,
   });
 }

--- a/packages/client/src/hooks/react-query/useStatementQuery.tsx
+++ b/packages/client/src/hooks/react-query/useStatementQuery.tsx
@@ -9,5 +9,6 @@ export function useStatementQuery(statementId: string) {
       return res.data;
     },
     enabled: !!statementId && api.isLoggedIn(),
+    staleTime: 2 * 60 * 1000,
   });
 }

--- a/packages/client/src/hooks/react-query/useTemplatesQuery.tsx
+++ b/packages/client/src/hooks/react-query/useTemplatesQuery.tsx
@@ -2,20 +2,18 @@ import { IEntity } from "@inkvisitor/shared/types";
 import { useQuery } from "@tanstack/react-query";
 import api from "api";
 
-export function useTemplatesQuery() {
+export function useTemplatesQuery(enabled = true) {
   return useQuery({
     queryKey: ["templates"],
     queryFn: async () => {
       const res = await api.entitiesSearch({ onlyTemplates: true });
       const templates: IEntity[] = res.data ?? [];
       templates.sort((a: IEntity, b: IEntity) =>
-        a.labels[0].toLocaleLowerCase() > b.labels[0].toLocaleLowerCase()
-          ? 1
-          : -1
+        a.labels[0].toLocaleLowerCase() > b.labels[0].toLocaleLowerCase() ? 1 : -1,
       );
       return templates;
     },
-    enabled: api.isLoggedIn(),
+    enabled: api.isLoggedIn() && enabled,
     staleTime: 5 * 60 * 1000,
   });
 }

--- a/packages/client/src/hooks/react-query/useTemplatesQuery.tsx
+++ b/packages/client/src/hooks/react-query/useTemplatesQuery.tsx
@@ -1,0 +1,21 @@
+import { IEntity } from "@inkvisitor/shared/types";
+import { useQuery } from "@tanstack/react-query";
+import api from "api";
+
+export function useTemplatesQuery() {
+  return useQuery({
+    queryKey: ["templates"],
+    queryFn: async () => {
+      const res = await api.entitiesSearch({ onlyTemplates: true });
+      const templates: IEntity[] = res.data ?? [];
+      templates.sort((a: IEntity, b: IEntity) =>
+        a.labels[0].toLocaleLowerCase() > b.labels[0].toLocaleLowerCase()
+          ? 1
+          : -1
+      );
+      return templates;
+    },
+    enabled: api.isLoggedIn(),
+    staleTime: 5 * 60 * 1000,
+  });
+}

--- a/packages/client/src/hooks/react-query/useTemplatesQuery.tsx
+++ b/packages/client/src/hooks/react-query/useTemplatesQuery.tsx
@@ -14,6 +14,8 @@ export function useTemplatesQuery(enabled = true) {
       return templates;
     },
     enabled: api.isLoggedIn() && enabled,
-    staleTime: 5 * 60 * 1000,
+    // templaptes are refetched on apply template dropdown click
+    // (has also refresh button when yet empty)
+    staleTime: 2 * 60 * 1000,
   });
 }

--- a/packages/client/src/hooks/useIsInViewport.tsx
+++ b/packages/client/src/hooks/useIsInViewport.tsx
@@ -1,0 +1,31 @@
+import { RefObject, useEffect, useState } from "react";
+
+/**
+ * Tracks whether the referenced element is intersecting the viewport.
+ * `rootMargin` is a primitive so the effect deps stay stable across renders;
+ * pass a positive margin (e.g. "200px") to start loading just before the
+ * element scrolls into view.
+ */
+export function useIsInViewport(
+  ref: RefObject<HTMLElement | null>,
+  rootMargin = "0px"
+) {
+  const [isInViewport, setIsInViewport] = useState(false);
+
+  useEffect(() => {
+    const element = ref.current;
+    if (!element) {
+      return;
+    }
+    const observer = new IntersectionObserver(
+      ([entry]) => setIsInViewport(entry.isIntersecting),
+      { rootMargin }
+    );
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, [ref, rootMargin]);
+
+  return isInViewport;
+}
+
+export default useIsInViewport;

--- a/packages/client/src/hooks/useIsInViewport.tsx
+++ b/packages/client/src/hooks/useIsInViewport.tsx
@@ -1,31 +1,39 @@
-import { RefObject, useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 /**
  * Tracks whether the referenced element is intersecting the viewport.
+ *
+ * Returns a callback ref that re-attaches the observer whenever the node mounts
+ * or unmounts, so it also works for elements that are conditionally rendered.
+ *
  * `rootMargin` is a primitive so the effect deps stay stable across renders;
  * pass a positive margin (e.g. "200px") to start loading just before the
  * element scrolls into view.
+ *
+ * Usage: `const [ref, isInViewport] = useIsInViewport("200px");` then
+ * `<div ref={ref} />`.
  */
-export function useIsInViewport(
-  ref: RefObject<HTMLElement | null>,
-  rootMargin = "0px"
-) {
+export function useIsInViewport(rootMargin = "0px") {
   const [isInViewport, setIsInViewport] = useState(false);
+  const [node, setNode] = useState<HTMLElement | null>(null);
+
+  const ref = useCallback((element: HTMLElement | null) => {
+    setNode(element);
+  }, []);
 
   useEffect(() => {
-    const element = ref.current;
-    if (!element) {
+    if (!node) {
       return;
     }
     const observer = new IntersectionObserver(
       ([entry]) => setIsInViewport(entry.isIntersecting),
       { rootMargin }
     );
-    observer.observe(element);
+    observer.observe(node);
     return () => observer.disconnect();
-  }, [ref, rootMargin]);
+  }, [node, rootMargin]);
 
-  return isInViewport;
+  return [ref, isInViewport] as const;
 }
 
 export default useIsInViewport;

--- a/packages/client/src/pages/Documents/DocumentRow/DocumentRow.tsx
+++ b/packages/client/src/pages/Documents/DocumentRow/DocumentRow.tsx
@@ -7,7 +7,8 @@ import { Button, ButtonGroup, Input } from "components";
 import { EntitySuggester, EntityTag } from "components/advanced";
 import { useResizeObserver, useTheme } from "hooks";
 import React, { Dispatch, SetStateAction, useEffect, useMemo, useState } from "react";
-import { FaDownload, FaTrash } from "react-icons/fa";
+import { FaDownload } from "react-icons/fa";
+import { IcoTrash } from "Theme/icons";
 import { RiFileEditFill } from "react-icons/ri";
 import { EntityColors } from "types";
 import {
@@ -140,7 +141,7 @@ export const DocumentRow: React.FC<DocumentRow> = ({
             tooltipLabel={"open document"}
           />
           <Button
-            icon={<FaTrash />}
+            icon={<IcoTrash />}
             color="danger"
             inverted
             disabled={!canManage}

--- a/packages/client/src/pages/Documents/DocumentsPage.tsx
+++ b/packages/client/src/pages/Documents/DocumentsPage.tsx
@@ -1,4 +1,4 @@
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { v4 as uuidv4 } from "uuid";
 
 import { EntityEnums, UserEnums } from "@inkvisitor/shared/enums";
@@ -6,7 +6,11 @@ import { IDocument } from "@inkvisitor/shared/types";
 import api from "api";
 import { Loader, Submit } from "components";
 import { DocumentModalEdit, DocumentModalExport } from "components/advanced";
-import { useUserQuery } from "hooks/react-query";
+import {
+  useDocumentsQuery,
+  useResourcesWithDocumentsQuery,
+  useUserQuery,
+} from "hooks/react-query";
 import React, { ChangeEvent, useCallback, useMemo, useRef, useState } from "react";
 import { DocumentRow } from "./DocumentRow/DocumentRow";
 import { DocumentsTableHeader } from "./DocumentsTableHeader";
@@ -49,33 +53,13 @@ export const DocumentsPage: React.FC = ({}) => {
     [isAdminOrOwner, userData, assignedResourceIds]
   );
 
-  const {
-    data: documents,
-    error,
-    isFetching,
-  } = useQuery({
-    queryKey: ["documents"],
-    queryFn: async () => {
-      const res = await api.documentsGet({});
-      return res.data ?? [];
-    },
-    enabled: api.isLoggedIn(),
-  });
+  const { data: documents, error, isFetching } = useDocumentsQuery();
 
   const {
     data: resources,
     error: resourcesError,
     isFetching: resourcesIsFetching,
-  } = useQuery({
-    queryKey: ["resourcesWithDocuments"],
-    queryFn: async () => {
-      const res = await api.entitiesSearch({
-        resourceHasDocument: true,
-      });
-      return res.data ?? [];
-    },
-    enabled: api.isLoggedIn(),
-  });
+  } = useResourcesWithDocumentsQuery();
 
   const documentsWithResources: DocumentWithResource[] = useMemo(() => {
     return documents

--- a/packages/client/src/pages/Documents/DocumentsPage.tsx
+++ b/packages/client/src/pages/Documents/DocumentsPage.tsx
@@ -53,13 +53,15 @@ export const DocumentsPage: React.FC = ({}) => {
     [isAdminOrOwner, userData, assignedResourceIds]
   );
 
-  const { data: documents, error, isFetching } = useDocumentsQuery();
+  // documents page is the management hub - always refetch on entry so edits
+  // made elsewhere (or by other users) show up regardless of staleTime
+  const { data: documents, error, isFetching } = useDocumentsQuery(true, "always");
 
   const {
     data: resources,
     error: resourcesError,
     isFetching: resourcesIsFetching,
-  } = useResourcesWithDocumentsQuery();
+  } = useResourcesWithDocumentsQuery(true, "always");
 
   const documentsWithResources: DocumentWithResource[] = useMemo(() => {
     return documents

--- a/packages/client/src/pages/Main/MainPage.tsx
+++ b/packages/client/src/pages/Main/MainPage.tsx
@@ -274,11 +274,7 @@ const MainPage: React.FC<MainPage> = ({}) => {
     />
   );
 
-  const reverseThirdPanelIcon =
-    !firstPanelExpanded ||
-    !secondPanelExpanded ||
-    (!thirdPanelExpanded && fourthPanelExpanded) ||
-    (firstPanelExpanded && secondPanelExpanded && thirdPanelExpanded && fourthPanelExpanded);
+  const reverseThirdPanelIcon = !firstPanelExpanded && !secondPanelExpanded && !fourthPanelExpanded;
 
   const thirdPanelButton = () => (
     <IconButton

--- a/packages/client/src/pages/Main/MainPage.tsx
+++ b/packages/client/src/pages/Main/MainPage.tsx
@@ -121,15 +121,18 @@ const MainPage: React.FC<MainPage> = ({}) => {
     }
   }, [statementId]);
 
-  const prevEditorBoxStateRef = useRef(editorBoxState);
+  const prevEditorStateRef = useRef({ editorOpened, editorBoxState });
   useEffect(() => {
-    const wasFullHeight = prevEditorBoxStateRef.current === EditorBoxState.FullHeight;
-    prevEditorBoxStateRef.current = editorBoxState;
+    const prev = prevEditorStateRef.current;
+    prevEditorStateRef.current = { editorOpened, editorBoxState };
 
-    if (wasFullHeight && editorBoxState !== EditorBoxState.FullHeight) {
+    const wasFullSize = prev.editorOpened && prev.editorBoxState === EditorBoxState.FullHeight;
+    const isNowFullSize = editorOpened && editorBoxState === EditorBoxState.FullHeight;
+
+    if (wasFullSize && !isNowFullSize) {
       queryClient.invalidateQueries({ queryKey: ["document"] });
     }
-  }, [editorBoxState, queryClient]);
+  }, [editorOpened, editorBoxState, queryClient]);
 
   useEffect(() => {
     if (thirdPanelExpanded && editorBoxState !== EditorBoxState.FullHeight) {

--- a/packages/client/src/pages/Main/MainPage.tsx
+++ b/packages/client/src/pages/Main/MainPage.tsx
@@ -21,6 +21,7 @@ import { RiMenuFoldFill, RiMenuUnfoldFill } from "react-icons/ri";
 import { VscClose, VscCloseAll } from "react-icons/vsc";
 import { setDetailBoxState } from "redux/features/layout/mainPage/detailBoxStateSlice";
 import { setEditorBoxState } from "redux/features/layout/mainPage/editorBoxStateSlice";
+import { setThirdPanelExpanded } from "redux/features/layout/mainPage/thirdPanelExpandedSlice";
 import { ToggleFourthPanelBoxButton } from "./components/ToggleFourthPanelBoxButton";
 import { RefreshBoxButton } from "./components/RefreshBoxButton";
 import { setPanelWidths } from "redux/features/layout/mainPage/panelWidthsSlice";
@@ -111,9 +112,12 @@ const MainPage: React.FC<MainPage> = ({}) => {
     const isNewStatement = prevStatementIdRef.current !== statementId;
     prevStatementIdRef.current = statementId;
 
-    if (statementId && isNewStatement && (!editorOpened || editorBoxState === EditorBoxState.Minimized)) {
-      setEditorOpened(true);
-      dispatch(setEditorBoxState(EditorBoxState.Normal));
+    if (statementId && isNewStatement) {
+      dispatch(setThirdPanelExpanded(true));
+      if (!editorOpened || editorBoxState === EditorBoxState.Minimized) {
+        setEditorOpened(true);
+        dispatch(setEditorBoxState(EditorBoxState.Normal));
+      }
     }
   }, [statementId]);
 

--- a/packages/client/src/pages/Main/containers/AnnotatorBox/AnnotatorBox.tsx
+++ b/packages/client/src/pages/Main/containers/AnnotatorBox/AnnotatorBox.tsx
@@ -12,6 +12,7 @@ import api from "api";
 import { useSearchParams } from "hooks";
 import useAnnotator from "hooks/useAnnotator";
 import {
+  useDocumentQuery,
   useDocumentsQuery,
   useResourcesWithDocumentsQuery,
   useUserQuery,
@@ -145,17 +146,7 @@ export const AnnotatorBox: React.FC<AnnotatorBox> = ({ height, width }) => {
     data: selectedDocument,
     error: selectedDocumentError,
     isFetching: selectedDocumentIsFetching,
-  } = useQuery({
-    queryKey: ["document", selectedDocumentId],
-    queryFn: async () => {
-      if (selectedDocumentId) {
-        const res = await api.documentGet(selectedDocumentId);
-        return res.data ?? undefined;
-      }
-      return undefined;
-    },
-    enabled: api.isLoggedIn() && !!selectedDocumentId,
-  });
+  } = useDocumentQuery(selectedDocumentId);
 
   const statementCreateMutation = useMutation({
     mutationFn: async (newStatement: IStatement) => await api.entityCreate(newStatement),

--- a/packages/client/src/pages/Main/containers/AnnotatorBox/AnnotatorBox.tsx
+++ b/packages/client/src/pages/Main/containers/AnnotatorBox/AnnotatorBox.tsx
@@ -82,7 +82,8 @@ export const AnnotatorBox: React.FC<AnnotatorBox> = ({ height, width }) => {
     enabled: !!territoryId && api.isLoggedIn(),
   });
 
-  const { data: resources } = useResourcesWithDocumentsQuery();
+  const { data: resources, refetch: refetchResources } =
+    useResourcesWithDocumentsQuery();
 
   const { data: documents } = useDocumentsQuery();
 
@@ -283,6 +284,7 @@ export const AnnotatorBox: React.FC<AnnotatorBox> = ({ height, width }) => {
       selectedDocumentError={selectedDocumentError}
       selectedResource={selectedResource}
       resources={resources}
+      onResourcePickerFocus={() => refetchResources()}
       setSelectedResourceId={(id) => {
         userPickedRef.current = true;
         dispatch(setSelectedResourceId(id));

--- a/packages/client/src/pages/Main/containers/AnnotatorBox/AnnotatorBox.tsx
+++ b/packages/client/src/pages/Main/containers/AnnotatorBox/AnnotatorBox.tsx
@@ -83,10 +83,13 @@ export const AnnotatorBox: React.FC<AnnotatorBox> = ({ height, width }) => {
     enabled: !!territoryId && api.isLoggedIn(),
   });
 
-  const { data: resources, refetch: refetchResources } =
-    useResourcesWithDocumentsQuery();
+  const resourcesEnabled =
+    !!territoryId || (!!selectedTerritoryPath && selectedTerritoryPath.length > 0);
 
-  const { data: documents } = useDocumentsQuery();
+  const { data: resources, refetch: refetchResources } =
+    useResourcesWithDocumentsQuery(resourcesEnabled);
+
+  const { data: documents } = useDocumentsQuery(resourcesEnabled);
 
   // Set once the user manually picks a resource so auto-load stops overriding it.
   const userPickedRef = useRef(false);

--- a/packages/client/src/pages/Main/containers/AnnotatorBox/AnnotatorBox.tsx
+++ b/packages/client/src/pages/Main/containers/AnnotatorBox/AnnotatorBox.tsx
@@ -11,7 +11,11 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import api from "api";
 import { useSearchParams } from "hooks";
 import useAnnotator from "hooks/useAnnotator";
-import { useUserQuery } from "hooks/react-query";
+import {
+  useDocumentsQuery,
+  useResourcesWithDocumentsQuery,
+  useUserQuery,
+} from "hooks/react-query";
 import React, { useEffect, useMemo, useRef, useState } from "react";
 import { setSelectedResourceId } from "redux/features/statementAnnotator/selectedResourceIdSlice";
 import { setHoveredStatementId } from "redux/features/statementAnnotator/hoveredStatementIdSlice";
@@ -78,23 +82,9 @@ export const AnnotatorBox: React.FC<AnnotatorBox> = ({ height, width }) => {
     enabled: !!territoryId && api.isLoggedIn(),
   });
 
-  const { data: resources } = useQuery({
-    queryKey: ["resourcesWithDocuments"],
-    queryFn: async () => {
-      const res = await api.entitiesSearch({ resourceHasDocument: true });
-      return res.data;
-    },
-    enabled: api.isLoggedIn(),
-  });
+  const { data: resources } = useResourcesWithDocumentsQuery();
 
-  const { data: documents } = useQuery({
-    queryKey: ["documents"],
-    queryFn: async () => {
-      const res = await api.documentsGet({});
-      return res.data;
-    },
-    enabled: api.isLoggedIn(),
-  });
+  const { data: documents } = useDocumentsQuery();
 
   // Set once the user manually picks a resource so auto-load stops overriding it.
   const userPickedRef = useRef(false);

--- a/packages/client/src/pages/Main/containers/AnnotatorBox/AnnotatorBox.tsx
+++ b/packages/client/src/pages/Main/containers/AnnotatorBox/AnnotatorBox.tsx
@@ -83,13 +83,10 @@ export const AnnotatorBox: React.FC<AnnotatorBox> = ({ height, width }) => {
     enabled: !!territoryId && api.isLoggedIn(),
   });
 
-  const resourcesEnabled =
-    !!territoryId || (!!selectedTerritoryPath && selectedTerritoryPath.length > 0);
-
   const { data: resources, refetch: refetchResources } =
-    useResourcesWithDocumentsQuery(resourcesEnabled);
+    useResourcesWithDocumentsQuery(!!territoryId);
 
-  const { data: documents } = useDocumentsQuery(resourcesEnabled);
+  const { data: documents } = useDocumentsQuery(!!territoryId);
 
   // Set once the user manually picks a resource so auto-load stops overriding it.
   const userPickedRef = useRef(false);

--- a/packages/client/src/pages/Main/containers/AnnotatorBox/AnnotatorContent.tsx
+++ b/packages/client/src/pages/Main/containers/AnnotatorBox/AnnotatorContent.tsx
@@ -51,6 +51,7 @@ interface StatementListTextAnnotator {
   selectedDocument?: IDocument;
   selectedResource: IResponseEntity | false;
   resources?: IResponseEntity[];
+  onResourcePickerFocus?: () => void;
   setSelectedResourceId: (id: string | false) => void;
 
   // useQuery for selectedDocument
@@ -92,6 +93,7 @@ export const StatementListTextAnnotator: React.FC<StatementListTextAnnotator> = 
   selectedDocument,
   selectedResource,
   resources,
+  onResourcePickerFocus,
   setSelectedResourceId,
 
   selectedDocumentId,
@@ -210,6 +212,7 @@ export const StatementListTextAnnotator: React.FC<StatementListTextAnnotator> = 
           annotator={annotator}
           territoryId={territoryId}
           resources={resources || []}
+          onResourcePickerFocus={onResourcePickerFocus}
           showStatementList={showStatementList}
           canSelectResource={canSelectResource}
           canEditDocument={canEditDocument}

--- a/packages/client/src/pages/Main/containers/AnnotatorBox/AnnotatorDocumentLine.tsx
+++ b/packages/client/src/pages/Main/containers/AnnotatorBox/AnnotatorDocumentLine.tsx
@@ -276,7 +276,11 @@ const StatementListDocumentLine: React.FC<StatementListDocumentLine> = ({
             {contentWidth > 0 && !isUndersized && (
               <>
                 <StyledInfoText style={{ textWrap: "nowrap" }}>
-                  <IconWithTooltip icon={<FaHighlighter />} tooltipLabel="Highlight" />
+                  <IconWithTooltip
+                    color="info"
+                    icon={<FaHighlighter size={14} />}
+                    tooltipLabel="Highlight"
+                  />
                 </StyledInfoText>
                 <Dropdown.Multi.Entity
                   shortLabel

--- a/packages/client/src/pages/Main/containers/AnnotatorBox/AnnotatorDocumentLine.tsx
+++ b/packages/client/src/pages/Main/containers/AnnotatorBox/AnnotatorDocumentLine.tsx
@@ -77,6 +77,9 @@ interface StatementListDocumentLine {
   annotator?: any;
   territoryId?: string;
   resources: IEntity[];
+  // refetch resources-with-documents when the user focuses the picker, so a
+  // resource another user just linked shows up without waiting out staleTime
+  onResourcePickerFocus?: () => void;
   // is list non empty
   showStatementList: boolean;
   // Editor/admin/owner may load any Resource (show the resource suggester).
@@ -104,6 +107,7 @@ const StatementListDocumentLine: React.FC<StatementListDocumentLine> = ({
   annotator,
   territoryId,
   resources,
+  onResourcePickerFocus,
   showStatementList,
   canSelectResource,
   canEditDocument,
@@ -143,19 +147,21 @@ const StatementListDocumentLine: React.FC<StatementListDocumentLine> = ({
         <StyledDocumentContainer>
           <StyledEntityContainer>
             {!selectedResource && (
-              <EntitySuggester
-                placeholder="select resource"
-                categoryTypes={[EntityEnums.Class.Resource]}
-                preSuggestions={resources}
-                onPicked={(entity) => {
-                  if (resources.some((r) => r.id === entity.id)) {
-                    setSelectedResourceId(entity.id);
-                  } else {
-                    toast.warning("Resource does not have a document");
-                  }
-                }}
-                isHidden={!canSelectResource}
-              />
+              <div onFocus={onResourcePickerFocus}>
+                <EntitySuggester
+                  placeholder="select resource"
+                  categoryTypes={[EntityEnums.Class.Resource]}
+                  preSuggestions={resources}
+                  onPicked={(entity) => {
+                    if (resources.some((r) => r.id === entity.id)) {
+                      setSelectedResourceId(entity.id);
+                    } else {
+                      toast.warning("Resource does not have a document");
+                    }
+                  }}
+                  isHidden={!canSelectResource}
+                />
+              </div>
             )}
             {selectedResource && (
               <div

--- a/packages/client/src/pages/Main/containers/EntityBookmarkBox/EntityBookmarkBox.tsx
+++ b/packages/client/src/pages/Main/containers/EntityBookmarkBox/EntityBookmarkBox.tsx
@@ -26,10 +26,11 @@ import { IcoTrash } from "Theme/icons";
 export const EntityBookmarkBox: React.FC = () => {
   const queryClient = useQueryClient();
 
-  const fourthPanelBoxesOpened: { [key: string]: boolean } = useAppSelector(
-    (state) => state.layout.mainPage.fourthPanelBoxesOpened,
+  const isBookmarksBoxOpen = useAppSelector(
+    (state) => state.layout.mainPage.fourthPanelBoxesOpened.bookmarks,
   );
 
+  const fourthPanelExpanded = useAppSelector((state) => state.layout.mainPage.fourthPanelExpanded);
   const [editingFolder, setEditingFolder] = useState<string | false>(false);
   const [removingFolder, setRemovingFolder] = useState<string | false>(false);
   const [creatingFolder, setCreatingFolder] = useState<boolean>(false);
@@ -38,7 +39,7 @@ export const EntityBookmarkBox: React.FC = () => {
 
   // User query
   const { data: bookmarkFolders, isFetching } = useBookmarksQuery(
-    fourthPanelBoxesOpened["bookmarks"],
+    isBookmarksBoxOpen && fourthPanelExpanded,
   );
 
   const removingFolderName = useMemo(() => {

--- a/packages/client/src/pages/Main/containers/EntityBookmarkBox/EntityBookmarkBox.tsx
+++ b/packages/client/src/pages/Main/containers/EntityBookmarkBox/EntityBookmarkBox.tsx
@@ -12,9 +12,10 @@ import {
   Submit,
 } from "components";
 import { CBookmarkFolder } from "constructors";
+import { useBookmarksQuery } from "hooks/react-query";
 import React, { useMemo, useState } from "react";
 import { FaPlus } from "react-icons/fa";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { toast } from "react-toastify";
 import { useAppSelector } from "redux/hooks";
 import { StyledContent, StyledFolderList, StyledHeader } from "./EntityBookmarkBoxStyles";
@@ -34,21 +35,9 @@ export const EntityBookmarkBox: React.FC = () => {
   const [openedFolders, setOpenedFolders] = useState<string[]>([]);
 
   // User query
-  const {
-    status: statusStatement,
-    data: bookmarkFolders,
-    error: errorStatement,
-    isFetching: isFetching,
-  } = useQuery({
-    queryKey: ["bookmarks"],
-    queryFn: async () => {
-      const res = await api.bookmarksGet("me");
-      const data = res.data ?? [];
-      data.sort((a, b) => (a.name > b.name ? 1 : -1));
-      return data;
-    },
-    enabled: api.isLoggedIn() && fourthPanelBoxesOpened["bookmarks"],
-  });
+  const { data: bookmarkFolders, isFetching } = useBookmarksQuery(
+    fourthPanelBoxesOpened["bookmarks"],
+  );
 
   const removingFolderName = useMemo(() => {
     if (bookmarkFolders) {
@@ -136,7 +125,7 @@ export const EntityBookmarkBox: React.FC = () => {
     },
 
     onSuccess: () => {
-      toast.info("Bookmark edited");
+      toast.info("Bookmark folder edited");
       queryClient.invalidateQueries({ queryKey: ["bookmarks"] });
       setEditingFolderName("");
       setEditingFolder(false);

--- a/packages/client/src/pages/Main/containers/EntityBookmarkBox/EntityBookmarkBox.tsx
+++ b/packages/client/src/pages/Main/containers/EntityBookmarkBox/EntityBookmarkBox.tsx
@@ -20,6 +20,8 @@ import { toast } from "react-toastify";
 import { useAppSelector } from "redux/hooks";
 import { StyledContent, StyledFolderList, StyledHeader } from "./EntityBookmarkBoxStyles";
 import { EntityBookmarkFolder } from "./EntityBookmarkFolder/EntityBookmarkFolder";
+import { MdEdit } from "react-icons/md";
+import { FaTrashCan } from "react-icons/fa6";
 
 export const EntityBookmarkBox: React.FC = () => {
   const queryClient = useQueryClient();
@@ -218,17 +220,19 @@ export const EntityBookmarkBox: React.FC = () => {
         showModal={isFolderModalOpen}
         onClose={closeFolderModal}
         onEnterPress={submitFolderModal}
+        width={350}
       >
-        <ModalHeader title="Bookmark Folder" />
+        <ModalHeader icon={<MdEdit />} title="Edit Bookmark folder" />
         <ModalContent>
           <Input
-            label="Bookmark folder name: "
+            label="new label:"
             labelSpaceNoWrap
             placeholder=""
             onChangeFn={(newName: string) => setEditingFolderName(newName)}
             value={editingFolderName}
             changeOnType
             autoFocus
+            width="full"
           />
         </ModalContent>
 
@@ -249,6 +253,7 @@ export const EntityBookmarkBox: React.FC = () => {
       </Modal>
 
       <Submit
+        headerIcon={<FaTrashCan size={14} />}
         title={`Delete Bookmark folder ${removingFolderName}`}
         text={`Do you really want do delete Bookmark folder ${removingFolderName}?`}
         show={removingFolder != false}

--- a/packages/client/src/pages/Main/containers/EntityBookmarkBox/EntityBookmarkBox.tsx
+++ b/packages/client/src/pages/Main/containers/EntityBookmarkBox/EntityBookmarkBox.tsx
@@ -21,7 +21,7 @@ import { useAppSelector } from "redux/hooks";
 import { StyledContent, StyledFolderList, StyledHeader } from "./EntityBookmarkBoxStyles";
 import { EntityBookmarkFolder } from "./EntityBookmarkFolder/EntityBookmarkFolder";
 import { MdEdit } from "react-icons/md";
-import { FaTrashCan } from "react-icons/fa6";
+import { IcoTrash } from "Theme/icons";
 
 export const EntityBookmarkBox: React.FC = () => {
   const queryClient = useQueryClient();
@@ -253,7 +253,7 @@ export const EntityBookmarkBox: React.FC = () => {
       </Modal>
 
       <Submit
-        headerIcon={<FaTrashCan size={14} />}
+        headerIcon={<IcoTrash size={14} />}
         title={`Delete Bookmark folder ${removingFolderName}`}
         text={`Do you really want do delete Bookmark folder ${removingFolderName}?`}
         show={removingFolder != false}

--- a/packages/client/src/pages/Main/containers/EntityBookmarkBox/EntityBookmarkBoxStyles.tsx
+++ b/packages/client/src/pages/Main/containers/EntityBookmarkBox/EntityBookmarkBoxStyles.tsx
@@ -6,7 +6,7 @@ export const StyledContent = styled.div`
   flex-direction: column;
   align-items: start;
   padding-top: 0.3rem;
-  padding-left: 0.5rem;
+  padding-left: 0.6rem;
   background-color: ${({ theme }) => theme.color["white"]};
   padding-bottom: 1rem;
   overflow: auto;

--- a/packages/client/src/pages/Main/containers/EntityBookmarkBox/EntityBookmarkBoxStyles.tsx
+++ b/packages/client/src/pages/Main/containers/EntityBookmarkBox/EntityBookmarkBoxStyles.tsx
@@ -21,6 +21,6 @@ export const StyledFolderList = styled.div`
   width: 100%;
   display: flex;
   flex-direction: column;
-  gap: 0.3rem;
+  gap: 0.5rem;
   padding-right: 0.3rem;
 `;

--- a/packages/client/src/pages/Main/containers/EntityBookmarkBox/EntityBookmarkFolder/EntityBookmarkFolder.tsx
+++ b/packages/client/src/pages/Main/containers/EntityBookmarkBox/EntityBookmarkFolder/EntityBookmarkFolder.tsx
@@ -8,7 +8,7 @@ import { EntitySuggester } from "components/advanced";
 import React, { useRef, useState } from "react";
 import { DropTargetMonitor, useDrop } from "react-dnd";
 import { FaFolder, FaFolderOpen, FaRegFolder, FaRegFolderOpen } from "react-icons/fa";
-import { FaTrashCan } from "react-icons/fa6";
+import { IcoTrash } from "Theme/icons";
 import { MdEdit } from "react-icons/md";
 import { DragItem, ItemTypes } from "types";
 import { EntityBookmarkTable } from "../EntityBookmarkTable/EntityBookmarkTable";
@@ -170,7 +170,7 @@ export const EntityBookmarkFolder: React.FC<EntityBookmarkFolder> = ({
             <StyledRemoveButtonWrap>
               <Button
                 key="remove"
-                icon={<FaTrashCan size={14} />}
+                icon={<IcoTrash size={14} />}
                 inverted
                 onClick={(e: React.MouseEvent) => {
                   e.stopPropagation();

--- a/packages/client/src/pages/Main/containers/EntityBookmarkBox/EntityBookmarkFolder/EntityBookmarkFolder.tsx
+++ b/packages/client/src/pages/Main/containers/EntityBookmarkBox/EntityBookmarkFolder/EntityBookmarkFolder.tsx
@@ -149,7 +149,7 @@ export const EntityBookmarkFolder: React.FC<EntityBookmarkFolder> = ({
         onMouseLeave={() => setShowTooltip(false)}
       >
         <StyledFolderWrapperOpenArea>
-          <StyledIconWrap>
+          <StyledIconWrap $isOpen={open}>
             <FolderIcon size={15} />
           </StyledIconWrap>
           <StyledFolderHeaderText $open={open}>{bookmarkFolder.name}</StyledFolderHeaderText>

--- a/packages/client/src/pages/Main/containers/EntityBookmarkBox/EntityBookmarkFolder/EntityBookmarkFolder.tsx
+++ b/packages/client/src/pages/Main/containers/EntityBookmarkBox/EntityBookmarkFolder/EntityBookmarkFolder.tsx
@@ -6,8 +6,6 @@ import api from "api";
 import { Button, ButtonGroup, Tooltip } from "components";
 import { EntitySuggester } from "components/advanced";
 import React, { useRef, useState } from "react";
-import { useSelector } from "react-redux";
-import { selectPanelWidth } from "redux/features/layout/mainPage/panelWidthsSlice";
 import { DropTargetMonitor, useDrop } from "react-dnd";
 import {
   FaEdit,
@@ -15,7 +13,7 @@ import {
   FaFolderOpen,
   FaRegFolder,
   FaRegFolderOpen,
-  FaTrash,
+  FaTrashAlt,
 } from "react-icons/fa";
 import { DragItem, ItemTypes } from "types";
 import { EntityBookmarkTable } from "../EntityBookmarkTable/EntityBookmarkTable";
@@ -158,26 +156,30 @@ export const EntityBookmarkFolder: React.FC<EntityBookmarkFolder> = ({
         </StyledFolderWrapperOpenArea>
 
         <StyledFolderHeaderButtons>
-          <ButtonGroup>
+          <ButtonGroup $smallGap>
             <Button
               key="edit"
-              icon={<FaEdit size={12} />}
+              icon={<FaEdit size={16} />}
               color="warning"
               inverted
               onClick={(e: React.MouseEvent) => {
                 e.stopPropagation();
                 startEditingFolder(bookmarkFolder);
               }}
+              noBackground
+              noBorder
             />
             <Button
               key="remove"
-              icon={<FaTrash size={12} />}
+              icon={<FaTrashAlt size={14} />}
               color="danger"
               inverted
               onClick={(e: React.MouseEvent) => {
                 e.stopPropagation();
                 askRemoveFolder(bookmarkFolder.id);
               }}
+              noBackground
+              noBorder
             />
           </ButtonGroup>
         </StyledFolderHeaderButtons>

--- a/packages/client/src/pages/Main/containers/EntityBookmarkBox/EntityBookmarkFolder/EntityBookmarkFolder.tsx
+++ b/packages/client/src/pages/Main/containers/EntityBookmarkBox/EntityBookmarkFolder/EntityBookmarkFolder.tsx
@@ -23,11 +23,15 @@ import {
   StyledFolderHeader,
   StyledFolderHeaderButtons,
   StyledFolderHeaderText,
+  StyledEditButtonWrap,
   StyledFolderSuggester,
   StyledFolderWrapper,
   StyledFolderWrapperOpenArea,
   StyledIconWrap,
+  StyledRemoveButtonWrap,
 } from "./EntityBookmarkFolderStyles";
+import { MdEdit } from "react-icons/md";
+import { FaTrashCan } from "react-icons/fa6";
 
 interface EntityBookmarkFolder {
   bookmarkFolder: IResponseBookmarkFolder;
@@ -157,30 +161,34 @@ export const EntityBookmarkFolder: React.FC<EntityBookmarkFolder> = ({
 
         <StyledFolderHeaderButtons>
           <ButtonGroup $smallGap>
-            <Button
-              key="edit"
-              icon={<FaEdit size={16} />}
-              color="warning"
-              inverted
-              onClick={(e: React.MouseEvent) => {
-                e.stopPropagation();
-                startEditingFolder(bookmarkFolder);
-              }}
-              noBackground
-              noBorder
-            />
-            <Button
-              key="remove"
-              icon={<FaTrashAlt size={14} />}
-              color="danger"
-              inverted
-              onClick={(e: React.MouseEvent) => {
-                e.stopPropagation();
-                askRemoveFolder(bookmarkFolder.id);
-              }}
-              noBackground
-              noBorder
-            />
+            <StyledEditButtonWrap>
+              <Button
+                key="edit"
+                icon={<MdEdit size={17} />}
+                // color="warning"
+                inverted
+                onClick={(e: React.MouseEvent) => {
+                  e.stopPropagation();
+                  startEditingFolder(bookmarkFolder);
+                }}
+                noBackground
+                noBorder
+              />
+            </StyledEditButtonWrap>
+            <StyledRemoveButtonWrap>
+              <Button
+                key="remove"
+                icon={<FaTrashCan size={14} />}
+                // color="danger"
+                inverted
+                onClick={(e: React.MouseEvent) => {
+                  e.stopPropagation();
+                  askRemoveFolder(bookmarkFolder.id);
+                }}
+                noBackground
+                noBorder
+              />
+            </StyledRemoveButtonWrap>
           </ButtonGroup>
         </StyledFolderHeaderButtons>
       </StyledFolderHeader>

--- a/packages/client/src/pages/Main/containers/EntityBookmarkBox/EntityBookmarkFolder/EntityBookmarkFolder.tsx
+++ b/packages/client/src/pages/Main/containers/EntityBookmarkBox/EntityBookmarkFolder/EntityBookmarkFolder.tsx
@@ -7,31 +7,24 @@ import { Button, ButtonGroup, Tooltip } from "components";
 import { EntitySuggester } from "components/advanced";
 import React, { useRef, useState } from "react";
 import { DropTargetMonitor, useDrop } from "react-dnd";
-import {
-  FaEdit,
-  FaFolder,
-  FaFolderOpen,
-  FaRegFolder,
-  FaRegFolderOpen,
-  FaTrashAlt,
-} from "react-icons/fa";
+import { FaFolder, FaFolderOpen, FaRegFolder, FaRegFolderOpen } from "react-icons/fa";
+import { FaTrashCan } from "react-icons/fa6";
+import { MdEdit } from "react-icons/md";
 import { DragItem, ItemTypes } from "types";
 import { EntityBookmarkTable } from "../EntityBookmarkTable/EntityBookmarkTable";
 import {
+  StyledEditButtonWrap,
   StyledFolderContent,
   StyledFolderContentTags,
   StyledFolderHeader,
   StyledFolderHeaderButtons,
   StyledFolderHeaderText,
-  StyledEditButtonWrap,
   StyledFolderSuggester,
   StyledFolderWrapper,
   StyledFolderWrapperOpenArea,
   StyledIconWrap,
   StyledRemoveButtonWrap,
 } from "./EntityBookmarkFolderStyles";
-import { MdEdit } from "react-icons/md";
-import { FaTrashCan } from "react-icons/fa6";
 
 interface EntityBookmarkFolder {
   bookmarkFolder: IResponseBookmarkFolder;
@@ -164,8 +157,7 @@ export const EntityBookmarkFolder: React.FC<EntityBookmarkFolder> = ({
             <StyledEditButtonWrap>
               <Button
                 key="edit"
-                icon={<MdEdit size={17} />}
-                // color="warning"
+                icon={<MdEdit size={18} />}
                 inverted
                 onClick={(e: React.MouseEvent) => {
                   e.stopPropagation();
@@ -179,7 +171,6 @@ export const EntityBookmarkFolder: React.FC<EntityBookmarkFolder> = ({
               <Button
                 key="remove"
                 icon={<FaTrashCan size={14} />}
-                // color="danger"
                 inverted
                 onClick={(e: React.MouseEvent) => {
                   e.stopPropagation();

--- a/packages/client/src/pages/Main/containers/EntityBookmarkBox/EntityBookmarkFolder/EntityBookmarkFolder.tsx
+++ b/packages/client/src/pages/Main/containers/EntityBookmarkBox/EntityBookmarkFolder/EntityBookmarkFolder.tsx
@@ -150,9 +150,9 @@ export const EntityBookmarkFolder: React.FC<EntityBookmarkFolder> = ({
       >
         <StyledFolderWrapperOpenArea>
           <StyledIconWrap>
-            <FolderIcon />
+            <FolderIcon size={15} />
           </StyledIconWrap>
-          <StyledFolderHeaderText>{bookmarkFolder.name}</StyledFolderHeaderText>
+          <StyledFolderHeaderText $open={open}>{bookmarkFolder.name}</StyledFolderHeaderText>
         </StyledFolderWrapperOpenArea>
 
         <StyledFolderHeaderButtons>

--- a/packages/client/src/pages/Main/containers/EntityBookmarkBox/EntityBookmarkFolder/EntityBookmarkFolderStyles.tsx
+++ b/packages/client/src/pages/Main/containers/EntityBookmarkBox/EntityBookmarkFolder/EntityBookmarkFolderStyles.tsx
@@ -10,41 +10,87 @@ export const StyledFolderWrapper = styled.div`
   box-shadow: ${({ theme }) => theme.boxShadow["subtle"]};
   background-color: ${({ theme }) => theme.color["white"]};
   overflow: hidden;
+  transition:
+    background-color 0.2s ease,
+    border-color 0.2s ease,
+    box-shadow 0.2s ease;
   &:hover {
     background-color: ${({ theme }) => theme.color["gray"][100]};
+    border-color: ${({ theme }) => theme.color["gray"][450]};
+    box-shadow: ${({ theme }) => theme.boxShadow["normal"]};
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    transition: none;
   }
 `;
 export const StyledFolderHeader = styled.div`
   width: 100%;
   height: ${({ theme }) => theme.space[14]};
   display: inline-flex;
+  align-items: center;
   overflow: hidden;
   color: ${({ theme }) => theme.color["gray"][700]};
   padding: ${({ theme }) => theme.space[3]};
-`;
-export const StyledFolderHeaderText = styled.div`
-  display: flex;
-  align-items: center;
-  font-weight: ${({ theme }) => theme.fontWeight["medium"]};
-  font-size: ${({ theme }) => theme.fontSize["sm"]};
-  margin-left: ${({ theme }) => theme.space[2]};
-  margin-right: ${({ theme }) => theme.space[1]};
-  width: 100%;
-
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
 `;
 export const StyledFolderWrapperOpenArea = styled.div`
   cursor: pointer;
   display: inline-flex;
   align-items: center;
+  flex: 1;
+  min-width: 0;
   overflow: hidden;
-  width: 100%;
+`;
+export const StyledIconWrap = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  width: ${({ theme }) => theme.space[9]};
+  height: ${({ theme }) => theme.space[9]};
+  border-radius: ${({ theme }) => theme.borderRadius["rounded-md"]};
+  transition: scale 0.2s ease;
+
+  ${StyledFolderHeader}:hover & {
+    scale: 1.1;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    transition: none;
+  }
+`;
+export const StyledFolderHeaderText = styled.div<{ $open?: boolean }>`
+  flex: 1;
+  min-width: 0;
+  margin-left: ${({ theme }) => theme.space[3]};
+  font-weight: ${({ theme, $open }) =>
+    $open ? theme.fontWeight["bold"] : theme.fontWeight["medium"]};
+  font-size: ${({ theme }) => theme.fontSize["sm"]};
+  color: ${({ theme, $open }) => ($open ? theme.color["primary"] : theme.color["gray"][700])};
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
 `;
 export const StyledFolderHeaderButtons = styled.div`
   display: flex;
-  align-items: start;
+  align-items: center;
+  flex-shrink: 0;
+  max-width: 0;
+  opacity: 0;
+  overflow: hidden;
+  transition:
+    max-width 0.2s ease,
+    opacity 0.15s ease;
+
+  ${StyledFolderHeader}:hover &,
+  ${StyledFolderHeader}:focus-within & {
+    max-width: ${({ theme }) => theme.space[24]};
+    opacity: 1;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    transition: none;
+  }
 `;
 export const StyledFolderContent = styled.div`
   padding: ${({ theme }) => theme.space[3]};
@@ -60,8 +106,3 @@ export const StyledFolderContentTag = styled.div`
   display: inline-block;
 `;
 export const StyledFolderSuggester = styled.div``;
-export const StyledIconWrap = styled.div`
-  display: flex;
-  align-items: center;
-  width: ${({ theme }) => theme.space[7]};
-`;

--- a/packages/client/src/pages/Main/containers/EntityBookmarkBox/EntityBookmarkFolder/EntityBookmarkFolderStyles.tsx
+++ b/packages/client/src/pages/Main/containers/EntityBookmarkBox/EntityBookmarkFolder/EntityBookmarkFolderStyles.tsx
@@ -110,3 +110,21 @@ export const StyledFolderContentTag = styled.div`
   display: inline-block;
 `;
 export const StyledFolderSuggester = styled.div``;
+
+export const StyledEditButtonWrap = styled.div`
+  display: flex;
+  align-items: center;
+
+  &:hover button {
+    color: ${({ theme }) => theme.color["warning"]};
+  }
+`;
+
+export const StyledRemoveButtonWrap = styled.div`
+  display: flex;
+  align-items: center;
+
+  &:hover button {
+    color: ${({ theme }) => theme.color["danger"]};
+  }
+`;

--- a/packages/client/src/pages/Main/containers/EntityBookmarkBox/EntityBookmarkFolder/EntityBookmarkFolderStyles.tsx
+++ b/packages/client/src/pages/Main/containers/EntityBookmarkBox/EntityBookmarkFolder/EntityBookmarkFolderStyles.tsx
@@ -23,8 +23,10 @@ export const StyledFolderHeader = styled.div`
   padding: ${({ theme }) => theme.space[3]};
 `;
 export const StyledFolderHeaderText = styled.div`
-  vertical-align: text-bottom;
+  display: flex;
+  align-items: center;
   font-weight: ${({ theme }) => theme.fontWeight["medium"]};
+  font-size: ${({ theme }) => theme.fontSize["sm"]};
   margin-left: ${({ theme }) => theme.space[2]};
   margin-right: ${({ theme }) => theme.space[1]};
   width: 100%;
@@ -36,6 +38,7 @@ export const StyledFolderHeaderText = styled.div`
 export const StyledFolderWrapperOpenArea = styled.div`
   cursor: pointer;
   display: inline-flex;
+  align-items: center;
   overflow: hidden;
   width: 100%;
 `;

--- a/packages/client/src/pages/Main/containers/EntityBookmarkBox/EntityBookmarkFolder/EntityBookmarkFolderStyles.tsx
+++ b/packages/client/src/pages/Main/containers/EntityBookmarkBox/EntityBookmarkFolder/EntityBookmarkFolderStyles.tsx
@@ -41,7 +41,10 @@ export const StyledFolderWrapperOpenArea = styled.div`
   min-width: 0;
   overflow: hidden;
 `;
-export const StyledIconWrap = styled.div`
+interface StyledIconWrapProps {
+  $isOpen: boolean;
+}
+export const StyledIconWrap = styled.div<StyledIconWrapProps>`
   display: flex;
   align-items: center;
   justify-content: center;
@@ -49,6 +52,7 @@ export const StyledIconWrap = styled.div`
   width: ${({ theme }) => theme.space[9]};
   height: ${({ theme }) => theme.space[9]};
   border-radius: ${({ theme }) => theme.borderRadius["rounded-md"]};
+  scale: ${({ $isOpen }) => ($isOpen ? 1.1 : 1)};
   transition: scale 0.2s ease;
 
   ${StyledFolderHeader}:hover & {

--- a/packages/client/src/pages/Main/containers/EntityBookmarkBox/EntityBookmarkTable/EntityBookmarkTable.tsx
+++ b/packages/client/src/pages/Main/containers/EntityBookmarkBox/EntityBookmarkTable/EntityBookmarkTable.tsx
@@ -5,7 +5,7 @@ import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { CellProps, Column, Row, useTable } from "react-table";
 import { EntityBookmarkTableRow } from "./EntityBookmarkTableRow";
 import { StyledTable, StyledTagWrap } from "./EntityBookmarkTableStyles";
-import { FaTrash } from "react-icons/fa";
+import { IcoTrash } from "Theme/icons";
 
 type CellType = CellProps<IEntity>;
 
@@ -44,7 +44,7 @@ export const EntityBookmarkTable: React.FC<EntityBookmarkTable> = ({
                     removeBookmark(folder.id, entity.id);
                   },
                   tooltipLabel: "delete bookmark",
-                  icon: <FaTrash />,
+                  icon: <IcoTrash />,
                 }}
               />
             </StyledTagWrap>

--- a/packages/client/src/pages/Main/containers/EntityBookmarkBox/EntityBookmarkTable/EntityBookmarkTableRow.tsx
+++ b/packages/client/src/pages/Main/containers/EntityBookmarkBox/EntityBookmarkTable/EntityBookmarkTableRow.tsx
@@ -1,17 +1,16 @@
 import { IEntity, IResponseBookmarkFolder } from "@inkvisitor/shared/types";
-import { useTheme } from "hooks";
 import React, { useRef } from "react";
-import {
-  DragSourceMonitor,
-  DropTargetMonitor,
-  useDrag,
-  useDrop,
-} from "react-dnd";
-import { FaGripVertical } from "react-icons/fa";
+import { DragSourceMonitor, DropTargetMonitor, useDrag, useDrop } from "react-dnd";
 import { ColumnInstance, Row } from "react-table";
 import { DragItem, ItemTypes } from "types";
 import { dndHoverFn } from "utils/utils";
-import { StyledTd, StyledTr } from "./EntityBookmarkTableStyles";
+import {
+  StyledDragHandleIcon,
+  StyledDragHandlePlaceholderTd,
+  StyledDragHandleTd,
+  StyledTd,
+  StyledTr,
+} from "./EntityBookmarkTableStyles";
 
 interface EntityBookmarkTableRow {
   row: Row<IEntity>;
@@ -58,17 +57,15 @@ export const EntityBookmarkTableRow: React.FC<EntityBookmarkTableRow> = ({
   preview(drop(dropRef));
   drag(dragRef);
 
-  const theme = useTheme();
-
   return (
     <React.Fragment key={index}>
       <StyledTr ref={dropRef} opacity={opacity} $isOdd={Boolean(index % 2)}>
         {hasOrder ? (
-          <td ref={dragRef} style={{ cursor: "move" }}>
-            <FaGripVertical color={theme.color.black} />
-          </td>
+          <StyledDragHandleTd ref={dragRef}>
+            <StyledDragHandleIcon />
+          </StyledDragHandleTd>
         ) : (
-          <td style={{ width: "2rem" }} />
+          <StyledDragHandlePlaceholderTd />
         )}
         {row.cells.map((cell, key) => {
           return (

--- a/packages/client/src/pages/Main/containers/EntityBookmarkBox/EntityBookmarkTable/EntityBookmarkTableStyles.tsx
+++ b/packages/client/src/pages/Main/containers/EntityBookmarkBox/EntityBookmarkTable/EntityBookmarkTableStyles.tsx
@@ -1,4 +1,5 @@
 import styled from "styled-components";
+import { FaGripVertical } from "react-icons/fa";
 
 export const StyledTable = styled.table`
   /* width: 100%; */
@@ -22,6 +23,9 @@ interface StyledTr {
 }
 export const StyledTr = styled.tr<StyledTr>`
   opacity: ${({ opacity }) => (opacity ? opacity : 1)};
+  td {
+    vertical-align: middle;
+  }
   td:first-child {
     padding-left: ${({ theme }) => theme.space[1]};
     padding-right: ${({ theme }) => theme.space[2]};
@@ -39,4 +43,14 @@ export const StyledTd = styled.td`
 `;
 export const StyledTagWrap = styled.div`
   display: grid;
+`;
+export const StyledDragHandleTd = styled.td`
+  cursor: move;
+`;
+export const StyledDragHandlePlaceholderTd = styled.td`
+  width: 2rem;
+`;
+export const StyledDragHandleIcon = styled(FaGripVertical)`
+  color: ${({ theme }) => theme.color.black};
+  display: block;
 `;

--- a/packages/client/src/pages/Main/containers/EntityDetailBox/EntityDetail/EntityDetail.tsx
+++ b/packages/client/src/pages/Main/containers/EntityDetailBox/EntityDetail/EntityDetail.tsx
@@ -9,6 +9,7 @@ import { Button, CustomScrollbar, Loader, Message, Submit, ToastWithLink } from 
 import { ApplyTemplateModal, AuditTable, EntityTag, JSONExplorer } from "components/advanced";
 import { CMetaProp, DProps } from "constructors";
 import { useSearchParams } from "hooks";
+import { useTemplatesQuery } from "hooks/react-query";
 import { invalidateAllExplorerQueries } from "pages/Query/useQueryData";
 import React, { useEffect, useMemo, useState } from "react";
 import { FaPlus } from "react-icons/fa";
@@ -154,29 +155,12 @@ export const EntityDetail: React.FC<EntityDetail> = ({ detailId, entity, error, 
 
   const isClassChangeable = entity && allowedEntityChangeClasses.includes(entity.class);
 
-  const {
-    status: templateStatus,
-    data: templates,
-    error: templateError,
-    isFetching: isFetchingTemplates,
-  } = useQuery({
-    queryKey: ["entity-templates", "templates", entity?.class],
-    queryFn: async () => {
-      if (entity) {
-        const res = await api.entitiesSearch({
-          onlyTemplates: true,
-          class: entity?.class,
-        });
+  const { data: allTemplates } = useTemplatesQuery();
 
-        const templates: IEntity[] = res.data ?? [];
-        templates.sort((a: IEntity, b: IEntity) =>
-          a.labels[0].toLocaleLowerCase() > b.labels[0].toLocaleLowerCase() ? 1 : -1
-        );
-        return templates;
-      }
-    },
-    enabled: !!entity && api.isLoggedIn(),
-  });
+  const templates = useMemo(
+    () => allTemplates?.filter((template: IEntity) => template.class === entity?.class),
+    [allTemplates, entity?.class]
+  );
 
   const templateOptions = useMemo<DropdownItem[]>(() => {
     const options =
@@ -280,7 +264,6 @@ export const EntityDetail: React.FC<EntityDetail> = ({ detailId, entity, error, 
       }
       if (entity?.isTemplate) {
         queryClient.invalidateQueries({ queryKey: ["templates"] });
-        queryClient.invalidateQueries({ queryKey: ["entity-templates"] });
         if (entity?.class === EntityEnums.Class.Statement) {
           queryClient.invalidateQueries({ queryKey: ["statement-templates"] });
         }

--- a/packages/client/src/pages/Main/containers/EntityDetailBox/EntityDetail/EntityDetail.tsx
+++ b/packages/client/src/pages/Main/containers/EntityDetailBox/EntityDetail/EntityDetail.tsx
@@ -812,7 +812,6 @@ export const EntityDetail: React.FC<EntityDetail> = ({ detailId, entity, error, 
                         originId={entity.id}
                         entities={entity.entities}
                         props={entity.props}
-                        territoryId={territoryId}
                         updateProp={updateProp}
                         removeProp={removeProp}
                         addProp={addMetaProp}

--- a/packages/client/src/pages/Main/containers/EntityDetailBox/EntityDetail/EntityDetail.tsx
+++ b/packages/client/src/pages/Main/containers/EntityDetailBox/EntityDetail/EntityDetail.tsx
@@ -3,15 +3,19 @@ import { EntityEnums, RelationEnums, UserEnums } from "@inkvisitor/shared/enums"
 import { IEntity, IProp, IReference, IResponseDetail, Relation } from "@inkvisitor/shared/types";
 import { EProtocolTieType, ITerritoryValidation } from "@inkvisitor/shared/types/territory";
 import { IWarningPositionSection } from "@inkvisitor/shared/types/warning";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import api from "api";
 import { Button, CustomScrollbar, Loader, Message, Submit, ToastWithLink } from "components";
 import { ApplyTemplateModal, AuditTable, EntityTag, JSONExplorer } from "components/advanced";
 import { CMetaProp, DProps } from "constructors";
-import { useSearchParams } from "hooks";
-import { useStatementQuery, useTemplatesQuery } from "hooks/react-query";
+import { useIsInViewport, useSearchParams } from "hooks";
+import {
+  useAuditQuery,
+  useStatementQuery,
+  useTemplatesQuery,
+} from "hooks/react-query";
 import { invalidateAllExplorerQueries } from "pages/Query/useQueryData";
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import { FaPlus } from "react-icons/fa";
 import { toast } from "react-toastify";
 import { useAppSelector } from "redux/hooks";
@@ -188,27 +192,10 @@ export const EntityDetail: React.FC<EntityDetail> = ({ detailId, entity, error, 
     return options;
   }, [templates, entity]);
 
-  // Audit query
-  const {
-    status: statusAudit,
-    data: audit,
-    error: auditError,
-    isFetching: isFetchingAudit,
-  } = useQuery({
-    queryKey: ["audit", detailId],
-    queryFn: async () => {
-      const res = await api.auditGet(detailId);
-      return res.data;
-    },
-    enabled: !!detailId && api.isLoggedIn(),
-  });
-
-  // refetch audit when statement changes
-  useEffect(() => {
-    if (entity !== undefined) {
-      queryClient.invalidateQueries({ queryKey: ["audit"] });
-    }
-  }, [entity]);
+  // Audit query - only fetched once the Audits section scrolls into view
+  const auditSectionRef = useRef<HTMLDivElement>(null);
+  const auditInViewport = useIsInViewport(auditSectionRef, "200px");
+  const { data: audit } = useAuditQuery(detailId, auditInViewport);
 
   useEffect(() => {
     if (entity !== undefined) {
@@ -233,6 +220,7 @@ export const EntityDetail: React.FC<EntityDetail> = ({ detailId, entity, error, 
     mutationFn: async (changes: Partial<IEntity>) => await api.entityUpdate(detailId, changes),
     onSuccess: (data, variables) => {
       queryClient.invalidateQueries({ queryKey: ["entity"] });
+      queryClient.invalidateQueries({ queryKey: ["audit", detailId] });
       invalidateAllExplorerQueries(queryClient);
 
       if (
@@ -1013,7 +1001,7 @@ export const EntityDetail: React.FC<EntityDetail> = ({ detailId, entity, error, 
                   <StyledDetailSectionHeading>Audits</StyledDetailSectionHeading>
                 </StyledDetailSectionHeader>
                 {isSectionExpanded(EntityDetailSection.Audits) && (
-                  <StyledDetailSectionContent>
+                  <StyledDetailSectionContent ref={auditSectionRef}>
                     {audit && <AuditTable {...audit} />}
                   </StyledDetailSectionContent>
                 )}

--- a/packages/client/src/pages/Main/containers/EntityDetailBox/EntityDetail/EntityDetail.tsx
+++ b/packages/client/src/pages/Main/containers/EntityDetailBox/EntityDetail/EntityDetail.tsx
@@ -264,9 +264,6 @@ export const EntityDetail: React.FC<EntityDetail> = ({ detailId, entity, error, 
       }
       if (entity?.isTemplate) {
         queryClient.invalidateQueries({ queryKey: ["templates"] });
-        if (entity?.class === EntityEnums.Class.Statement) {
-          queryClient.invalidateQueries({ queryKey: ["statement-templates"] });
-        }
       }
     },
   });

--- a/packages/client/src/pages/Main/containers/EntityDetailBox/EntityDetail/EntityDetail.tsx
+++ b/packages/client/src/pages/Main/containers/EntityDetailBox/EntityDetail/EntityDetail.tsx
@@ -625,7 +625,9 @@ export const EntityDetail: React.FC<EntityDetail> = ({ detailId, entity, error, 
                       {entity.warnings
                         .filter((w) => w.position?.section === IWarningPositionSection.Entity)
                         .map((warning, key) => {
-                          return <Message key={key} warning={warning} />;
+                          return (
+                            <Message key={key} warning={warning} entities={entity.entities} />
+                          );
                         })}
                     </StyledDetailWarnings>
                   )}
@@ -713,7 +715,9 @@ export const EntityDetail: React.FC<EntityDetail> = ({ detailId, entity, error, 
                               (w) => w.position?.section === IWarningPositionSection.Valencies
                             )
                             .map((warning, key) => {
-                              return <Message key={key} warning={warning} />;
+                              return (
+                            <Message key={key} warning={warning} entities={entity.entities} />
+                          );
                             })}
                       </StyledDetailWarnings>
                       <StyledDetailSectionContent>
@@ -748,7 +752,9 @@ export const EntityDetail: React.FC<EntityDetail> = ({ detailId, entity, error, 
                         {entity.warnings
                           .filter((w) => w.position?.section === IWarningPositionSection.Relations)
                           .map((warning, key) => {
-                            return <Message key={key} warning={warning} />;
+                            return (
+                            <Message key={key} warning={warning} entities={entity.entities} />
+                          );
                           })}
                       </StyledDetailWarnings>
                     )}

--- a/packages/client/src/pages/Main/containers/EntityDetailBox/EntityDetail/EntityDetail.tsx
+++ b/packages/client/src/pages/Main/containers/EntityDetailBox/EntityDetail/EntityDetail.tsx
@@ -155,12 +155,24 @@ export const EntityDetail: React.FC<EntityDetail> = ({ detailId, entity, error, 
 
   const isClassChangeable = entity && allowedEntityChangeClasses.includes(entity.class);
 
-  const { data: allTemplates } = useTemplatesQuery();
+  const {
+    data: allTemplates,
+    isStale: templatesStale,
+    refetch: refetchTemplates,
+  } = useTemplatesQuery();
 
   const templates = useMemo(
     () => allTemplates?.filter((template: IEntity) => template.class === entity?.class),
     [allTemplates, entity?.class]
   );
+
+  // refresh the template list when the user opens the dropdown, but only once
+  // the 5min staleTime has elapsed - avoids refetching on every open
+  const handleTemplateDropdownFocus = () => {
+    if (templatesStale) {
+      refetchTemplates();
+    }
+  };
 
   const templateOptions = useMemo<DropdownItem[]>(() => {
     const options =
@@ -645,6 +657,7 @@ export const EntityDetail: React.FC<EntityDetail> = ({ detailId, entity, error, 
                     isTerritoryWithParent={isTerritoryWithParent}
                     allowedEntityChangeClasses={allowedEntityChangeClasses}
                     handleAskForTemplateApply={handleAskForTemplateApply}
+                    onTemplateDropdownFocus={handleTemplateDropdownFocus}
                     setSelectedEntityType={setSelectedEntityType}
                     setShowTypeSubmit={setShowTypeSubmit}
                     templateOptions={templateOptions}

--- a/packages/client/src/pages/Main/containers/EntityDetailBox/EntityDetail/EntityDetail.tsx
+++ b/packages/client/src/pages/Main/containers/EntityDetailBox/EntityDetail/EntityDetail.tsx
@@ -1,6 +1,13 @@
 import { entitiesDictKeys } from "@inkvisitor/shared/dictionaries";
 import { EntityEnums, RelationEnums, UserEnums } from "@inkvisitor/shared/enums";
-import { IEntity, IProp, IReference, IResponseDetail, Relation } from "@inkvisitor/shared/types";
+import {
+  IEntity,
+  IProp,
+  IReference,
+  IResponseDetail,
+  IResponseStatement,
+  Relation,
+} from "@inkvisitor/shared/types";
 import { EProtocolTieType, ITerritoryValidation } from "@inkvisitor/shared/types/territory";
 import { IWarningPositionSection } from "@inkvisitor/shared/types/warning";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
@@ -9,11 +16,7 @@ import { Button, CustomScrollbar, Loader, Message, Submit, ToastWithLink } from 
 import { ApplyTemplateModal, AuditTable, EntityTag, JSONExplorer } from "components/advanced";
 import { CMetaProp, DProps } from "constructors";
 import { useIsInViewport, useSearchParams } from "hooks";
-import {
-  useAuditQuery,
-  useStatementQuery,
-  useTemplatesQuery,
-} from "hooks/react-query";
+import { useAuditQuery, useTemplatesQuery } from "hooks/react-query";
 import { invalidateAllExplorerQueries } from "pages/Query/useQueryData";
 import React, { useEffect, useMemo, useRef, useState } from "react";
 import { FaPlus } from "react-icons/fa";
@@ -214,8 +217,6 @@ export const EntityDetail: React.FC<EntityDetail> = ({ detailId, entity, error, 
     );
   }, [entity]);
 
-  const { data: statement } = useStatementQuery(statementId);
-
   const updateEntityMutation = useMutation({
     mutationFn: async (changes: Partial<IEntity>) => await api.entityUpdate(detailId, changes),
     onSuccess: (data, variables) => {
@@ -223,6 +224,12 @@ export const EntityDetail: React.FC<EntityDetail> = ({ detailId, entity, error, 
       queryClient.invalidateQueries({ queryKey: ["audit", detailId] });
       invalidateAllExplorerQueries(queryClient);
 
+      // read the open statement from cache (the editor already fetched it) -
+      // no need to subscribe and fetch it here just for this check
+      const statement = queryClient.getQueryData<IResponseStatement>([
+        "statement",
+        statementId,
+      ]);
       if (
         statementId &&
         (statementId === entity?.id ||

--- a/packages/client/src/pages/Main/containers/EntityDetailBox/EntityDetail/EntityDetail.tsx
+++ b/packages/client/src/pages/Main/containers/EntityDetailBox/EntityDetail/EntityDetail.tsx
@@ -18,7 +18,7 @@ import { CMetaProp, DProps } from "constructors";
 import { useIsInViewport, useSearchParams } from "hooks";
 import { useAuditQuery, useTemplatesQuery } from "hooks/react-query";
 import { invalidateAllExplorerQueries } from "pages/Query/useQueryData";
-import React, { useEffect, useMemo, useRef, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import { FaPlus } from "react-icons/fa";
 import { toast } from "react-toastify";
 import { useAppSelector } from "redux/hooks";
@@ -196,8 +196,7 @@ export const EntityDetail: React.FC<EntityDetail> = ({ detailId, entity, error, 
   }, [templates, entity]);
 
   // Audit query - only fetched once the Audits section scrolls into view
-  const auditSectionRef = useRef<HTMLDivElement>(null);
-  const auditInViewport = useIsInViewport(auditSectionRef, "200px");
+  const [auditSectionRef, auditInViewport] = useIsInViewport("200px");
   const { data: audit } = useAuditQuery(detailId, auditInViewport);
 
   useEffect(() => {

--- a/packages/client/src/pages/Main/containers/EntityDetailBox/EntityDetail/EntityDetail.tsx
+++ b/packages/client/src/pages/Main/containers/EntityDetailBox/EntityDetail/EntityDetail.tsx
@@ -9,7 +9,7 @@ import { Button, CustomScrollbar, Loader, Message, Submit, ToastWithLink } from 
 import { ApplyTemplateModal, AuditTable, EntityTag, JSONExplorer } from "components/advanced";
 import { CMetaProp, DProps } from "constructors";
 import { useSearchParams } from "hooks";
-import { useTemplatesQuery } from "hooks/react-query";
+import { useStatementQuery, useTemplatesQuery } from "hooks/react-query";
 import { invalidateAllExplorerQueries } from "pages/Query/useQueryData";
 import React, { useEffect, useMemo, useState } from "react";
 import { FaPlus } from "react-icons/fa";
@@ -227,19 +227,7 @@ export const EntityDetail: React.FC<EntityDetail> = ({ detailId, entity, error, 
     );
   }, [entity]);
 
-  const {
-    status: statusStatement,
-    data: statement,
-    error: statementError,
-    isFetching: isFetchingStatement,
-  } = useQuery({
-    queryKey: ["statement", statementId],
-    queryFn: async () => {
-      const res = await api.statementGet(statementId);
-      return res.data;
-    },
-    enabled: !!statementId && api.isLoggedIn(),
-  });
+  const { data: statement } = useStatementQuery(statementId);
 
   const updateEntityMutation = useMutation({
     mutationFn: async (changes: Partial<IEntity>) => await api.entityUpdate(detailId, changes),

--- a/packages/client/src/pages/Main/containers/EntityDetailBox/EntityDetail/EntityDetailCreateTemplateModal/EntityDetailCreateTemplateModal.tsx
+++ b/packages/client/src/pages/Main/containers/EntityDetailBox/EntityDetail/EntityDetailCreateTemplateModal/EntityDetailCreateTemplateModal.tsx
@@ -1,4 +1,4 @@
-import { EntityEnums, UserEnums } from "@inkvisitor/shared/enums";
+import { UserEnums } from "@inkvisitor/shared/enums";
 import { IEntity, IResponseGeneric } from "@inkvisitor/shared/types";
 import { UseMutationResult, useMutation, useQueryClient } from "@tanstack/react-query";
 import api from "api";
@@ -43,15 +43,12 @@ export const EntityDetailCreateTemplateModal: React.FC<EntityDetailCreateTemplat
   const queryClient = useQueryClient();
   const [createTemplateLabel, setCreateTemplateLabel] = useState<string>("");
 
-  const { statementId, appendDetailId } = useSearchParams();
+  const { appendDetailId } = useSearchParams();
 
   const templateCreateMutation = useMutation({
     mutationFn: async (templateEntity: IEntity) => await api.entityCreate(templateEntity),
     onSuccess: (data, variables) => {
       queryClient.invalidateQueries({ queryKey: ["templates"] });
-      if (statementId && variables.class === EntityEnums.Class.Statement) {
-        queryClient.invalidateQueries({ queryKey: ["statement-templates"] });
-      }
       updateEntityMutation.mutate({ usedTemplate: variables.id });
 
       appendDetailId(variables.id);

--- a/packages/client/src/pages/Main/containers/EntityDetailBox/EntityDetail/EntityDetailCreateTemplateModal/EntityDetailCreateTemplateModal.tsx
+++ b/packages/client/src/pages/Main/containers/EntityDetailBox/EntityDetail/EntityDetailCreateTemplateModal/EntityDetailCreateTemplateModal.tsx
@@ -1,10 +1,6 @@
 import { EntityEnums, UserEnums } from "@inkvisitor/shared/enums";
 import { IEntity, IResponseGeneric } from "@inkvisitor/shared/types";
-import {
-  UseMutationResult,
-  useMutation,
-  useQueryClient,
-} from "@tanstack/react-query";
+import { UseMutationResult, useMutation, useQueryClient } from "@tanstack/react-query";
 import api from "api";
 import { AxiosResponse } from "axios";
 import {
@@ -37,9 +33,7 @@ interface EntityDetailCreateTemplateModal {
     unknown
   >;
 }
-export const EntityDetailCreateTemplateModal: React.FC<
-  EntityDetailCreateTemplateModal
-> = ({
+export const EntityDetailCreateTemplateModal: React.FC<EntityDetailCreateTemplateModal> = ({
   entity,
   showModal = false,
   userCanEdit,
@@ -49,18 +43,14 @@ export const EntityDetailCreateTemplateModal: React.FC<
   const queryClient = useQueryClient();
   const [createTemplateLabel, setCreateTemplateLabel] = useState<string>("");
 
-  const { statementId, selectedDetailId, appendDetailId } = useSearchParams();
+  const { statementId, appendDetailId } = useSearchParams();
 
   const templateCreateMutation = useMutation({
-    mutationFn: async (templateEntity: IEntity) =>
-      await api.entityCreate(templateEntity),
+    mutationFn: async (templateEntity: IEntity) => await api.entityCreate(templateEntity),
     onSuccess: (data, variables) => {
       queryClient.invalidateQueries({ queryKey: ["templates"] });
       if (statementId && variables.class === EntityEnums.Class.Statement) {
         queryClient.invalidateQueries({ queryKey: ["statement-templates"] });
-      }
-      if (selectedDetailId) {
-        queryClient.invalidateQueries({ queryKey: ["entity-templates"] });
       }
       updateEntityMutation.mutate({ usedTemplate: variables.id });
 
@@ -72,11 +62,8 @@ export const EntityDetailCreateTemplateModal: React.FC<
       toast.info(
         `Template [${variables.class}]: "${getShortLabelByLetterCount(
           variables.labels[0],
-          120
-        )}" created from entity "${getShortLabelByLetterCount(
-          entity.labels[0],
-          120
-        )}"`
+          120,
+        )}" created from entity "${getShortLabelByLetterCount(entity.labels[0], 120)}"`,
       );
     },
   });
@@ -86,7 +73,7 @@ export const EntityDetailCreateTemplateModal: React.FC<
     const templateEntity = CTemplateEntity(
       localStorage.getItem("userrole") as UserEnums.Role,
       entity,
-      createTemplateLabel
+      createTemplateLabel,
     );
     templateCreateMutation.mutate(templateEntity);
   };
@@ -110,7 +97,7 @@ export const EntityDetailCreateTemplateModal: React.FC<
       <ModalHeader title="Create Template" />
       <ModalContent>
         <ModalInputForm alignLeft>
-          <ModalInputLabel>Label</ModalInputLabel>
+          <ModalInputLabel>Label:</ModalInputLabel>
           <ModalInputWrap>
             <Input
               disabled={!userCanEdit}

--- a/packages/client/src/pages/Main/containers/EntityDetailBox/EntityDetail/EntityDetailFormSection/EntityDetailFormSection.tsx
+++ b/packages/client/src/pages/Main/containers/EntityDetailBox/EntityDetail/EntityDetailFormSection/EntityDetailFormSection.tsx
@@ -16,7 +16,8 @@ import {
   ITerritory,
 } from "@inkvisitor/shared/types";
 import { IConceptData } from "@inkvisitor/shared/types/concept";
-import { useMutation, UseMutationResult, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useMutation, UseMutationResult, useQueryClient } from "@tanstack/react-query";
+import { useDocumentsQuery } from "hooks/react-query";
 import { MIN_LABEL_LENGTH_MESSAGE, rootTerritoryId } from "Theme/constants";
 import api from "api";
 import { AxiosResponse } from "axios";
@@ -82,14 +83,7 @@ export const EntityDetailFormSection: React.FC<EntityDetailFormSection> = ({
   isStatementWithTerritory,
   widthTooNarrow,
 }) => {
-  const { data: documents } = useQuery({
-    queryKey: ["documents"],
-    queryFn: async () => {
-      const res = await api.documentsGet({});
-      return res.data;
-    },
-    enabled: actantMode === "resource" && api.isLoggedIn(),
-  });
+  const { data: documents } = useDocumentsQuery(actantMode === "resource");
 
   const noDocumentLinkedItem: DropdownItem = {
     value: "",

--- a/packages/client/src/pages/Main/containers/EntityDetailBox/EntityDetail/EntityDetailFormSection/EntityDetailFormSection.tsx
+++ b/packages/client/src/pages/Main/containers/EntityDetailBox/EntityDetail/EntityDetailFormSection/EntityDetailFormSection.tsx
@@ -83,7 +83,9 @@ export const EntityDetailFormSection: React.FC<EntityDetailFormSection> = ({
   isStatementWithTerritory,
   widthTooNarrow,
 }) => {
-  const { data: documents } = useDocumentsQuery(actantMode === "resource");
+  const { data: documents, refetch: refetchDocuments } = useDocumentsQuery(
+    actantMode === "resource",
+  );
 
   const noDocumentLinkedItem: DropdownItem = {
     value: "",
@@ -594,7 +596,7 @@ export const EntityDetailFormSection: React.FC<EntityDetailFormSection> = ({
               {/* document id */}
               <StyledDetailContentRow>
                 <StyledDetailContentRowLabel>Linked Document</StyledDetailContentRowLabel>
-                <StyledDetailContentRowValue>
+                <StyledDetailContentRowValue onFocus={() => refetchDocuments()}>
                   <Dropdown.Single.Basic
                     disabled={!userCanEdit}
                     value={selectedDocumentOption}

--- a/packages/client/src/pages/Main/containers/EntityDetailBox/EntityDetail/EntityDetailFormSection/EntityDetailFormSection.tsx
+++ b/packages/client/src/pages/Main/containers/EntityDetailBox/EntityDetail/EntityDetailFormSection/EntityDetailFormSection.tsx
@@ -63,6 +63,7 @@ interface EntityDetailFormSection {
   setSelectedEntityType: (value: React.SetStateAction<EntityEnums.Class | undefined>) => void;
   setShowTypeSubmit: (value: React.SetStateAction<boolean>) => void;
   handleAskForTemplateApply: (templateIdToApply: string) => void;
+  onTemplateDropdownFocus?: () => void;
   isTerritoryWithParent: (entity: IResponseDetail) => boolean;
   isStatementWithTerritory: (entity: IResponseDetail) => boolean;
   widthTooNarrow: boolean;
@@ -79,6 +80,7 @@ export const EntityDetailFormSection: React.FC<EntityDetailFormSection> = ({
   setSelectedEntityType,
   setShowTypeSubmit,
   handleAskForTemplateApply,
+  onTemplateDropdownFocus,
   isTerritoryWithParent,
   isStatementWithTerritory,
   widthTooNarrow,
@@ -214,6 +216,7 @@ export const EntityDetailFormSection: React.FC<EntityDetailFormSection> = ({
                 width="full"
                 value={null}
                 options={templateOptions}
+                onFocus={onTemplateDropdownFocus}
                 onChange={handleAskForTemplateApply}
               />
             </StyledDetailContentRowValue>

--- a/packages/client/src/pages/Main/containers/EntityDetailBox/EntityDetail/EntityDetailHeaderRow/EntityDetailHeaderRow.tsx
+++ b/packages/client/src/pages/Main/containers/EntityDetailBox/EntityDetail/EntityDetailHeaderRow/EntityDetailHeaderRow.tsx
@@ -9,7 +9,8 @@ import { useSearchParams } from "hooks";
 import React, { useState } from "react";
 import { AiOutlineLink } from "react-icons/ai";
 import { CgListTree } from "react-icons/cg";
-import { FaClone, FaEdit, FaTrashAlt } from "react-icons/fa";
+import { FaClone, FaEdit } from "react-icons/fa";
+import { IcoTrash } from "Theme/icons";
 import { MdCleaningServices } from "react-icons/md";
 import { toast } from "react-toastify";
 import { setTreeInitialized } from "redux/features/territoryTree/treeInitializeSlice";
@@ -114,7 +115,7 @@ export const EntityDetailHeaderRow: React.FC<EntityDetailHeaderRow> = ({
               size={ButtonSize.Medium}
               shape="square"
               color="primary"
-              icon={<FaTrashAlt size={13} />}
+              icon={<IcoTrash size={13} />}
               disabled={!mayBeRemoved}
               tooltipLabel={
                 mayBeRemoved

--- a/packages/client/src/pages/Main/containers/EntityDetailBox/EntityDetail/EntityDetailRelations/EntityDetailRelationTypeBlock/EntityDetailRelationTypeIcon/EntityDetailRelationTypeIconStyles.tsx
+++ b/packages/client/src/pages/Main/containers/EntityDetailBox/EntityDetail/EntityDetailRelations/EntityDetailRelationTypeBlock/EntityDetailRelationTypeIcon/EntityDetailRelationTypeIconStyles.tsx
@@ -17,5 +17,5 @@ export const StyledArrow = styled.span`
 `;
 export const StyledLabel = styled.div`
   color: ${({ theme }) => theme.color["info"]};
-  font-size: ${({ theme }) => theme.fontSize["s"]};
+  font-size: ${({ theme }) => theme.fontSize["base"]};
 `;

--- a/packages/client/src/pages/Main/containers/EntityDetailBox/EntityDetail/EntityDetailUsedInTable/EntityDetailStatementsTable/EntityDetailStatementsTable.tsx
+++ b/packages/client/src/pages/Main/containers/EntityDetailBox/EntityDetail/EntityDetailUsedInTable/EntityDetailStatementsTable/EntityDetailStatementsTable.tsx
@@ -6,16 +6,12 @@ import {
   IStatementActant,
   IStatementAction,
 } from "@inkvisitor/shared/types";
-import { Button, Table, TagGroup } from "components";
+import { Table, TagGroup } from "components";
 import { EntityTag } from "components/advanced";
 import { useSearchParams } from "hooks";
 import React, { useMemo } from "react";
-import { FaEdit } from "react-icons/fa";
 import { CellProps, Column } from "react-table";
-import {
-  StyledShortenedText,
-  StyledTableTextGridCell,
-} from "../EntityDetailUsedInTableStyles";
+import { StyledShortenedText, StyledTableTextGridCell } from "../EntityDetailUsedInTableStyles";
 
 type CellType = CellProps<IResponseUsedInStatement<EntityEnums.UsedInPosition>>;
 
@@ -26,16 +22,18 @@ interface EntityDetailStatementsTable {
   perPage?: number;
   disableRowClick?: boolean;
 }
-export const EntityDetailStatementsTable: React.FC<
-  EntityDetailStatementsTable
-> = ({ title, entities, useCases, perPage = 5, disableRowClick }) => {
+export const EntityDetailStatementsTable: React.FC<EntityDetailStatementsTable> = ({
+  title,
+  entities,
+  useCases,
+  perPage = 5,
+  disableRowClick,
+}) => {
   const { setStatementId, setTerritoryId } = useSearchParams();
 
   const data = useMemo(() => (useCases ? useCases : []), [useCases]);
 
-  const columns = useMemo<
-    Column<IResponseUsedInStatement<EntityEnums.UsedInPosition>>[]
-  >(
+  const columns = useMemo<Column<IResponseUsedInStatement<EntityEnums.UsedInPosition>>[]>(
     () => [
       {
         Header: "",
@@ -44,13 +42,7 @@ export const EntityDetailStatementsTable: React.FC<
           const useCase = row.original;
           const entityId = useCase.statement?.id;
           const entity = entityId ? entities[entityId] : false;
-          return (
-            <>
-              {entity && (
-                <EntityTag key={entity.id} entity={entity} showOnly="tag" />
-              )}
-            </>
-          );
+          return <>{entity && <EntityTag key={entity.id} entity={entity} showOnly="tag" />}</>;
         },
       },
       {
@@ -65,15 +57,7 @@ export const EntityDetailStatementsTable: React.FC<
             return entities[actantId];
           });
 
-          return (
-            <>
-              {subjectObjects ? (
-                <TagGroup definedEntities={subjectObjects} />
-              ) : (
-                <div />
-              )}
-            </>
-          );
+          return <>{subjectObjects ? <TagGroup definedEntities={subjectObjects} /> : <div />}</>;
         },
       },
       {
@@ -86,15 +70,7 @@ export const EntityDetailStatementsTable: React.FC<
             return entities[actionId];
           });
 
-          return (
-            <>
-              {actionObjects ? (
-                <TagGroup definedEntities={actionObjects} />
-              ) : (
-                <div />
-              )}
-            </>
-          );
+          return <>{actionObjects ? <TagGroup definedEntities={actionObjects} /> : <div />}</>;
         },
       },
       {
@@ -146,7 +122,7 @@ export const EntityDetailStatementsTable: React.FC<
         accessor: "position",
       },
     ],
-    [entities]
+    [entities],
   );
 
   return (

--- a/packages/client/src/pages/Main/containers/EntityDetailBox/EntityDetail/EntityDetailUsedInTable/EntityDetailUsedInDocumentsTable/EntityDetailUsedInDocumentsTable.tsx
+++ b/packages/client/src/pages/Main/containers/EntityDetailBox/EntityDetail/EntityDetailUsedInTable/EntityDetailUsedInDocumentsTable/EntityDetailUsedInDocumentsTable.tsx
@@ -11,7 +11,8 @@ import {
   EntityTag,
 } from "components/advanced";
 import React, { useMemo } from "react";
-import { FaAnchor, FaTrashAlt } from "react-icons/fa";
+import { FaAnchor } from "react-icons/fa";
+import { IcoTrash } from "Theme/icons";
 import { HiClipboardList } from "react-icons/hi";
 import { CellProps, Column } from "react-table";
 import { toast } from "react-toastify";
@@ -242,7 +243,7 @@ export const EntityDetailUsedInDocumentsTable: React.FC<
         Cell: ({ row }: CellType) => {
           return (
             <Button
-              icon={<FaTrashAlt />}
+              icon={<IcoTrash />}
               color="danger"
               inverted
               onClick={() =>

--- a/packages/client/src/pages/Main/containers/EntityDetailBox/EntityDetailBox.tsx
+++ b/packages/client/src/pages/Main/containers/EntityDetailBox/EntityDetailBox.tsx
@@ -48,7 +48,7 @@ export const EntityDetailBox: React.FC<EntityDetailBox> = ({ onTabOpen, maxTabs 
   const { data, error } = useQuery({
     queryKey: ["detail-tab-entities", detailIdArray],
     queryFn: async () => {
-      const res = await api.entitiesSearch({ entityIds: detailIdArray });
+      const res = await api.entitiesGet(detailIdArray);
       return res.data ?? [];
     },
     enabled: api.isLoggedIn() && detailIdArray.length > 0,

--- a/packages/client/src/pages/Main/containers/EntityDetailBox/EntityDetailBox.tsx
+++ b/packages/client/src/pages/Main/containers/EntityDetailBox/EntityDetailBox.tsx
@@ -1,6 +1,7 @@
 import { IResponseEntity } from "@inkvisitor/shared/types";
 import api from "api";
 import { useSearchParams } from "hooks";
+import { useDetailQuery } from "hooks/react-query";
 import React, { useCallback, useEffect, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { EntityDetail } from "./EntityDetail/EntityDetail";
@@ -111,18 +112,10 @@ export const EntityDetailBox: React.FC<EntityDetailBox> = ({ onTabOpen, maxTabs 
   }, [detailBoxMinimized]);
 
   const {
-    status,
     data: entity,
     error: entityError,
     isFetching,
-  } = useQuery({
-    queryKey: ["entity", selectedDetailId],
-    queryFn: async () => {
-      const res = await api.detailGet(selectedDetailId);
-      return res.data;
-    },
-    enabled: !!selectedDetailId && api.isLoggedIn(),
-  });
+  } = useDetailQuery(selectedDetailId);
 
   return (
     <>

--- a/packages/client/src/pages/Main/containers/EntityDetailBox/EntityDetailTab/EntityDetailTab.tsx
+++ b/packages/client/src/pages/Main/containers/EntityDetailBox/EntityDetailTab/EntityDetailTab.tsx
@@ -151,6 +151,9 @@ export const EntityDetailTab: React.FC<EntityDetailTab> = ({
         referenceElement={referenceElement}
         label={getEntityLabel(entity)}
         position="top"
+        // never sit center-right over the move/close buttons: prefer left,
+        // then bottom-right, before any horizontal-center fallback
+        fallbackPlacements={["left", "bottom-end", "bottom"]}
       />
     </>
   );

--- a/packages/client/src/pages/Main/containers/EntityReferenceTable/EntityReferenceTable.tsx
+++ b/packages/client/src/pages/Main/containers/EntityReferenceTable/EntityReferenceTable.tsx
@@ -155,7 +155,6 @@ export const EntityReferenceTable: React.FC<EntityReferenceTable> = ({
             inputWidth={editorWidthTooNarrow ? "full" : undefined}
             alwaysShowCreateModal={alwaysShowCreateModal}
             openDetailOnCreate={openDetailOnCreate}
-            territoryActants={[]}
             onSelected={(newSelectedId) => {
               onChange([...references, { id: uuidv4(), resource: newSelectedId, value: "" }], true);
               setAutoFocusField("value");
@@ -177,7 +176,6 @@ export const EntityReferenceTable: React.FC<EntityReferenceTable> = ({
             alwaysShowCreateModal={alwaysShowCreateModal}
             excludedEntityClasses={excludedSuggesterEntities}
             openDetailOnCreate={openDetailOnCreate}
-            territoryActants={[]}
             onSelected={(newSelectedId: string) => {
               onChange([...references, { id: uuidv4(), resource: "", value: newSelectedId }], true);
               setAutoFocusField("resource");

--- a/packages/client/src/pages/Main/containers/EntityReferenceTable/EntityReferenceTableResource.tsx
+++ b/packages/client/src/pages/Main/containers/EntityReferenceTable/EntityReferenceTableResource.tsx
@@ -78,7 +78,6 @@ export const EntityReferenceTableResource: React.FC<
           inputWidth={editorWidthTooNarrow ? "full" : 100}
           alwaysShowCreateModal={alwaysShowCreateModal}
           openDetailOnCreate={openDetailOnCreate}
-          territoryActants={[]}
           onSelected={(newSelectedId) => {
             handleChangeResource(reference.id, newSelectedId, true);
           }}

--- a/packages/client/src/pages/Main/containers/EntityReferenceTable/EntityReferenceTableRow.tsx
+++ b/packages/client/src/pages/Main/containers/EntityReferenceTable/EntityReferenceTableRow.tsx
@@ -3,7 +3,8 @@ import { Button } from "components";
 import { useTheme } from "hooks";
 import React, { useEffect, useRef } from "react";
 import { DragSourceMonitor, DropTargetMonitor, useDrag, useDrop } from "react-dnd";
-import { FaExternalLinkAlt, FaGripVertical, FaTrashAlt } from "react-icons/fa";
+import { FaExternalLinkAlt, FaGripVertical } from "react-icons/fa";
+import { IcoTrash } from "Theme/icons";
 import { DragItem, Identifier, ItemTypes } from "types";
 import { dndHoverFn } from "utils/utils";
 import { EntityReferenceTableResource } from "./EntityReferenceTableResource";
@@ -171,7 +172,7 @@ export const EntityReferenceTableRow: React.FC<EntityReferenceTableRow> = ({
                 key="delete"
                 tooltipLabel="remove reference row"
                 inverted
-                icon={<FaTrashAlt />}
+                icon={<IcoTrash />}
                 color="plain"
                 onClick={() => {
                   handleRemove(reference.id);

--- a/packages/client/src/pages/Main/containers/EntityReferenceTable/EntityReferenceTableValue.tsx
+++ b/packages/client/src/pages/Main/containers/EntityReferenceTable/EntityReferenceTableValue.tsx
@@ -87,7 +87,6 @@ export const EntityReferenceTableValue: React.FC<EntityReferenceTableValue> = ({
           placeholder={resourceEntity?.data?.partValueLabel}
           excludedEntityClasses={excludedSuggesterEntities}
           openDetailOnCreate={openDetailOnCreate}
-          territoryActants={[]}
           onSelected={(newSelectedId: string) => {
             handleChangeValue(reference.id, newSelectedId, true);
           }}

--- a/packages/client/src/pages/Main/containers/EntitySearchBox/EntitySearchBox.tsx
+++ b/packages/client/src/pages/Main/containers/EntitySearchBox/EntitySearchBox.tsx
@@ -39,6 +39,7 @@ import {
   StyledDropdownWithTypeBar,
 } from "./EntitySearchBoxStyles";
 import { EntitySearchResults } from "./EntitySearchResults/EntitySearchResults";
+import { BiSearch } from "react-icons/bi";
 
 const initSearchValues: IRequestSearch = {
   labelOrId: "",
@@ -341,35 +342,29 @@ export const EntitySearchBox: React.FC = () => {
       <StyledBoxContent>
         <StyledOptions $isUndersized={isUndersized}>
           <StyledRow>
-            <StyledRowHeader>label or uuid</StyledRowHeader>
-            <div
-              style={{
-                display: "grid",
-                gridTemplateColumns: "1fr auto",
-                width: "100%",
-              }}
-            >
-              <Input
-                width="full"
-                placeholder="type to search"
-                changeOnType
-                onChangeFn={(value: string) => handleChange({ labelOrId: value })}
-                clearable
-                rightContent={
-                  <>
-                    {userRole !== UserEnums.Role.Viewer && (
-                      <Button
-                        tooltipLabel="create entity"
-                        icon={<FaPlus />}
-                        onClick={() => setShowEntityCreateModal(true)}
-                        noBackground
-                        noBorder
-                        inverted
-                      />
-                    )}
-                  </>
-                }
-              />
+            <div style={{ gridColumn: "1 / -1" }}>
+            <Input
+              width="full"
+              icon={<BiSearch />}
+              placeholder="label or uuid"
+              changeOnType
+              onChangeFn={(value: string) => handleChange({ labelOrId: value })}
+              clearable
+              rightContent={
+                <>
+                  {userRole !== UserEnums.Role.Viewer && (
+                    <Button
+                      tooltipLabel="create entity"
+                      icon={<FaPlus />}
+                      onClick={() => setShowEntityCreateModal(true)}
+                      noBackground
+                      noBorder
+                      inverted
+                    />
+                  )}
+                </>
+              }
+            />
             </div>
           </StyledRow>
 

--- a/packages/client/src/pages/Main/containers/EntitySearchBox/EntitySearchBox.tsx
+++ b/packages/client/src/pages/Main/containers/EntitySearchBox/EntitySearchBox.tsx
@@ -39,7 +39,7 @@ import {
   StyledDropdownWithTypeBar,
 } from "./EntitySearchBoxStyles";
 import { EntitySearchResults } from "./EntitySearchResults/EntitySearchResults";
-import { BiSearch } from "react-icons/bi";
+import { IcoSearch } from "Theme/icons";
 
 const initSearchValues: IRequestSearch = {
   labelOrId: "",
@@ -345,7 +345,7 @@ export const EntitySearchBox: React.FC = () => {
             <div style={{ gridColumn: "1 / -1" }}>
             <Input
               width="full"
-              icon={<BiSearch />}
+              icon={<IcoSearch />}
               placeholder="label or uuid"
               changeOnType
               onChangeFn={(value: string) => handleChange({ labelOrId: value })}

--- a/packages/client/src/pages/Main/containers/EntitySearchBox/EntitySearchBox.tsx
+++ b/packages/client/src/pages/Main/containers/EntitySearchBox/EntitySearchBox.tsx
@@ -1,13 +1,14 @@
 import { entityStatusDict, languageDict } from "@inkvisitor/shared/dictionaries";
 import { entitiesDict } from "@inkvisitor/shared/dictionaries/entity";
 import { EntityEnums, SearchEnums, UserEnums } from "@inkvisitor/shared/enums";
-import { IEntity } from "@inkvisitor/shared/types";
+import { DropdownItem, IEntity } from "@inkvisitor/shared/types";
 import {
   IRequestSearch,
   IRequestSearchRootValidity,
 } from "@inkvisitor/shared/types/request-search";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { FOURTH_PANEL_MIN_WIDTH, wildCardChar } from "Theme/constants";
+import { IcoSearch } from "Theme/icons";
 import api from "api";
 import { Button, IconWithTooltip, Input, Loader, TypeBar } from "components";
 import Dropdown, {
@@ -22,10 +23,11 @@ import { FaPlus } from "react-icons/fa";
 import { RiCloseFill } from "react-icons/ri";
 import { setExpandedOptions } from "redux/features/entitySearch/expandedOptionsSlice";
 import { useAppDispatch, useAppSelector } from "redux/hooks";
-import { DropdownItem } from "@inkvisitor/shared/types";
 import { EntitySearchAdvancedOptions } from "./EntitySearchAdvancedOptions/EntitySearchAdvancedOptions";
 import {
   StyledBoxContent,
+  StyledCellMerge,
+  StyledDropdownWithTypeBar,
   StyledNoResults,
   StyledOptions,
   StyledPill,
@@ -36,10 +38,8 @@ import {
   StyledResultsWrapper,
   StyledRow,
   StyledRowHeader,
-  StyledDropdownWithTypeBar,
 } from "./EntitySearchBoxStyles";
 import { EntitySearchResults } from "./EntitySearchResults/EntitySearchResults";
-import { IcoSearch } from "Theme/icons";
 
 const initSearchValues: IRequestSearch = {
   labelOrId: "",
@@ -342,30 +342,30 @@ export const EntitySearchBox: React.FC = () => {
       <StyledBoxContent>
         <StyledOptions $isUndersized={isUndersized}>
           <StyledRow>
-            <div style={{ gridColumn: "1 / -1" }}>
-            <Input
-              width="full"
-              icon={<IcoSearch />}
-              placeholder="label or uuid"
-              changeOnType
-              onChangeFn={(value: string) => handleChange({ labelOrId: value })}
-              clearable
-              rightContent={
-                <>
-                  {userRole !== UserEnums.Role.Viewer && (
-                    <Button
-                      tooltipLabel="create entity"
-                      icon={<FaPlus />}
-                      onClick={() => setShowEntityCreateModal(true)}
-                      noBackground
-                      noBorder
-                      inverted
-                    />
-                  )}
-                </>
-              }
-            />
-            </div>
+            <StyledCellMerge>
+              <Input
+                width="full"
+                icon={<IcoSearch />}
+                placeholder="label or uuid"
+                changeOnType
+                onChangeFn={(value: string) => handleChange({ labelOrId: value })}
+                clearable
+                rightContent={
+                  <>
+                    {userRole !== UserEnums.Role.Viewer && (
+                      <Button
+                        tooltipLabel="create entity"
+                        icon={<FaPlus />}
+                        onClick={() => setShowEntityCreateModal(true)}
+                        noBackground
+                        noBorder
+                        inverted
+                      />
+                    )}
+                  </>
+                }
+              />
+            </StyledCellMerge>
           </StyledRow>
 
           <EntitySearchAdvancedOptions

--- a/packages/client/src/pages/Main/containers/EntitySearchBox/EntitySearchBoxStyles.tsx
+++ b/packages/client/src/pages/Main/containers/EntitySearchBox/EntitySearchBoxStyles.tsx
@@ -25,6 +25,9 @@ export const StyledRow = styled.div`
   align-items: center;
   margin-bottom: ${({ theme }) => theme.space[2]};
 `;
+export const StyledCellMerge = styled.div`
+  grid-column: 1 / -1;
+`;
 export const StyledAdvancedOptions = styled.div`
   display: flex;
   align-items: center;

--- a/packages/client/src/pages/Main/containers/EntitySearchBox/EntitySearchBoxStyles.tsx
+++ b/packages/client/src/pages/Main/containers/EntitySearchBox/EntitySearchBoxStyles.tsx
@@ -14,7 +14,9 @@ interface StyledOptionsProps {
   $isUndersized?: boolean;
 }
 export const StyledOptions = styled.div<StyledOptionsProps>`
-  margin-right: ${({ $isUndersized, theme }) => ($isUndersized ? theme.space[1] : theme.space[4])};
+  padding-top: 0.5rem;
+  padding-right: ${({ $isUndersized }) => ($isUndersized ? "0.5rem" : "1rem")};
+  padding-left: ${({ $isUndersized }) => ($isUndersized ? "0.5rem" : "1rem")};
 `;
 export const StyledRow = styled.div`
   position: relative;
@@ -30,7 +32,6 @@ export const StyledAdvancedOptions = styled.div`
   padding: 0 ${({ theme }) => theme.space[4]};
   height: 3rem;
   margin-bottom: 0.5rem;
-  margin-left: 0.7rem;
   border: 1px dashed ${({ theme }) => theme.color["gray"][300]};
   border-radius: 5rem;
   cursor: default;

--- a/packages/client/src/pages/Main/containers/PropGroup/FirstLevelPropGroupRow/FirstLevelPropGroupRow.tsx
+++ b/packages/client/src/pages/Main/containers/PropGroup/FirstLevelPropGroupRow/FirstLevelPropGroupRow.tsx
@@ -28,7 +28,7 @@ interface FirstLevelPropGroupRow {
   setInitValueTyped: (value: React.SetStateAction<string>) => void;
 
   userCanEdit: boolean;
-  territoryId: string;
+  territoryId?: string;
   entities: {
     [key: string]: IEntity;
   };

--- a/packages/client/src/pages/Main/containers/PropGroup/FirstLevelPropGroupRow/FirstLevelPropGroupRow.tsx
+++ b/packages/client/src/pages/Main/containers/PropGroup/FirstLevelPropGroupRow/FirstLevelPropGroupRow.tsx
@@ -28,7 +28,7 @@ interface FirstLevelPropGroupRow {
   setInitValueTyped: (value: React.SetStateAction<string>) => void;
 
   userCanEdit: boolean;
-  territoryActants: string[];
+  territoryId: string;
   entities: {
     [key: string]: IEntity;
   };
@@ -59,7 +59,7 @@ export const FirstLevelPropGroupRow: React.FC<FirstLevelPropGroupRow> = ({
   setInitValueTyped,
 
   userCanEdit,
-  territoryActants,
+  territoryId,
   entities,
   disabledAttributes,
   originId,
@@ -98,7 +98,7 @@ export const FirstLevelPropGroupRow: React.FC<FirstLevelPropGroupRow> = ({
         removeProp={removeProp}
         addProp={addProp}
         userCanEdit={userCanEdit}
-        territoryActants={territoryActants || []}
+        territoryId={territoryId}
         openDetailOnCreate={openDetailOnCreate}
         moveProp={moveProp}
         movePropToIndex={movePropToIndex}

--- a/packages/client/src/pages/Main/containers/PropGroup/PropGroup.tsx
+++ b/packages/client/src/pages/Main/containers/PropGroup/PropGroup.tsx
@@ -21,7 +21,8 @@ interface PropGroup {
   originId: string;
   entities: { [key: string]: IEntity };
   props: IProp[];
-  territoryId: string;
+  /** Only used to flag suggestions already in the territory (home icon); omit outside the StatementEditor. */
+  territoryId?: string;
   boxEntity: IResponseStatement | IResponseDetail;
 
   updateProp: (

--- a/packages/client/src/pages/Main/containers/PropGroup/PropGroup.tsx
+++ b/packages/client/src/pages/Main/containers/PropGroup/PropGroup.tsx
@@ -5,9 +5,7 @@ import {
   IResponseDetail,
   IResponseStatement,
 } from "@inkvisitor/shared/types";
-import { useQuery } from "@tanstack/react-query";
 import { excludedSuggesterEntities } from "Theme/constants";
-import api from "api";
 import { EntitySuggester } from "components/advanced";
 import React, { useCallback, useEffect, useState } from "react";
 import { DraggedPropRowCategory, ItemTypes, PropAttributeFilter } from "types";
@@ -76,25 +74,6 @@ export const PropGroup: React.FC<PropGroup> = ({
   alwaysShowCreateModal,
   disableSpareRow,
 }) => {
-  // territory query
-  const {
-    status,
-    data: territoryActants = [],
-    error,
-    isFetching,
-  } = useQuery({
-    queryKey: ["territoryActants", territoryId],
-    queryFn: async () => {
-      if (territoryId) {
-        const res = await api.entityIdsInTerritory(territoryId);
-        return res.data ?? [];
-      } else {
-        return [];
-      }
-    },
-    enabled: !!territoryId && api.isLoggedIn(),
-  });
-
   // this states are part of the spare row functionality
   const [tempTypeTyped, setTempTypeTyped] = useState("");
   const [tempValueTyped, setTempValueTyped] = useState("");
@@ -148,7 +127,7 @@ export const PropGroup: React.FC<PropGroup> = ({
           movePropToIndex={movePropToIndex}
           userCanEdit={userCanEdit}
           addPropWithEntityId={addPropWithEntityId}
-          territoryActants={territoryActants}
+          territoryId={territoryId}
           entities={entities}
           disabledAttributes={disabledAttributes}
           originId={originId}
@@ -202,7 +181,7 @@ export const PropGroup: React.FC<PropGroup> = ({
             removeProp={removeProp}
             addProp={addProp}
             userCanEdit={userCanEdit}
-            territoryActants={territoryActants || []}
+            territoryId={territoryId}
             openDetailOnCreate={openDetailOnCreate}
             moveProp={moveProp}
             movePropToIndex={movePropToIndex}
@@ -253,7 +232,7 @@ export const PropGroup: React.FC<PropGroup> = ({
             removeProp={removeProp}
             addProp={addProp}
             userCanEdit={userCanEdit}
-            territoryActants={territoryActants || []}
+            territoryId={territoryId}
             openDetailOnCreate={openDetailOnCreate}
             moveProp={moveProp}
             movePropToIndex={movePropToIndex}
@@ -290,7 +269,6 @@ export const PropGroup: React.FC<PropGroup> = ({
             placeholder="type"
             alwaysShowCreateModal={alwaysShowCreateModal}
             openDetailOnCreate={openDetailOnCreate}
-            territoryActants={[]}
             onSelected={(newSelectedId) => {
               if (addPropWithEntityId) {
                 addPropWithEntityId({ typeEntityId: newSelectedId });
@@ -314,7 +292,6 @@ export const PropGroup: React.FC<PropGroup> = ({
             alwaysShowCreateModal={alwaysShowCreateModal}
             excludedEntityClasses={excludedSuggesterEntities}
             openDetailOnCreate={openDetailOnCreate}
-            territoryActants={[]}
             onSelected={(newSelectedId: string) => {
               if (addPropWithEntityId) {
                 addPropWithEntityId({ valueEntityId: newSelectedId });

--- a/packages/client/src/pages/Main/containers/PropGroup/PropGroupRow/PropGroupRow.tsx
+++ b/packages/client/src/pages/Main/containers/PropGroup/PropGroupRow/PropGroupRow.tsx
@@ -51,7 +51,7 @@ interface PropGroupRow {
   movePropToIndex: (propId: string, oldIndex: number, newIndex: number) => void;
 
   userCanEdit: boolean;
-  territoryId: string;
+  territoryId?: string;
   openDetailOnCreate: boolean;
 
   parentId: string;

--- a/packages/client/src/pages/Main/containers/PropGroup/PropGroupRow/PropGroupRow.tsx
+++ b/packages/client/src/pages/Main/containers/PropGroup/PropGroupRow/PropGroupRow.tsx
@@ -50,7 +50,7 @@ interface PropGroupRow {
   movePropToIndex: (propId: string, oldIndex: number, newIndex: number) => void;
 
   userCanEdit: boolean;
-  territoryActants: string[];
+  territoryId: string;
   openDetailOnCreate: boolean;
 
   parentId: string;
@@ -82,7 +82,7 @@ export const PropGroupRow: React.FC<PropGroupRow> = ({
   moveProp,
   movePropToIndex,
   userCanEdit,
-  territoryActants = [],
+  territoryId,
   openDetailOnCreate = false,
   parentId,
   id,
@@ -209,7 +209,7 @@ export const PropGroupRow: React.FC<PropGroupRow> = ({
                 disabledAttributes={disabledAttributes}
                 isInsideTemplate={isInsideTemplate}
                 openDetailOnCreate={openDetailOnCreate}
-                territoryActants={territoryActants}
+                territoryId={territoryId}
                 territoryParentId={territoryParentId}
                 updateProp={updateProp}
                 userCanEdit={userCanEdit}
@@ -227,7 +227,7 @@ export const PropGroupRow: React.FC<PropGroupRow> = ({
               disabledAttributes={disabledAttributes}
               isInsideTemplate={isInsideTemplate}
               openDetailOnCreate={openDetailOnCreate}
-              territoryActants={territoryActants}
+              territoryId={territoryId}
               territoryParentId={territoryParentId}
               updateProp={updateProp}
               userCanEdit={userCanEdit}

--- a/packages/client/src/pages/Main/containers/PropGroup/PropGroupRow/PropGroupRow.tsx
+++ b/packages/client/src/pages/Main/containers/PropGroup/PropGroupRow/PropGroupRow.tsx
@@ -8,7 +8,8 @@ import {
   useDrag,
   useDrop,
 } from "react-dnd";
-import { FaPlus, FaTrashAlt } from "react-icons/fa";
+import { FaPlus } from "react-icons/fa";
+import { IcoTrash } from "Theme/icons";
 import { FaCaretDown } from "react-icons/fa6";
 import { setDraggedPropRow } from "redux/features/rowDnd/draggedPropRowSlice";
 import { useAppDispatch, useAppSelector } from "redux/hooks";
@@ -327,7 +328,7 @@ export const PropGroupRow: React.FC<PropGroupRow> = ({
                   {userCanEdit && (
                     <Button
                       key="delete"
-                      icon={<FaTrashAlt />}
+                      icon={<IcoTrash />}
                       tooltipLabel="remove prop row"
                       color="plain"
                       inverted

--- a/packages/client/src/pages/Main/containers/PropGroup/PropGroupRow/PropGroupRowType.tsx
+++ b/packages/client/src/pages/Main/containers/PropGroup/PropGroupRow/PropGroupRowType.tsx
@@ -29,7 +29,7 @@ interface PropGroupRowType {
   userCanEdit: boolean;
   isInsideTemplate: boolean;
   territoryParentId?: string;
-  territoryActants: string[];
+  territoryId: string;
   isExpanded: boolean;
   disabledAttributes: PropAttributeFilter;
   openDetailOnCreate: boolean;
@@ -44,7 +44,7 @@ export const PropGroupRowType: React.FC<PropGroupRowType> = ({
   userCanEdit,
   isInsideTemplate,
   territoryParentId,
-  territoryActants,
+  territoryId,
   isExpanded,
   disabledAttributes,
   openDetailOnCreate,
@@ -132,7 +132,7 @@ export const PropGroupRowType: React.FC<PropGroupRowType> = ({
           </>
         ) : (
           <EntitySuggester
-            territoryActants={territoryActants}
+            territoryId={territoryId}
             onSelected={(newSelectedId: string) => {
               updateProp(
                 prop.id,

--- a/packages/client/src/pages/Main/containers/PropGroup/PropGroupRow/PropGroupRowType.tsx
+++ b/packages/client/src/pages/Main/containers/PropGroup/PropGroupRow/PropGroupRowType.tsx
@@ -29,7 +29,7 @@ interface PropGroupRowType {
   userCanEdit: boolean;
   isInsideTemplate: boolean;
   territoryParentId?: string;
-  territoryId: string;
+  territoryId?: string;
   isExpanded: boolean;
   disabledAttributes: PropAttributeFilter;
   openDetailOnCreate: boolean;

--- a/packages/client/src/pages/Main/containers/PropGroup/PropGroupRow/PropGroupRowValue.tsx
+++ b/packages/client/src/pages/Main/containers/PropGroup/PropGroupRow/PropGroupRowValue.tsx
@@ -29,7 +29,7 @@ interface PropGroupRowValue {
   userCanEdit: boolean;
   isInsideTemplate: boolean;
   territoryParentId?: string;
-  territoryId: string;
+  territoryId?: string;
   isExpanded: boolean;
   disabledAttributes: PropAttributeFilter;
   openDetailOnCreate: boolean;

--- a/packages/client/src/pages/Main/containers/PropGroup/PropGroupRow/PropGroupRowValue.tsx
+++ b/packages/client/src/pages/Main/containers/PropGroup/PropGroupRow/PropGroupRowValue.tsx
@@ -29,7 +29,7 @@ interface PropGroupRowValue {
   userCanEdit: boolean;
   isInsideTemplate: boolean;
   territoryParentId?: string;
-  territoryActants: string[];
+  territoryId: string;
   isExpanded: boolean;
   disabledAttributes: PropAttributeFilter;
   openDetailOnCreate: boolean;
@@ -45,7 +45,7 @@ export const PropGroupRowValue: React.FC<PropGroupRowValue> = ({
   userCanEdit,
   isInsideTemplate,
   territoryParentId,
-  territoryActants,
+  territoryId,
   isExpanded,
   disabledAttributes,
   openDetailOnCreate,
@@ -133,7 +133,7 @@ export const PropGroupRowValue: React.FC<PropGroupRowValue> = ({
           </>
         ) : (
           <EntitySuggester
-            territoryActants={territoryActants}
+            territoryId={territoryId}
             onSelected={(newSelectedId: string) => {
               updateProp(
                 prop.id,

--- a/packages/client/src/pages/Main/containers/StatementEditorBox/StatementEditor/StatementEditor.tsx
+++ b/packages/client/src/pages/Main/containers/StatementEditorBox/StatementEditor/StatementEditor.tsx
@@ -196,6 +196,19 @@ export const StatementEditor: React.FC<StatementEditor> = ({
     enabled: !!statementId && !!statementTerritoryId,
   });
 
+  // territoryData already carries every entity referenced by the territory's
+  // statements - the same set api.entityIdsInTerritory returns. Seed the shared
+  // ["territoryActants"] cache from it so the EntitySuggesters in this editor
+  // resolve the home-icon ids from cache instead of firing a redundant request.
+  useEffect(() => {
+    if (statementTerritoryId && territoryData) {
+      queryClient.setQueryData(
+        ["territoryActants", statementTerritoryId],
+        Object.keys(territoryData.entities),
+      );
+    }
+  }, [statementTerritoryId, territoryData]);
+
   // get data for the previous statement
   const previousStatement: false | IResponseStatement = useMemo(() => {
     if (territoryData) {

--- a/packages/client/src/pages/Main/containers/StatementEditorBox/StatementEditor/StatementEditor.tsx
+++ b/packages/client/src/pages/Main/containers/StatementEditorBox/StatementEditor/StatementEditor.tsx
@@ -119,25 +119,6 @@ export const StatementEditor: React.FC<StatementEditor> = ({
   const username: string = useAppSelector((state) => state.username);
   const { data: user } = useUserQuery();
 
-  // territory query
-  const {
-    status,
-    data: territoryActants = [],
-    error,
-    isFetching,
-  } = useQuery({
-    queryKey: ["territoryActants", statement.data.territory?.territoryId],
-    queryFn: async () => {
-      if (statement.data.territory?.territoryId) {
-        const res = await api.entityIdsInTerritory(statement.data.territory.territoryId);
-        return res.data ?? [];
-      } else {
-        return [];
-      }
-    },
-    enabled: !!statement.data.territory?.territoryId && api.isLoggedIn(),
-  });
-
   // TEMPLATES
   const [showApplyTemplateModal, setShowApplyTemplateModal] = useState<boolean>(false);
   const [templateToApply, setTemplateToApply] = useState<IEntity | false>(false);
@@ -808,12 +789,11 @@ export const StatementEditor: React.FC<StatementEditor> = ({
               removeProp={removeProp}
               movePropToIndex={movePropToIndex}
               territoryParentId={statementTerritoryId}
-              territoryActants={territoryActants}
               handleDataAttributeChange={handleDataAttributeChange}
             />
             {userCanEdit && (
               <EntitySuggester
-                territoryActants={territoryActants}
+                territoryId={statementTerritoryId}
                 openDetailOnCreate
                 onSelected={(newSelectedId: string) => {
                   addAction(newSelectedId);
@@ -864,12 +844,11 @@ export const StatementEditor: React.FC<StatementEditor> = ({
               territoryParentId={statementTerritoryId}
               addClassification={addClassification}
               addIdentification={addIdentification}
-              territoryActants={territoryActants}
               handleDataAttributeChange={handleDataAttributeChange}
             />
             {userCanEdit && (
               <EntitySuggester
-                territoryActants={territoryActants}
+                territoryId={statementTerritoryId}
                 openDetailOnCreate
                 onSelected={addActant}
                 categoryTypes={classesEditorActants}
@@ -953,7 +932,7 @@ export const StatementEditor: React.FC<StatementEditor> = ({
             </StyledTagsList>
             {userCanEdit && (
               <EntitySuggester
-                territoryActants={territoryActants}
+                territoryId={statementTerritoryId}
                 openDetailOnCreate
                 onSelected={(newSelectedId: string) => {
                   if (!statement.data.tags.find((t) => t === newSelectedId)) {

--- a/packages/client/src/pages/Main/containers/StatementEditorBox/StatementEditor/StatementEditor.tsx
+++ b/packages/client/src/pages/Main/containers/StatementEditorBox/StatementEditor/StatementEditor.tsx
@@ -33,7 +33,7 @@ import {
 } from "constructors";
 import { useIsInViewport, useSearchParams, useTheme } from "hooks";
 import useAnnotator from "hooks/useAnnotator";
-import React, { useEffect, useMemo, useRef, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import { AiOutlineCaretRight, AiOutlineWarning } from "react-icons/ai";
 import { FaAnchor, FaRegCopy } from "react-icons/fa";
 import { toast } from "react-toastify";
@@ -111,8 +111,7 @@ export const StatementEditor: React.FC<StatementEditor> = ({
   const theme = useTheme();
 
   // Audit query - only fetched once the Audits section scrolls into view
-  const auditSectionRef = useRef<HTMLDivElement>(null);
-  const auditInViewport = useIsInViewport(auditSectionRef, "200px");
+  const [auditSectionRef, auditInViewport] = useIsInViewport("200px");
   const { data: audit } = useAuditQuery(statementId, auditInViewport);
 
   // user query

--- a/packages/client/src/pages/Main/containers/StatementEditorBox/StatementEditor/StatementEditor.tsx
+++ b/packages/client/src/pages/Main/containers/StatementEditorBox/StatementEditor/StatementEditor.tsx
@@ -169,7 +169,6 @@ export const StatementEditor: React.FC<StatementEditor> = ({
     return options;
   }, [templates, statement]);
 
-
   // stores territory id
   const statementTerritoryId: string | undefined = useMemo(() => {
     return statement.data.territory?.territoryId;
@@ -196,9 +195,7 @@ export const StatementEditor: React.FC<StatementEditor> = ({
     enabled: !!statementId && !!statementTerritoryId,
   });
 
-  // territoryData already carries every entity referenced by the territory's
-  // statements - the same set api.entityIdsInTerritory returns. Seed the shared
-  // ["territoryActants"] cache from it so the EntitySuggesters in this editor
+  // Seed the shared ["territoryActants"] cache for EntitySuggester in this editor
   // resolve the home-icon ids from cache instead of firing a redundant request.
   useEffect(() => {
     if (statementTerritoryId && territoryData) {

--- a/packages/client/src/pages/Main/containers/StatementEditorBox/StatementEditor/StatementEditor.tsx
+++ b/packages/client/src/pages/Main/containers/StatementEditorBox/StatementEditor/StatementEditor.tsx
@@ -165,7 +165,19 @@ export const StatementEditor: React.FC<StatementEditor> = ({
     }
   };
 
-  const { data: allTemplates } = useTemplatesQuery();
+  const {
+    data: allTemplates,
+    isStale: templatesStale,
+    refetch: refetchTemplates,
+  } = useTemplatesQuery();
+
+  // refresh the template list when the user opens the dropdown, but only once
+  // the 5min staleTime has elapsed - avoids refetching on every open
+  const handleTemplateDropdownFocus = () => {
+    if (templatesStale) {
+      refetchTemplates();
+    }
+  };
 
   const templates = useMemo(
     () =>
@@ -676,6 +688,7 @@ export const StatementEditor: React.FC<StatementEditor> = ({
                   width="full"
                   value={null}
                   options={templateOptions}
+                  onFocus={handleTemplateDropdownFocus}
                   onChange={(templateToApply) => {
                     handleAskForTemplateApply(templateToApply);
                   }}

--- a/packages/client/src/pages/Main/containers/StatementEditorBox/StatementEditor/StatementEditor.tsx
+++ b/packages/client/src/pages/Main/containers/StatementEditorBox/StatementEditor/StatementEditor.tsx
@@ -31,9 +31,9 @@ import {
   CStatementActant,
   CStatementAction,
 } from "constructors";
-import { useSearchParams, useTheme } from "hooks";
+import { useIsInViewport, useSearchParams, useTheme } from "hooks";
 import useAnnotator from "hooks/useAnnotator";
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import { AiOutlineCaretRight, AiOutlineWarning } from "react-icons/ai";
 import { FaAnchor, FaRegCopy } from "react-icons/fa";
 import { toast } from "react-toastify";
@@ -72,7 +72,7 @@ import {
 import { StatementEditorActantTable } from "./StatementEditorActantTable/StatementEditorActantTable";
 import { StatementEditorActionTable } from "./StatementEditorActionTable/StatementEditorActionTable";
 import { StatementEditorSectionButtons } from "./StatementEditorSectionButtons/StatementEditorSectionButtons";
-import { useTemplatesQuery, useUserQuery } from "hooks/react-query";
+import { useAuditQuery, useTemplatesQuery, useUserQuery } from "hooks/react-query";
 
 const valencyErrorTypes: WarningTypeEnums[] = [
   WarningTypeEnums.MA,
@@ -110,20 +110,10 @@ export const StatementEditor: React.FC<StatementEditor> = ({
   const queryClient = useQueryClient();
   const theme = useTheme();
 
-  // Audit query
-  const {
-    status: statusAudit,
-    data: audit,
-    error: auditError,
-    isFetching: isFetchingAudit,
-  } = useQuery({
-    queryKey: ["audit", statementId],
-    queryFn: async () => {
-      const res = await api.auditGet(statementId);
-      return res.data;
-    },
-    enabled: !!statementId && api.isLoggedIn(),
-  });
+  // Audit query - only fetched once the Audits section scrolls into view
+  const auditSectionRef = useRef<HTMLDivElement>(null);
+  const auditInViewport = useIsInViewport(auditSectionRef, "200px");
+  const { data: audit } = useAuditQuery(statementId, auditInViewport);
 
   // user query
   const username: string = useAppSelector((state) => state.username);
@@ -198,10 +188,6 @@ export const StatementEditor: React.FC<StatementEditor> = ({
     return options;
   }, [templates, statement]);
 
-  // refetch audit when statement changes
-  useEffect(() => {
-    queryClient.invalidateQueries({ queryKey: ["audit"] });
-  }, [statement]);
 
   // stores territory id
   const statementTerritoryId: string | undefined = useMemo(() => {
@@ -1016,7 +1002,7 @@ export const StatementEditor: React.FC<StatementEditor> = ({
           <StyledEditorSectionHeader>
             <StyledEditorSectionHeading>Audits</StyledEditorSectionHeading>
           </StyledEditorSectionHeader>
-          <StyledEditorSectionContent>
+          <StyledEditorSectionContent ref={auditSectionRef}>
             {audit && <AuditTable {...audit} />}
           </StyledEditorSectionContent>
         </StyledEditorSection>

--- a/packages/client/src/pages/Main/containers/StatementEditorBox/StatementEditor/StatementEditor.tsx
+++ b/packages/client/src/pages/Main/containers/StatementEditorBox/StatementEditor/StatementEditor.tsx
@@ -72,7 +72,7 @@ import {
 import { StatementEditorActantTable } from "./StatementEditorActantTable/StatementEditorActantTable";
 import { StatementEditorActionTable } from "./StatementEditorActionTable/StatementEditorActionTable";
 import { StatementEditorSectionButtons } from "./StatementEditorSectionButtons/StatementEditorSectionButtons";
-import { useUserQuery } from "hooks/react-query";
+import { useTemplatesQuery, useUserQuery } from "hooks/react-query";
 
 const valencyErrorTypes: WarningTypeEnums[] = [
   WarningTypeEnums.MA,
@@ -165,27 +165,13 @@ export const StatementEditor: React.FC<StatementEditor> = ({
     }
   };
 
-  const {
-    status: templateStatus,
-    data: templates,
-    error: templateError,
-    isFetching: isFetchingTemplates,
-  } = useQuery({
-    queryKey: ["statement-templates"],
-    queryFn: async () => {
-      const res = await api.entitiesSearch({
-        onlyTemplates: true,
-        class: EntityEnums.Class.Statement,
-      });
+  const { data: allTemplates } = useTemplatesQuery();
 
-      const templates = res.data ?? [];
-      templates.sort((a: IEntity, b: IEntity) =>
-        a.labels[0].toLocaleLowerCase() > b.labels[0].toLocaleLowerCase() ? 1 : -1,
-      );
-      return templates;
-    },
-    enabled: !!statement && api.isLoggedIn(),
-  });
+  const templates = useMemo(
+    () =>
+      allTemplates?.filter((template: IEntity) => template.class === EntityEnums.Class.Statement),
+    [allTemplates],
+  );
 
   const templateOptions: DropdownItem[] = useMemo(() => {
     const options = templates

--- a/packages/client/src/pages/Main/containers/StatementEditorBox/StatementEditor/StatementEditorActantTable/StatementEditorActantClassification/StatementEditorActantClassification.tsx
+++ b/packages/client/src/pages/Main/containers/StatementEditorBox/StatementEditor/StatementEditorActantTable/StatementEditorActantClassification/StatementEditorActantClassification.tsx
@@ -16,7 +16,7 @@ import Dropdown, {
 } from "components/advanced";
 import { TooltipAttributes } from "pages/Main/containers";
 import React, { useState } from "react";
-import { FaTrashAlt } from "react-icons/fa";
+import { IcoTrash } from "Theme/icons";
 import { FaCaretDown } from "react-icons/fa6";
 import { AttributeData } from "types";
 import {
@@ -168,7 +168,7 @@ export const StatementEditorActantClassification: React.FC<
         {userCanEdit && (
           <Button
             key="d"
-            icon={<FaTrashAlt />}
+            icon={<IcoTrash />}
             color="plain"
             inverted
             tooltipLabel="remove classification row"

--- a/packages/client/src/pages/Main/containers/StatementEditorBox/StatementEditor/StatementEditorActantTable/StatementEditorActantClassification/StatementEditorActantClassification.tsx
+++ b/packages/client/src/pages/Main/containers/StatementEditorBox/StatementEditor/StatementEditorActantTable/StatementEditorActantClassification/StatementEditorActantClassification.tsx
@@ -39,7 +39,7 @@ interface StatementEditorActantClassification {
   isInsideTemplate: boolean;
   territoryParentId?: string;
   sActant: IStatementActant;
-  territoryActants?: string[];
+  territoryId?: string;
 }
 export const StatementEditorActantClassification: React.FC<
   StatementEditorActantClassification
@@ -52,7 +52,7 @@ export const StatementEditorActantClassification: React.FC<
   userCanEdit,
   isInsideTemplate,
   territoryParentId,
-  territoryActants,
+  territoryId,
 }) => {
   const entity = statement.entities[classification.entityId];
 
@@ -117,7 +117,7 @@ export const StatementEditorActantClassification: React.FC<
               }}
               openDetailOnCreate
               isInsideTemplate={isInsideTemplate}
-              territoryActants={territoryActants}
+              territoryId={territoryId}
               isHidden={!userCanEdit}
             />
           </StyledSuggesterWrap>

--- a/packages/client/src/pages/Main/containers/StatementEditorBox/StatementEditor/StatementEditorActantTable/StatementEditorActantIdentification/StatementEditorActantIdentification.tsx
+++ b/packages/client/src/pages/Main/containers/StatementEditorBox/StatementEditor/StatementEditorActantTable/StatementEditorActantIdentification/StatementEditorActantIdentification.tsx
@@ -41,7 +41,7 @@ interface StatementEditorActantIdentification {
   territoryParentId?: string;
   sActant: IStatementActant;
   classEntitiesActant: EntityEnums.Class[];
-  territoryActants?: string[];
+  territoryId?: string;
 }
 export const StatementEditorActantIdentification: React.FC<
   StatementEditorActantIdentification
@@ -55,7 +55,7 @@ export const StatementEditorActantIdentification: React.FC<
   territoryParentId,
   sActant,
   classEntitiesActant,
-  territoryActants,
+  territoryId,
 }) => {
   const entity = statement.entities[identification.entityId];
 
@@ -121,7 +121,7 @@ export const StatementEditorActantIdentification: React.FC<
               }}
               openDetailOnCreate
               isInsideTemplate={isInsideTemplate}
-              territoryActants={territoryActants}
+              territoryId={territoryId}
               excludedEntityClasses={excludedSuggesterEntities}
               isHidden={!userCanEdit}
             />

--- a/packages/client/src/pages/Main/containers/StatementEditorBox/StatementEditor/StatementEditorActantTable/StatementEditorActantIdentification/StatementEditorActantIdentification.tsx
+++ b/packages/client/src/pages/Main/containers/StatementEditorBox/StatementEditor/StatementEditorActantTable/StatementEditorActantIdentification/StatementEditorActantIdentification.tsx
@@ -17,7 +17,7 @@ import Dropdown, {
 } from "components/advanced";
 import { TooltipAttributes } from "pages/Main/containers";
 import React, { useState } from "react";
-import { FaTrashAlt } from "react-icons/fa";
+import { IcoTrash } from "Theme/icons";
 import { FaCaretDown } from "react-icons/fa6";
 import { AttributeData } from "types";
 import {
@@ -173,7 +173,7 @@ export const StatementEditorActantIdentification: React.FC<
         {userCanEdit && (
           <Button
             key="d"
-            icon={<FaTrashAlt />}
+            icon={<IcoTrash />}
             color="plain"
             inverted
             tooltipLabel="remove identification row"

--- a/packages/client/src/pages/Main/containers/StatementEditorBox/StatementEditor/StatementEditorActantTable/StatementEditorActantTable.tsx
+++ b/packages/client/src/pages/Main/containers/StatementEditorBox/StatementEditor/StatementEditorActantTable/StatementEditorActantTable.tsx
@@ -22,7 +22,6 @@ interface StatementEditorActantTable {
   territoryParentId?: string;
   addClassification: (originId: string) => void;
   addIdentification: (originId: string) => void;
-  territoryActants?: string[];
 
   handleDataAttributeChange: (
     changes: Partial<IStatementData>,
@@ -42,7 +41,6 @@ export const StatementEditorActantTable: React.FC<
   territoryParentId,
   addClassification,
   addIdentification,
-  territoryActants,
 
   handleDataAttributeChange,
 }) => {
@@ -104,7 +102,6 @@ export const StatementEditorActantTable: React.FC<
                 territoryParentId={territoryParentId}
                 addClassification={addClassification}
                 addIdentification={addIdentification}
-                territoryActants={territoryActants}
                 hasOrder={filteredActants.length > 1}
                 handleDataAttributeChange={handleDataAttributeChange}
               />

--- a/packages/client/src/pages/Main/containers/StatementEditorBox/StatementEditor/StatementEditorActantTable/StatementEditorActantTableRow.tsx
+++ b/packages/client/src/pages/Main/containers/StatementEditorBox/StatementEditor/StatementEditorActantTable/StatementEditorActantTableRow.tsx
@@ -92,7 +92,6 @@ export const StatementEditorActantTableRow: React.FC<StatementEditorActantTableR
   const dispatch = useAppDispatch();
 
   const isInsideTemplate = statement.isTemplate || false;
-  const { statementId, territoryId } = useSearchParams();
   // the statement's own territory - may differ from the URL territoryId, so the
   // suggester home icon is keyed off the statement, not the opened territory.
   const statementTerritoryId = statement.data.territory?.territoryId;
@@ -332,7 +331,7 @@ export const StatementEditorActantTableRow: React.FC<StatementEditorActantTableR
             originId={originActant ? originActant.id : ""}
             entities={statement.entities}
             props={props}
-            territoryId={territoryId}
+            territoryId={statementTerritoryId}
             updateProp={updateProp}
             removeProp={removeProp}
             addProp={addProp}

--- a/packages/client/src/pages/Main/containers/StatementEditorBox/StatementEditor/StatementEditorActantTable/StatementEditorActantTableRow.tsx
+++ b/packages/client/src/pages/Main/containers/StatementEditorBox/StatementEditor/StatementEditorActantTable/StatementEditorActantTableRow.tsx
@@ -262,7 +262,7 @@ export const StatementEditorActantTableRow: React.FC<StatementEditorActantTableR
     const { entityId: propOriginId, id: propRowId } = sActant;
 
     return (
-      <ButtonGroup $noMarginRight $height={19} style={{ gap: "0.2rem" }}>
+      <ButtonGroup $smallGap $height={19}>
         {userCanEdit && (
           <Button
             key="a"

--- a/packages/client/src/pages/Main/containers/StatementEditorBox/StatementEditor/StatementEditorActantTable/StatementEditorActantTableRow.tsx
+++ b/packages/client/src/pages/Main/containers/StatementEditorBox/StatementEditor/StatementEditorActantTable/StatementEditorActantTableRow.tsx
@@ -63,7 +63,6 @@ interface StatementEditorActantTableRow {
   territoryParentId?: string;
   addClassification: (originId: string) => void;
   addIdentification: (originId: string) => void;
-  territoryActants?: string[];
   hasOrder?: boolean;
 
   handleDataAttributeChange: (changes: Partial<IStatementData>, instantUpdate?: boolean) => void;
@@ -84,7 +83,6 @@ export const StatementEditorActantTableRow: React.FC<StatementEditorActantTableR
   territoryParentId,
   addClassification,
   addIdentification,
-  territoryActants,
   hasOrder,
 
   handleDataAttributeChange,
@@ -94,6 +92,9 @@ export const StatementEditorActantTableRow: React.FC<StatementEditorActantTableR
 
   const isInsideTemplate = statement.isTemplate || false;
   const { statementId, territoryId } = useSearchParams();
+  // the statement's own territory - may differ from the URL territoryId, so the
+  // suggester home icon is keyed off the statement, not the opened territory.
+  const statementTerritoryId = statement.data.territory?.territoryId;
   const {
     actant,
     sActant,
@@ -234,7 +235,7 @@ export const StatementEditorActantTableRow: React.FC<StatementEditorActantTableR
           excludedEntityClasses={excludedSuggesterEntities}
           isInsideTemplate={isInsideTemplate}
           territoryParentId={territoryParentId}
-          territoryActants={territoryActants}
+          territoryId={statementTerritoryId}
           placeholder={"add actant"}
           isInsideStatement
           isHidden={!userCanEdit}
@@ -532,7 +533,7 @@ export const StatementEditorActantTableRow: React.FC<StatementEditorActantTableR
                     isInsideTemplate={isInsideTemplate}
                     updateActant={updateActant}
                     userCanEdit={userCanEdit}
-                    territoryActants={territoryActants}
+                    territoryId={statementTerritoryId}
                   />
                 ))}
             </StyledCI>
@@ -555,7 +556,7 @@ export const StatementEditorActantTableRow: React.FC<StatementEditorActantTableR
                     updateActant={updateActant}
                     userCanEdit={userCanEdit}
                     classEntitiesActant={classEntitiesActant}
-                    territoryActants={territoryActants}
+                    territoryId={statementTerritoryId}
                   />
                 ))}
             </StyledCI>

--- a/packages/client/src/pages/Main/containers/StatementEditorBox/StatementEditor/StatementEditorActantTable/StatementEditorActantTableRow.tsx
+++ b/packages/client/src/pages/Main/containers/StatementEditorBox/StatementEditor/StatementEditorActantTable/StatementEditorActantTableRow.tsx
@@ -21,7 +21,8 @@ import { useSearchParams, useTheme } from "hooks";
 import { TooltipAttributes } from "pages/Main/containers";
 import React, { useCallback, useEffect, useRef, useState } from "react";
 import { DragSourceMonitor, DropTargetMonitor, useDrag, useDrop } from "react-dnd";
-import { FaCaretDown, FaGripVertical, FaPlus, FaTrashAlt } from "react-icons/fa";
+import { FaCaretDown, FaGripVertical, FaPlus } from "react-icons/fa";
+import { IcoTrash } from "Theme/icons";
 import { setDraggedActantRow } from "redux/features/rowDnd/draggedActantRowSlice";
 import { useAppDispatch, useAppSelector } from "redux/hooks";
 import {
@@ -421,7 +422,7 @@ export const StatementEditorActantTableRow: React.FC<StatementEditorActantTableR
               {userCanEdit && (
                 <Button
                   key="d"
-                  icon={<FaTrashAlt />}
+                  icon={<IcoTrash />}
                   color="plain"
                   inverted
                   tooltipLabel="remove actant row"

--- a/packages/client/src/pages/Main/containers/StatementEditorBox/StatementEditor/StatementEditorActionTable/StatementEditorActionTable.tsx
+++ b/packages/client/src/pages/Main/containers/StatementEditorBox/StatementEditor/StatementEditorActionTable/StatementEditorActionTable.tsx
@@ -18,7 +18,6 @@ interface StatementEditorActionTable {
   removeProp: (propId: string) => void;
   movePropToIndex: (propId: string, oldIndex: number, newIndex: number) => void;
   territoryParentId?: string;
-  territoryActants?: string[];
 
   handleDataAttributeChange: (
     changes: Partial<IStatementData>,
@@ -35,7 +34,6 @@ export const StatementEditorActionTable: React.FC<
   removeProp,
   movePropToIndex,
   territoryParentId,
-  territoryActants,
 
   handleDataAttributeChange,
 }) => {
@@ -95,7 +93,6 @@ export const StatementEditorActionTable: React.FC<
                 removeProp={removeProp}
                 movePropToIndex={movePropToIndex}
                 territoryParentId={territoryParentId}
-                territoryActants={territoryActants}
                 hasOrder={filteredActions.length > 1}
                 handleDataAttributeChange={handleDataAttributeChange}
               />

--- a/packages/client/src/pages/Main/containers/StatementEditorBox/StatementEditor/StatementEditorActionTable/StatementEditorActionTableRow.tsx
+++ b/packages/client/src/pages/Main/containers/StatementEditorBox/StatementEditor/StatementEditorActionTable/StatementEditorActionTableRow.tsx
@@ -21,7 +21,8 @@ import { TooltipAttributes } from "pages/Main/containers";
 import { PropGroup } from "pages/Main/containers/PropGroup/PropGroup";
 import React, { useCallback, useEffect, useRef, useState } from "react";
 import { DragSourceMonitor, DropTargetMonitor, useDrag, useDrop } from "react-dnd";
-import { FaGripVertical, FaPlus, FaTrashAlt } from "react-icons/fa";
+import { FaGripVertical, FaPlus } from "react-icons/fa";
+import { IcoTrash } from "Theme/icons";
 import { FaCaretDown } from "react-icons/fa6";
 import { setDraggedActantRow } from "redux/features/rowDnd/draggedActantRowSlice";
 import { useAppDispatch, useAppSelector } from "redux/hooks";
@@ -378,7 +379,7 @@ export const StatementEditorActionTableRow: React.FC<StatementEditorActionTableR
               {userCanEdit && (
                 <Button
                   key="d"
-                  icon={<FaTrashAlt />}
+                  icon={<IcoTrash />}
                   color="plain"
                   inverted
                   tooltipLabel="remove action row"

--- a/packages/client/src/pages/Main/containers/StatementEditorBox/StatementEditor/StatementEditorActionTable/StatementEditorActionTableRow.tsx
+++ b/packages/client/src/pages/Main/containers/StatementEditorBox/StatementEditor/StatementEditorActionTable/StatementEditorActionTableRow.tsx
@@ -54,7 +54,6 @@ interface StatementEditorActionTableRow {
   removeProp: (propId: string) => void;
   movePropToIndex: (propId: string, oldIndex: number, newIndex: number) => void;
   territoryParentId?: string;
-  territoryActants?: string[];
   hasOrder?: boolean;
 
   handleDataAttributeChange: (changes: Partial<IStatementData>, instantUpdate?: boolean) => void;
@@ -72,13 +71,15 @@ export const StatementEditorActionTableRow: React.FC<StatementEditorActionTableR
   removeProp,
   movePropToIndex,
   territoryParentId,
-  territoryActants,
   hasOrder,
 
   handleDataAttributeChange,
 }) => {
   const isInsideTemplate = statement.isTemplate || false;
   const { statementId, territoryId } = useSearchParams();
+  // the statement's own territory - may differ from the URL territoryId, so the
+  // suggester home icon is keyed off the statement, not the opened territory.
+  const statementTerritoryId = statement.data.territory?.territoryId;
   const { action, sAction } = filteredAction.data;
 
   const dropRef = useRef<HTMLTableRowElement>(null);
@@ -192,7 +193,7 @@ export const StatementEditorActionTableRow: React.FC<StatementEditorActionTableR
           placeholder={"add action"}
           isInsideTemplate={isInsideTemplate}
           territoryParentId={territoryParentId}
-          territoryActants={territoryActants}
+          territoryId={statementTerritoryId}
           isHidden={!userCanEdit}
         />
       </StyledSuggesterWrap>

--- a/packages/client/src/pages/Main/containers/StatementEditorBox/StatementEditor/StatementEditorActionTable/StatementEditorActionTableRow.tsx
+++ b/packages/client/src/pages/Main/containers/StatementEditorBox/StatementEditor/StatementEditorActionTable/StatementEditorActionTableRow.tsx
@@ -203,7 +203,7 @@ export const StatementEditorActionTableRow: React.FC<StatementEditorActionTableR
     const { actionId: propOriginId, id: rowId } = sAction;
 
     return (
-      <ButtonGroup $noMarginRight $height={19} style={{ gap: "0.2rem" }}>
+      <ButtonGroup $smallGap $height={19}>
         {userCanEdit && (
           <Button
             key="a"

--- a/packages/client/src/pages/Main/containers/StatementEditorBox/StatementEditor/StatementEditorActionTable/StatementEditorActionTableRow.tsx
+++ b/packages/client/src/pages/Main/containers/StatementEditorBox/StatementEditor/StatementEditorActionTable/StatementEditorActionTableRow.tsx
@@ -77,7 +77,7 @@ export const StatementEditorActionTableRow: React.FC<StatementEditorActionTableR
   handleDataAttributeChange,
 }) => {
   const isInsideTemplate = statement.isTemplate || false;
-  const { statementId, territoryId } = useSearchParams();
+  const { statementId } = useSearchParams();
   // the statement's own territory - may differ from the URL territoryId, so the
   // suggester home icon is keyed off the statement, not the opened territory.
   const statementTerritoryId = statement.data.territory?.territoryId;
@@ -266,7 +266,7 @@ export const StatementEditorActionTableRow: React.FC<StatementEditorActionTableR
             originId={originActant ? originActant.id : ""}
             entities={statement.entities}
             props={props}
-            territoryId={territoryId}
+            territoryId={statementTerritoryId}
             updateProp={updateProp}
             removeProp={removeProp}
             addProp={addProp}

--- a/packages/client/src/pages/Main/containers/StatementEditorBox/StatementEditor/StatementEditorSectionButtons/StatementEditorSectionButtons.tsx
+++ b/packages/client/src/pages/Main/containers/StatementEditorBox/StatementEditor/StatementEditorSectionButtons/StatementEditorSectionButtons.tsx
@@ -13,7 +13,7 @@ import {
   DStatementActions,
 } from "constructors";
 import React, { useState } from "react";
-import { FaClone, FaPlus, FaTrashAlt } from "react-icons/fa";
+import { FaClone, FaPlus } from "react-icons/fa";
 import { TbReplace } from "react-icons/tb";
 import { StyledSectionButtonsBorder } from "./StatementEditorSectionButtonsStyles";
 import { MdDeleteSweep } from "react-icons/md";

--- a/packages/client/src/pages/Main/containers/StatementEditorBox/StatementEditorBox.tsx
+++ b/packages/client/src/pages/Main/containers/StatementEditorBox/StatementEditorBox.tsx
@@ -68,7 +68,6 @@ export const StatementEditorBox: React.FC = () => {
       }
       if (statement && statement.isTemplate) {
         queryClient.invalidateQueries({ queryKey: ["templates"] });
-        queryClient.invalidateQueries({ queryKey: ["entity-templates"] });
       }
     },
     onError: (err, newTodo, context) => {

--- a/packages/client/src/pages/Main/containers/StatementEditorBox/StatementEditorBox.tsx
+++ b/packages/client/src/pages/Main/containers/StatementEditorBox/StatementEditorBox.tsx
@@ -1,6 +1,6 @@
 import { EntityEnums } from "@inkvisitor/shared/enums";
 import { IResponseStatement, IStatement, IStatementData } from "@inkvisitor/shared/types";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import api from "api";
 import { CustomScrollbar, Loader } from "components";
 import { useSearchParams } from "hooks";
@@ -11,7 +11,7 @@ import { StatementEditor } from "./StatementEditor/StatementEditor";
 import { StyledEditorEmptyState } from "./StatementEditorBoxStyles";
 import { useAppSelector } from "redux/hooks";
 import { computeDifferences } from "utils/utils";
-import { useUserQuery } from "hooks/react-query";
+import { useStatementQuery, useUserQuery } from "hooks/react-query";
 import { EditorBoxState } from "types";
 
 export const StatementEditorBox: React.FC = () => {
@@ -30,18 +30,10 @@ export const StatementEditorBox: React.FC = () => {
 
   // Statement query
   const {
-    status: statusStatement,
     data: statement,
     error: statementError,
     isFetching: isFetchingStatement,
-  } = useQuery({
-    queryKey: ["statement", statementId],
-    queryFn: async () => {
-      const res = await api.statementGet(statementId);
-      return res.data;
-    },
-    enabled: !!statementId && api.isLoggedIn(),
-  });
+  } = useStatementQuery(statementId);
 
   useEffect(() => {
     if (statementError && (statementError as any).error === "StatementDoesNotExits") {

--- a/packages/client/src/pages/Main/containers/StatementEditorBox/StatementEditorBox.tsx
+++ b/packages/client/src/pages/Main/containers/StatementEditorBox/StatementEditorBox.tsx
@@ -54,6 +54,7 @@ export const StatementEditorBox: React.FC = () => {
       // }
       queryClient.invalidateQueries({ queryKey: ["statement"] });
       queryClient.invalidateQueries({ queryKey: ["territory"] });
+      queryClient.invalidateQueries({ queryKey: ["audit", statementId] });
 
       if (variables.labels?.[0] !== undefined) {
         queryClient.invalidateQueries({ queryKey: ["detail-tab-entities"] });

--- a/packages/client/src/pages/Main/containers/StatementsListBox/StatementListBox.tsx
+++ b/packages/client/src/pages/Main/containers/StatementsListBox/StatementListBox.tsx
@@ -45,11 +45,7 @@ import {
 } from "./StatementListBoxStyles";
 import { StatementListHeader } from "./StatementListHeader/StatementListHeader";
 import { StatementListTable } from "./StatementListTable/StatementListTable";
-import {
-  useDocumentQuery,
-  useResourcesWithDocumentsQuery,
-  useUserQuery,
-} from "hooks/react-query";
+import { useDocumentQuery, useResourcesWithDocumentsQuery, useUserQuery } from "hooks/react-query";
 
 const initialData: {
   statements: IResponseStatement[];
@@ -66,7 +62,7 @@ export const StatementListBox: React.FC = () => {
   const dispatch = useAppDispatch();
   const rowsExpanded: string[] = useAppSelector((state) => state.statementList.rowsExpanded);
   const statementListOpened: boolean = useAppSelector(
-    (state) => state.layout.mainPage.statementListOpened
+    (state) => state.layout.mainPage.statementListOpened,
   );
   const isLoading: boolean = useAppSelector((state) => state.statementList.isLoading);
 
@@ -96,11 +92,9 @@ export const StatementListBox: React.FC = () => {
   // Hover sync (annotator -> list) and the selected resource now live in Redux,
   // shared with the separate AnnotatorBox.
   const annotatorHoveredStatementId = useAppSelector(
-    (state) => state.statementAnnotator.hoveredStatementId
+    (state) => state.statementAnnotator.hoveredStatementId,
   );
-  const selectedResourceId = useAppSelector(
-    (state) => state.statementAnnotator.selectedResourceId
-  );
+  const selectedResourceId = useAppSelector((state) => state.statementAnnotator.selectedResourceId);
 
   // The statement list is now always shown in full (the annotator lives in its
   // own box); the legacy list/annotator toggle has been removed.
@@ -169,10 +163,16 @@ export const StatementListBox: React.FC = () => {
   // The list still needs the live annotator to scroll to anchors on row click.
   const { scrollToAnchor } = useAnnotator();
 
+  const secondPanelExpanded = useAppSelector((state) => state.layout.mainPage.secondPanelExpanded);
+  const statementsListBoxOpen = useAppSelector(
+    (state) => state.layout.mainPage.statementListOpened,
+  );
   // Resources are needed only to resolve the selected resource -> documentId so
   // the list can read the document for order-correction / auto-order. The
   // document itself comes from the same React Query cache the AnnotatorBox fills.
-  const { data: resources } = useResourcesWithDocumentsQuery();
+  const { data: resources } = useResourcesWithDocumentsQuery(
+    secondPanelExpanded && statementsListBoxOpen && !!territoryId,
+  );
 
   const selectedDocumentId = useMemo<string | undefined>(() => {
     if (selectedResourceId && resources) {
@@ -207,7 +207,7 @@ export const StatementListBox: React.FC = () => {
         />,
         {
           autoClose: 5000,
-        }
+        },
       );
 
       if (detailIdArray.includes(sId)) {
@@ -292,7 +292,7 @@ export const StatementListBox: React.FC = () => {
         // Insert statement at correct position based on order
         const order = newStatement.data.territory.order;
         const insertIndex = updatedStatements.findIndex(
-          (s) => (s.data.territory?.order ?? 0) > order
+          (s) => (s.data.territory?.order ?? 0) > order,
         );
         if (insertIndex === -1) {
           updatedStatements.push(optimisticStatement);
@@ -305,7 +305,7 @@ export const StatementListBox: React.FC = () => {
           {
             ...previousTerritory,
             statements: updatedStatements,
-          }
+          },
         );
       }
 
@@ -333,13 +333,13 @@ export const StatementListBox: React.FC = () => {
       if (context?.previousTerritory) {
         queryClient.setQueryData<IResponseTerritory>(
           ["territory", "statement-list", territoryId, statementListOpened],
-          context.previousTerritory
+          context.previousTerritory,
         );
       }
       if (context?.previousDocument) {
         queryClient.setQueryData<IDocument | undefined>(
           ["document", selectedDocumentId],
-          context.previousDocument
+          context.previousDocument,
         );
       }
       toast.error(`Error: Statement not created!`);
@@ -371,7 +371,7 @@ export const StatementListBox: React.FC = () => {
           userData.options,
           "",
           "",
-          territoryId
+          territoryId,
         );
         (newStatement.data.territory as IStatementDataTerritory).order = newOrder;
 
@@ -400,7 +400,7 @@ export const StatementListBox: React.FC = () => {
       queryClient.invalidateQueries({ queryKey: ["territory"] });
       queryClient.invalidateQueries({ queryKey: ["tree"] });
       toast.info(
-        `${data.statements.length} statement${data.statements.length > 1 ? "s" : ""} moved`
+        `${data.statements.length} statement${data.statements.length > 1 ? "s" : ""} moved`,
       );
       setSelectedRows([]);
       setTerritoryId(data.newTerritoryId);
@@ -484,12 +484,12 @@ export const StatementListBox: React.FC = () => {
 
       const deletedRows = responseArray.filter((row) => !(row as any).error);
       const deletedIds = (deletedRows as EntitiesDeleteSuccessResponse[]).map(
-        (row) => row.entityId
+        (row) => row.entityId,
       );
 
       if (deletedIds.length < selectedRows.length) {
         toast.error(
-          `Some statements (${selectedRows.length - deletedIds.length}) are not possible to delete`
+          `Some statements (${selectedRows.length - deletedIds.length}) are not possible to delete`,
         );
       }
 
@@ -519,7 +519,7 @@ export const StatementListBox: React.FC = () => {
       if (errorCount > 0) {
         if (errorRows[0].details.error === "RelationPathExist") {
           toast.error(
-            `${errorCount} relation${errorCount === 1 ? "" : "s"} to this entity already existed`
+            `${errorCount} relation${errorCount === 1 ? "" : "s"} to this entity already existed`,
           );
         } else {
           toast.error(`Some relations ${errorCount} were not possible to create`);
@@ -541,17 +541,20 @@ export const StatementListBox: React.FC = () => {
       // Collect anchors from the document and remove duplicates
       const statementAnchors = Array.from(
         new Map(
-          collectStatementAnchors(selectedDocument.anchors).map((anchor) => [anchor.anchor, anchor])
-        ).values()
+          collectStatementAnchors(selectedDocument.anchors).map((anchor) => [
+            anchor.anchor,
+            anchor,
+          ]),
+        ).values(),
       );
       // only filter the statement anchors that are in the statements list
       const statementIds = new Set(statements.map((s) => s.id));
       const statementAnchorsInList = statementAnchors.filter((anchor) =>
-        statementIds.has(anchor.anchor)
+        statementIds.has(anchor.anchor),
       );
 
       const correctPositionMap = new Map(
-        statementAnchorsInList.map((anchor, index) => [anchor.anchor, index])
+        statementAnchorsInList.map((anchor, index) => [anchor.anchor, index]),
       );
 
       // Separate anchored and non-anchored statements
@@ -579,7 +582,7 @@ export const StatementListBox: React.FC = () => {
       });
 
       const currentOrderMap = new Map(
-        statements.map((statement) => [statement.id, statement.data.territory?.order])
+        statements.map((statement) => [statement.id, statement.data.territory?.order]),
       );
 
       const updates = finalOrder
@@ -615,18 +618,18 @@ export const StatementListBox: React.FC = () => {
     // Collect anchors from the document and remove duplicates
     const statementAnchors = Array.from(
       new Map(
-        collectStatementAnchors(selectedDocument.anchors).map((anchor) => [anchor.anchor, anchor])
-      ).values()
+        collectStatementAnchors(selectedDocument.anchors).map((anchor) => [anchor.anchor, anchor]),
+      ).values(),
     );
     const statementIds = new Set(statements.map((s) => s.id));
     const statementAnchorsInList = statementAnchors.filter((anchor) =>
-      statementIds.has(anchor.anchor)
+      statementIds.has(anchor.anchor),
     );
 
     // Create a map of statement IDs to their correct positions
     const correctPositionMap = new Map(
       // this index is the position of the statement IN THE DOCUMENT
-      statementAnchorsInList.map((anchor, index) => [anchor.anchor, index])
+      statementAnchorsInList.map((anchor, index) => [anchor.anchor, index]),
     );
 
     // First, create a map of all statements with their original indexes
@@ -642,7 +645,7 @@ export const StatementListBox: React.FC = () => {
     // Create a map of territory statements (anchored) with position in the list
     const currentAnchoredPositions = new Map(
       // this index is the position of the statement IN THE LIST
-      anchoredStatements.map((item, index) => [item.statement.id, index])
+      anchoredStatements.map((item, index) => [item.statement.id, index]),
     );
 
     // Create a map of anchored statements with their corrections
@@ -657,10 +660,10 @@ export const StatementListBox: React.FC = () => {
           shouldMoveDown:
             (item.correctPosition ?? 0) > (currentAnchoredPositions.get(item.statement.id) ?? 0),
           distance: Math.abs(
-            (item.correctPosition ?? 0) - (currentAnchoredPositions.get(item.statement.id) ?? 0)
+            (item.correctPosition ?? 0) - (currentAnchoredPositions.get(item.statement.id) ?? 0),
           ),
         },
-      ])
+      ]),
     );
 
     // Reconstruct the array in original order with corrections

--- a/packages/client/src/pages/Main/containers/StatementsListBox/StatementListBox.tsx
+++ b/packages/client/src/pages/Main/containers/StatementsListBox/StatementListBox.tsx
@@ -45,7 +45,11 @@ import {
 } from "./StatementListBoxStyles";
 import { StatementListHeader } from "./StatementListHeader/StatementListHeader";
 import { StatementListTable } from "./StatementListTable/StatementListTable";
-import { useResourcesWithDocumentsQuery, useUserQuery } from "hooks/react-query";
+import {
+  useDocumentQuery,
+  useResourcesWithDocumentsQuery,
+  useUserQuery,
+} from "hooks/react-query";
 
 const initialData: {
   statements: IResponseStatement[];
@@ -177,17 +181,7 @@ export const StatementListBox: React.FC = () => {
     return undefined;
   }, [selectedResourceId, resources]);
 
-  const { data: selectedDocument } = useQuery({
-    queryKey: ["document", selectedDocumentId],
-    queryFn: async () => {
-      if (selectedDocumentId) {
-        const res = await api.documentGet(selectedDocumentId);
-        return res.data ?? undefined;
-      }
-      return undefined;
-    },
-    enabled: api.isLoggedIn() && !!selectedDocumentId,
-  });
+  const { data: selectedDocument } = useDocumentQuery(selectedDocumentId);
 
   const deleteStatementMutation = useMutation({
     mutationFn: async (sId: string) => await api.entityDelete(sId, { ignoreErrorToast: true }),

--- a/packages/client/src/pages/Main/containers/StatementsListBox/StatementListBox.tsx
+++ b/packages/client/src/pages/Main/containers/StatementsListBox/StatementListBox.tsx
@@ -45,7 +45,7 @@ import {
 } from "./StatementListBoxStyles";
 import { StatementListHeader } from "./StatementListHeader/StatementListHeader";
 import { StatementListTable } from "./StatementListTable/StatementListTable";
-import { useUserQuery } from "hooks/react-query";
+import { useResourcesWithDocumentsQuery, useUserQuery } from "hooks/react-query";
 
 const initialData: {
   statements: IResponseStatement[];
@@ -168,16 +168,7 @@ export const StatementListBox: React.FC = () => {
   // Resources are needed only to resolve the selected resource -> documentId so
   // the list can read the document for order-correction / auto-order. The
   // document itself comes from the same React Query cache the AnnotatorBox fills.
-  const { data: resources } = useQuery({
-    queryKey: ["resourcesWithDocuments"],
-    queryFn: async () => {
-      const res = await api.entitiesSearch({
-        resourceHasDocument: true,
-      });
-      return res.data;
-    },
-    enabled: api.isLoggedIn(),
-  });
+  const { data: resources } = useResourcesWithDocumentsQuery();
 
   const selectedDocumentId = useMemo<string | undefined>(() => {
     if (selectedResourceId && resources) {

--- a/packages/client/src/pages/Main/containers/StatementsListBox/StatementListBoxStyles.tsx
+++ b/packages/client/src/pages/Main/containers/StatementsListBox/StatementListBoxStyles.tsx
@@ -95,7 +95,7 @@ export const StyledSearchContainer = styled.div`
   display: flex;
   align-items: center;
   gap: ${({ theme }) => theme.space[1]};
-  margin-left: ${({ theme }) => theme.space[2]};
+  margin-left: 0.2rem;
   flex-shrink: 1;
   min-width: 0;
   user-select: none;

--- a/packages/client/src/pages/Main/containers/StatementsListBox/StatementListHeader/StatementListHeader.tsx
+++ b/packages/client/src/pages/Main/containers/StatementsListBox/StatementListHeader/StatementListHeader.tsx
@@ -13,6 +13,7 @@ import {
 } from "@inkvisitor/shared/types";
 import { UseMutationResult, useQueryClient } from "@tanstack/react-query";
 import { rootTerritoryId } from "Theme/constants";
+import { IcoTrashSimple } from "Theme/icons";
 import { AxiosResponse } from "axios";
 import { Button, Checkbox, Submit } from "components";
 import Dropdown, {
@@ -23,7 +24,6 @@ import Dropdown, {
 import { useSearchParams } from "hooks";
 import { useUserQuery } from "hooks/react-query";
 import React, { useEffect, useMemo, useState } from "react";
-import { IcoTrash } from "Theme/icons";
 import { FaArrowDownShortWide } from "react-icons/fa6";
 import { TbHomeMove } from "react-icons/tb";
 import { setLastClickedIndex } from "redux/features/statementList/lastClickedIndexSlice";
@@ -285,7 +285,7 @@ export const StatementListHeader: React.FC<StatementListHeader> = ({
       : setSelectedRows([]);
 
   const renderCheckBox = () => {
-    const size = 16;
+    const size = 15;
     const hasSelection = isAllSelected || selectedRows.length > 0;
 
     return (
@@ -391,7 +391,7 @@ export const StatementListHeader: React.FC<StatementListHeader> = ({
                     {/* Batch delete */}
                     {batchAction.value === BatchOption.delete_S && (
                       <Button
-                        icon={<IcoTrash />}
+                        icon={<IcoTrashSimple />}
                         color="danger"
                         inverted
                         onClick={() => setShowSubmit(true)}

--- a/packages/client/src/pages/Main/containers/StatementsListBox/StatementListHeader/StatementListHeader.tsx
+++ b/packages/client/src/pages/Main/containers/StatementsListBox/StatementListHeader/StatementListHeader.tsx
@@ -285,12 +285,10 @@ export const StatementListHeader: React.FC<StatementListHeader> = ({
       : setSelectedRows([]);
 
   const renderCheckBox = () => {
-    const size = 15;
     const hasSelection = isAllSelected || selectedRows.length > 0;
 
     return (
       <Checkbox
-        size={size}
         value={isAllSelected}
         indeterminate={!isAllSelected && selectedRows.length > 0}
         onChangeFn={() => {

--- a/packages/client/src/pages/Main/containers/StatementsListBox/StatementListHeader/StatementListHeader.tsx
+++ b/packages/client/src/pages/Main/containers/StatementsListBox/StatementListHeader/StatementListHeader.tsx
@@ -23,7 +23,7 @@ import Dropdown, {
 import { useSearchParams } from "hooks";
 import { useUserQuery } from "hooks/react-query";
 import React, { useEffect, useMemo, useState } from "react";
-import { FaTrash } from "react-icons/fa";
+import { IcoTrash } from "Theme/icons";
 import { FaArrowDownShortWide } from "react-icons/fa6";
 import { TbHomeMove } from "react-icons/tb";
 import { setLastClickedIndex } from "redux/features/statementList/lastClickedIndexSlice";
@@ -391,7 +391,7 @@ export const StatementListHeader: React.FC<StatementListHeader> = ({
                     {/* Batch delete */}
                     {batchAction.value === BatchOption.delete_S && (
                       <Button
-                        icon={<FaTrash />}
+                        icon={<IcoTrash />}
                         color="danger"
                         inverted
                         onClick={() => setShowSubmit(true)}

--- a/packages/client/src/pages/Main/containers/StatementsListBox/StatementListTable/StatementListTable.tsx
+++ b/packages/client/src/pages/Main/containers/StatementsListBox/StatementListTable/StatementListTable.tsx
@@ -159,7 +159,6 @@ export const StatementListTable: React.FC<StatementListTable> = ({
       {
         id: "selection",
         Cell: ({ row }: CellType) => {
-          const size = 15;
           const checked = selectedRows.includes(row.id);
           const isFocused = lastClickedIndex === row.index;
 
@@ -168,7 +167,6 @@ export const StatementListTable: React.FC<StatementListTable> = ({
               {isFocused && <StyledFocusedCircle checked={checked} />}
               <StyledSelectionCheckbox>
                 <Checkbox
-                  size={size}
                   value={checked}
                   onChangeFn={(_value, e) => {
                     if (e?.shiftKey && lastClickedIndex !== -1 && lastClickedIndex !== row.index) {

--- a/packages/client/src/pages/Main/containers/StatementsListBox/StatementListTable/StatementListTable.tsx
+++ b/packages/client/src/pages/Main/containers/StatementsListBox/StatementListTable/StatementListTable.tsx
@@ -1,6 +1,5 @@
 import { UserEnums } from "@inkvisitor/shared/enums";
 import {
-  IDocument,
   IEntity,
   IResponseGeneric,
   IResponseStatement,
@@ -15,13 +14,13 @@ import update from "immutability-helper";
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { BsArrowDown, BsArrowUp } from "react-icons/bs";
 import { FaClone, FaPlus } from "react-icons/fa";
-import { IcoTrash } from "Theme/icons";
 import { TbAnchor } from "react-icons/tb";
 import { TiWarningOutline } from "react-icons/ti";
 import { CellProps, Column, useExpanded, useRowSelect, useTable } from "react-table";
 import { setShowWarnings } from "redux/features/statementEditor/showWarningsSlice";
 import { setLastClickedIndex } from "redux/features/statementList/lastClickedIndexSlice";
 import { useAppDispatch, useAppSelector } from "redux/hooks";
+import { IcoTrash } from "Theme/icons";
 import { ButtonSize, StatementListDisplayMode, StatementOrderCorrection } from "types";
 import { StatementListContextMenu } from "../StatementListContextMenu/StatementListContextMenu";
 import { StatementListRow } from "./StatementListRow";
@@ -31,10 +30,10 @@ import {
   StyledCheckboxWrapper,
   StyledFocusedCircle,
   StyledSelectionCheckbox,
-  StyledTagCellWrap,
-  StyledTHead,
   StyledTable,
+  StyledTagCellWrap,
   StyledTh,
+  StyledTHead,
 } from "./StatementListTableStyles";
 
 // stop tag clicks/double-clicks from bubbling up and activating the row
@@ -160,7 +159,7 @@ export const StatementListTable: React.FC<StatementListTable> = ({
       {
         id: "selection",
         Cell: ({ row }: CellType) => {
-          const size = 16;
+          const size = 15;
           const checked = selectedRows.includes(row.id);
           const isFocused = lastClickedIndex === row.index;
 
@@ -204,10 +203,7 @@ export const StatementListTable: React.FC<StatementListTable> = ({
         Cell: ({ row }: CellType) => {
           const statement = row.original;
           return (
-            <StyledTagCellWrap
-              onClick={stopRowActivation}
-              onDoubleClick={stopRowActivation}
-            >
+            <StyledTagCellWrap onClick={stopRowActivation} onDoubleClick={stopRowActivation}>
               <EntityTag entity={statement} showOnly="tag" />
             </StyledTagCellWrap>
           );
@@ -226,10 +222,7 @@ export const StatementListTable: React.FC<StatementListTable> = ({
           const definedSubjects = subjectObjects.filter((s) => s !== undefined);
 
           return (
-            <StyledTagCellWrap
-              onClick={stopRowActivation}
-              onDoubleClick={stopRowActivation}
-            >
+            <StyledTagCellWrap onClick={stopRowActivation} onDoubleClick={stopRowActivation}>
               {definedSubjects ? <TagGroup definedEntities={definedSubjects} /> : <div />}
             </StyledTagCellWrap>
           );
@@ -246,10 +239,7 @@ export const StatementListTable: React.FC<StatementListTable> = ({
           const definedActions = actionObjects.filter((a) => a !== undefined);
 
           return (
-            <StyledTagCellWrap
-              onClick={stopRowActivation}
-              onDoubleClick={stopRowActivation}
-            >
+            <StyledTagCellWrap onClick={stopRowActivation} onDoubleClick={stopRowActivation}>
               {definedActions ? <TagGroup definedEntities={definedActions} /> : <div />}
             </StyledTagCellWrap>
           );
@@ -266,10 +256,7 @@ export const StatementListTable: React.FC<StatementListTable> = ({
           const definedObjects = actantObjects.filter((o) => o !== undefined);
 
           return (
-            <StyledTagCellWrap
-              onClick={stopRowActivation}
-              onDoubleClick={stopRowActivation}
-            >
+            <StyledTagCellWrap onClick={stopRowActivation} onDoubleClick={stopRowActivation}>
               {definedObjects ? (
                 <TagGroup definedEntities={definedObjects} oversizeLimit={3} />
               ) : (

--- a/packages/client/src/pages/Main/containers/StatementsListBox/StatementListTable/StatementListTable.tsx
+++ b/packages/client/src/pages/Main/containers/StatementsListBox/StatementListTable/StatementListTable.tsx
@@ -30,10 +30,14 @@ import {
   StyledCheckboxWrapper,
   StyledFocusedCircle,
   StyledSelectionCheckbox,
+  StyledTagCellWrap,
   StyledTHead,
   StyledTable,
   StyledTh,
 } from "./StatementListTableStyles";
+
+// stop tag clicks/double-clicks from bubbling up and activating the row
+const stopRowActivation = (e: React.MouseEvent) => e.stopPropagation();
 
 const HIDDEN_COLUMNS_FULL = ["id", "anchor"];
 const HIDDEN_COLUMNS_MINIFIED = [
@@ -198,7 +202,14 @@ export const StatementListTable: React.FC<StatementListTable> = ({
         Header: "",
         Cell: ({ row }: CellType) => {
           const statement = row.original;
-          return <EntityTag entity={statement} showOnly="tag" />;
+          return (
+            <StyledTagCellWrap
+              onClick={stopRowActivation}
+              onDoubleClick={stopRowActivation}
+            >
+              <EntityTag entity={statement} showOnly="tag" />
+            </StyledTagCellWrap>
+          );
         },
       },
       {
@@ -213,7 +224,14 @@ export const StatementListTable: React.FC<StatementListTable> = ({
           const subjectObjects = subjectIds.map((actantId: string) => entities[actantId]);
           const definedSubjects = subjectObjects.filter((s) => s !== undefined);
 
-          return <>{definedSubjects ? <TagGroup definedEntities={definedSubjects} /> : <div />}</>;
+          return (
+            <StyledTagCellWrap
+              onClick={stopRowActivation}
+              onDoubleClick={stopRowActivation}
+            >
+              {definedSubjects ? <TagGroup definedEntities={definedSubjects} /> : <div />}
+            </StyledTagCellWrap>
+          );
         },
       },
       {
@@ -226,7 +244,14 @@ export const StatementListTable: React.FC<StatementListTable> = ({
           const actionObjects = actionIds.map((actionId: string) => entities[actionId]);
           const definedActions = actionObjects.filter((a) => a !== undefined);
 
-          return <>{definedActions ? <TagGroup definedEntities={definedActions} /> : <div />}</>;
+          return (
+            <StyledTagCellWrap
+              onClick={stopRowActivation}
+              onDoubleClick={stopRowActivation}
+            >
+              {definedActions ? <TagGroup definedEntities={definedActions} /> : <div />}
+            </StyledTagCellWrap>
+          );
         },
       },
       {
@@ -240,13 +265,16 @@ export const StatementListTable: React.FC<StatementListTable> = ({
           const definedObjects = actantObjects.filter((o) => o !== undefined);
 
           return (
-            <>
+            <StyledTagCellWrap
+              onClick={stopRowActivation}
+              onDoubleClick={stopRowActivation}
+            >
               {definedObjects ? (
                 <TagGroup definedEntities={definedObjects} oversizeLimit={3} />
               ) : (
                 <div />
               )}
-            </>
+            </StyledTagCellWrap>
           );
         },
       },

--- a/packages/client/src/pages/Main/containers/StatementsListBox/StatementListTable/StatementListTable.tsx
+++ b/packages/client/src/pages/Main/containers/StatementsListBox/StatementListTable/StatementListTable.tsx
@@ -14,7 +14,8 @@ import { useSearchParams } from "hooks";
 import update from "immutability-helper";
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { BsArrowDown, BsArrowUp } from "react-icons/bs";
-import { FaClone, FaPlus, FaTrashAlt } from "react-icons/fa";
+import { FaClone, FaPlus } from "react-icons/fa";
+import { IcoTrash } from "Theme/icons";
 import { TbAnchor } from "react-icons/tb";
 import { TiWarningOutline } from "react-icons/ti";
 import { CellProps, Column, useExpanded, useRowSelect, useTable } from "react-table";
@@ -349,7 +350,7 @@ export const StatementListTable: React.FC<StatementListTable> = ({
                 buttons={[
                   <Button
                     key="r"
-                    icon={<FaTrashAlt size={14} />}
+                    icon={<IcoTrash size={14} />}
                     color="danger"
                     tooltipLabel="delete"
                     onClick={() => {

--- a/packages/client/src/pages/Main/containers/StatementsListBox/StatementListTable/StatementListTableStyles.tsx
+++ b/packages/client/src/pages/Main/containers/StatementsListBox/StatementListTable/StatementListTableStyles.tsx
@@ -167,8 +167,11 @@ export const StyledOrderCorrection = styled.div`
 `;
 
 // wraps tag cells so clicking/double-clicking a tag (e.g. to open its detail)
-// does not bubble up and activate the statement row; display: contents keeps
-// the cell layout unchanged
+// does not bubble up and activate the statement row; width: fit-content keeps
+// the clickable box hugging the tags so clicks in the empty cell space still
+// reach the row
 export const StyledTagCellWrap = styled.div`
-  display: contents;
+  display: flex;
+  width: fit-content;
+  max-width: 100%;
 `;

--- a/packages/client/src/pages/Main/containers/StatementsListBox/StatementListTable/StatementListTableStyles.tsx
+++ b/packages/client/src/pages/Main/containers/StatementsListBox/StatementListTable/StatementListTableStyles.tsx
@@ -49,7 +49,7 @@ export const StyledTr = styled.tr<StyledTr>`
         ? theme.color["tableSelection"]
         : theme.color["white"]};
 
-  &:nth-child(odd) {
+  &:nth-child(even) {
     background-color: ${({ theme, $isOpened, $isSelected }) =>
       $isOpened
         ? theme.color["tableOpened"]
@@ -128,6 +128,8 @@ export const StyledCheckboxWrapper = styled.div`
   align-items: center;
   color: ${({ theme }) => theme.color["black"]};
   cursor: pointer;
+  margin-left: 0.4rem;
+  margin-right: 0.1rem;
 `;
 // keeps the checkbox above the absolutely-positioned focus circle
 export const StyledSelectionCheckbox = styled.div`

--- a/packages/client/src/pages/Main/containers/StatementsListBox/StatementListTable/StatementListTableStyles.tsx
+++ b/packages/client/src/pages/Main/containers/StatementsListBox/StatementListTable/StatementListTableStyles.tsx
@@ -163,3 +163,10 @@ export const StyledOrderCorrection = styled.div`
   width: 100%;
   color: ${({ theme }) => theme.color["gray"]["800"]};
 `;
+
+// wraps tag cells so clicking/double-clicking a tag (e.g. to open its detail)
+// does not bubble up and activate the statement row; display: contents keeps
+// the cell layout unchanged
+export const StyledTagCellWrap = styled.div`
+  display: contents;
+`;

--- a/packages/client/src/pages/Main/containers/TemplateListBox/TemplateListBox.tsx
+++ b/packages/client/src/pages/Main/containers/TemplateListBox/TemplateListBox.tsx
@@ -1,15 +1,12 @@
 import { entitiesDict, entitiesDictKeys } from "@inkvisitor/shared/dictionaries";
 import { EntityEnums, UserEnums } from "@inkvisitor/shared/enums";
 import { IEntity } from "@inkvisitor/shared/types";
-import { IRequestSearch } from "@inkvisitor/shared/types/request-search";
-import api from "api";
 import { Button, Input, Loader } from "components";
 
-import { useQuery } from "@tanstack/react-query";
 import Dropdown, { EntityTag } from "components/advanced";
+import { useTemplatesQuery } from "hooks/react-query";
 import React, { useMemo, useState } from "react";
 import { FaPlus, FaTrash } from "react-icons/fa";
-import { useAppSelector } from "redux/hooks";
 import {
   StyledBoxContent,
   StyledTemplateFilter,
@@ -40,42 +37,34 @@ export const TemplateListBox: React.FC<TemplateListBox> = () => {
   >(EntityEnums.Extension.Any);
   const [filterByLabel, setFilterByLabel] = useState<string>("");
 
-  const fourthPanelBoxesOpened: { [key: string]: boolean } = useAppSelector(
-    (state) => state.layout.mainPage.fourthPanelBoxesOpened
-  );
   const fourthPanelWidth = useDebounce(useSelector(selectPanelWidth(3)), 200);
   const widthTooNarrow = fourthPanelWidth < 220;
 
-  const {
-    status,
-    data: templatesData = [],
-    error,
-    isFetching: isFetchingTemplates,
-  } = useQuery({
-    queryKey: ["templates", filterByClass, filterByLabel],
-    queryFn: async () => {
-      const filters: IRequestSearch = {
-        onlyTemplates: true,
-      };
-      if (filterByClass !== allEntityOption.value) {
-        filters.class = filterByClass as EntityEnums.Class;
-      }
-      if (filterByLabel.length) {
-        filters.label = filterByLabel + "*";
-      }
+  const { data: allTemplatesData, isFetching: isFetchingTemplates } =
+    useTemplatesQuery();
 
-      const res = await api.entitiesSearch(filters);
-
-      const templates = res.data ?? [];
-      templates.sort((a: IEntity, b: IEntity) =>
-        a.labels[0].toLocaleLowerCase() > b.labels[0].toLocaleLowerCase()
-          ? 1
-          : -1
-      );
-      return templates;
-    },
-    enabled: api.isLoggedIn() && fourthPanelBoxesOpened["templates"],
-  });
+  const templatesData = useMemo(() => {
+    if (!allTemplatesData) {
+      return [];
+    }
+    return allTemplatesData.filter((template: IEntity) => {
+      if (
+        filterByClass !== allEntityOption.value &&
+        template.class !== filterByClass
+      ) {
+        return false;
+      }
+      if (
+        filterByLabel.length &&
+        !template.labels[0]
+          ?.toLocaleLowerCase()
+          .startsWith(filterByLabel.toLocaleLowerCase())
+      ) {
+        return false;
+      }
+      return true;
+    });
+  }, [allTemplatesData, filterByClass, filterByLabel]);
 
   // CREATE MODAL
   const [showCreateModal, setShowCreateModal] = useState<boolean>(false);

--- a/packages/client/src/pages/Main/containers/TemplateListBox/TemplateListBox.tsx
+++ b/packages/client/src/pages/Main/containers/TemplateListBox/TemplateListBox.tsx
@@ -6,7 +6,8 @@ import { Button, Input, Loader } from "components";
 import Dropdown, { EntityTag } from "components/advanced";
 import { useTemplatesQuery } from "hooks/react-query";
 import React, { useMemo, useState } from "react";
-import { FaPlus, FaTrash } from "react-icons/fa";
+import { FaPlus } from "react-icons/fa";
+import { IcoTrash } from "Theme/icons";
 import {
   StyledBoxContent,
   StyledTemplateFilter,
@@ -169,7 +170,7 @@ export const TemplateListBox: React.FC<TemplateListBox> = () => {
                           handleAskRemoveTemplate(templateEntity.id);
                         },
                         tooltipLabel: "delete template",
-                        icon: <FaTrash />,
+                        icon: <IcoTrash />,
                       }
                     }
                   />

--- a/packages/client/src/pages/Main/containers/TemplateListBox/TemplateListBox.tsx
+++ b/packages/client/src/pages/Main/containers/TemplateListBox/TemplateListBox.tsx
@@ -7,7 +7,7 @@ import Dropdown, { EntityTag } from "components/advanced";
 import { useTemplatesQuery } from "hooks/react-query";
 import React, { useMemo, useState } from "react";
 import { FaPlus } from "react-icons/fa";
-import { IcoTrash } from "Theme/icons";
+import { IcoTrashSimple } from "Theme/icons";
 import {
   StyledBoxContent,
   StyledTemplateFilter,
@@ -170,7 +170,7 @@ export const TemplateListBox: React.FC<TemplateListBox> = () => {
                           handleAskRemoveTemplate(templateEntity.id);
                         },
                         tooltipLabel: "delete template",
-                        icon: <IcoTrash />,
+                        icon: <IcoTrashSimple />,
                       }
                     }
                   />

--- a/packages/client/src/pages/Main/containers/TemplateListBox/TemplateListBox.tsx
+++ b/packages/client/src/pages/Main/containers/TemplateListBox/TemplateListBox.tsx
@@ -23,6 +23,7 @@ import { TemplateListRemoveModal } from "./TemplateListRemoveModal/TemplateListR
 import { selectPanelWidth } from "redux/features/layout/mainPage/panelWidthsSlice";
 import { useSelector } from "react-redux";
 import { useDebounce } from "hooks";
+import { useAppSelector } from "redux/hooks";
 
 interface TemplateListBox {}
 export const TemplateListBox: React.FC<TemplateListBox> = () => {
@@ -33,33 +34,28 @@ export const TemplateListBox: React.FC<TemplateListBox> = () => {
   } as { value: EntityEnums.Extension.Any; label: string };
   const allEntityOptions = [allEntityOption, ...entitiesDict];
 
-  const [filterByClass, setFilterByClass] = useState<
-    EntityEnums.Class | EntityEnums.Extension.Any
-  >(EntityEnums.Extension.Any);
+  const [filterByClass, setFilterByClass] = useState<EntityEnums.Class | EntityEnums.Extension.Any>(
+    EntityEnums.Extension.Any,
+  );
   const [filterByLabel, setFilterByLabel] = useState<string>("");
 
   const fourthPanelWidth = useDebounce(useSelector(selectPanelWidth(3)), 200);
   const widthTooNarrow = fourthPanelWidth < 220;
 
-  const { data: allTemplatesData, isFetching: isFetchingTemplates } =
-    useTemplatesQuery();
+  // purposefully fetch on page load so the detail box can use it immediately
+  const { data: allTemplatesData, isFetching: isFetchingTemplates } = useTemplatesQuery();
 
   const templatesData = useMemo(() => {
     if (!allTemplatesData) {
       return [];
     }
     return allTemplatesData.filter((template: IEntity) => {
-      if (
-        filterByClass !== allEntityOption.value &&
-        template.class !== filterByClass
-      ) {
+      if (filterByClass !== allEntityOption.value && template.class !== filterByClass) {
         return false;
       }
       if (
         filterByLabel.length &&
-        !template.labels[0]
-          ?.toLocaleLowerCase()
-          .startsWith(filterByLabel.toLocaleLowerCase())
+        !template.labels[0]?.toLocaleLowerCase().startsWith(filterByLabel.toLocaleLowerCase())
       ) {
         return false;
       }
@@ -84,7 +80,7 @@ export const TemplateListBox: React.FC<TemplateListBox> = () => {
   const entityToRemove: false | IEntity = useMemo(() => {
     if (removeEntityId) {
       const templateToBeRemoved = templatesData?.find(
-        (template: IEntity) => template.id === removeEntityId
+        (template: IEntity) => template.id === removeEntityId,
       );
       return templateToBeRemoved || false;
     } else {
@@ -113,9 +109,7 @@ export const TemplateListBox: React.FC<TemplateListBox> = () => {
 
         <StyledTemplateFilter>
           <StyledTemplateFilterInputRow>
-            <StyledTemplateFilterInputLabel>
-              {"Entity class: "}
-            </StyledTemplateFilterInputLabel>
+            <StyledTemplateFilterInputLabel>{"Entity class: "}</StyledTemplateFilterInputLabel>
             <StyledTemplateFilterInputValue>
               <div style={{ position: "relative" }}>
                 <Dropdown.Single.Entity
@@ -141,9 +135,7 @@ export const TemplateListBox: React.FC<TemplateListBox> = () => {
             </StyledTemplateFilterInputValue>
           </StyledTemplateFilterInputRow>
           <StyledTemplateFilterInputRow>
-            <StyledTemplateFilterInputLabel>
-              {"Label: "}
-            </StyledTemplateFilterInputLabel>
+            <StyledTemplateFilterInputLabel>{"Label: "}</StyledTemplateFilterInputLabel>
             <StyledTemplateFilterInputValue>
               <Input
                 value={filterByLabel}

--- a/packages/client/src/pages/Main/containers/TemplateListBox/TemplateListBoxStyles.tsx
+++ b/packages/client/src/pages/Main/containers/TemplateListBox/TemplateListBoxStyles.tsx
@@ -2,7 +2,6 @@ import styled from "styled-components";
 
 export const StyledBoxContent = styled.div`
   display: flex;
-  flex-direction: column;
   overflow: auto;
   height: 100%;
   background-color: ${({ theme }) => theme.color["white"]};
@@ -10,18 +9,17 @@ export const StyledBoxContent = styled.div`
 
 export const StyledTemplateSection = styled.div`
   position: relative;
+  display: flex;
+  flex-direction: column;
   margin-top: 0.3rem;
-  background-color: ${({ theme }) => theme.color["white"]};
+  gap: 0.5rem;
+  padding-left: 0.6rem;
 `;
 export const StyledTemplateSectionHeader = styled.div`
+  display: flex;
   font-weight: ${({ theme }) => theme.fontWeight.normal};
   font-size: ${({ theme }) => theme.fontSize.lg};
-  margin-bottom: ${({ theme }) => theme.space["2"]};
   color: ${({ theme }) => theme.color["primary"]};
-  display: flex;
-  button {
-    margin-left: ${({ theme }) => theme.space["2"]};
-  }
 `;
 
 export const StyledTemplateSectionList = styled.div`
@@ -34,32 +32,23 @@ export const StyledTemplateSectionList = styled.div`
   gap: 0.5rem;
 `;
 
-export const StyledTemplateFilterInputRow = styled.div``;
-export const StyledTemplateFilterInputLabel = styled.div`
-  color: ${({ theme }) => theme.color["black"]};
-`;
-export const StyledTemplateFilterInputValue = styled.div``;
-
 export const StyledTemplateFilter = styled.div`
-  display: table;
-  ${StyledTemplateFilterInputRow} {
-    display: table-row;
-    width: 100%;
-  }
-  ${StyledTemplateFilterInputLabel} {
-    width: 1%;
-    white-space: nowrap;
-    display: table-cell;
-    padding: ${({ theme }) => theme.space[3]};
-    vertical-align: top;
-    text-align: right;
-    float: initial;
-  }
-  ${StyledTemplateFilterInputValue} {
-    display: table-cell;
-    width: 100%;
-    padding: ${({ theme }) => theme.space[2]};
-  }
+  display: grid;
+  grid-template-columns: auto 1fr;
+  align-items: center;
+`;
+
+export const StyledTemplateFilterInputRow = styled.div`
+  display: contents;
+`;
+export const StyledTemplateFilterInputLabel = styled.div`
+  font-size: ${({ theme }) => theme.fontSize.sm};
+  color: ${({ theme }) => theme.color["primary"]};
+  white-space: nowrap;
+  text-align: right;
+`;
+export const StyledTemplateFilterInputValue = styled.div`
+  padding: ${({ theme }) => theme.space[2]};
 `;
 
 export const StyledModalContent = styled.div`

--- a/packages/client/src/pages/Main/containers/TemplateListBox/TemplateListBoxStyles.tsx
+++ b/packages/client/src/pages/Main/containers/TemplateListBox/TemplateListBoxStyles.tsx
@@ -1,9 +1,10 @@
 import styled from "styled-components";
 
 export const StyledBoxContent = styled.div`
-  display: flex;
+  display: block;
   overflow: auto;
   height: 100%;
+  padding-bottom: 0.8rem;
   background-color: ${({ theme }) => theme.color["white"]};
 `;
 
@@ -26,7 +27,6 @@ export const StyledTemplateSectionList = styled.div`
   position: relative;
   min-height: 5rem;
   width: 100%;
-  overflow: hidden;
   display: flex;
   flex-wrap: wrap;
   gap: 0.5rem;

--- a/packages/client/src/pages/Main/containers/TemplateListBox/TemplateListCreateModal/TemplateListCreateModal.tsx
+++ b/packages/client/src/pages/Main/containers/TemplateListBox/TemplateListCreateModal/TemplateListCreateModal.tsx
@@ -66,7 +66,6 @@ export const TemplateListCreateModal: React.FC<TemplateListCreateModal> = ({
       queryClient.invalidateQueries({ queryKey: ["templates"] });
       if (variables.class === EntityEnums.Class.Statement) {
         setStatementId(variables.id);
-        queryClient.invalidateQueries({ queryKey: ["statement-templates"] });
       } else {
         appendDetailId(variables.id);
       }

--- a/packages/client/src/pages/Main/containers/TemplateListBox/TemplateListCreateModal/TemplateListCreateModal.tsx
+++ b/packages/client/src/pages/Main/containers/TemplateListBox/TemplateListCreateModal/TemplateListCreateModal.tsx
@@ -32,8 +32,7 @@ export const TemplateListCreateModal: React.FC<TemplateListCreateModal> = ({
   setShowCreateModal,
 }) => {
   const queryClient = useQueryClient();
-  const { setStatementId, appendDetailId, selectedDetailId, setSelectedDetailId } =
-    useSearchParams();
+  const { setStatementId, appendDetailId } = useSearchParams();
 
   const [createModalEntityClass, setCreateModalEntityClass] = useState<EntityEnums.Class>(
     entitiesDict[0].value
@@ -65,9 +64,6 @@ export const TemplateListCreateModal: React.FC<TemplateListCreateModal> = ({
         )}" was created`
       );
       queryClient.invalidateQueries({ queryKey: ["templates"] });
-      if (selectedDetailId) {
-        queryClient.invalidateQueries({ queryKey: ["entity-templates"] });
-      }
       if (variables.class === EntityEnums.Class.Statement) {
         setStatementId(variables.id);
         queryClient.invalidateQueries({ queryKey: ["statement-templates"] });

--- a/packages/client/src/pages/Main/containers/TemplateListBox/TemplateListRemoveModal/TemplateListRemoveModal.tsx
+++ b/packages/client/src/pages/Main/containers/TemplateListBox/TemplateListRemoveModal/TemplateListRemoveModal.tsx
@@ -19,7 +19,7 @@ export const TemplateListRemoveModal: React.FC<TemplateListRemoveModal> = ({
   entityToRemove,
 }) => {
   const queryClient = useQueryClient();
-  const { detailIdArray, removeDetailId, statementId } = useSearchParams();
+  const { detailIdArray, removeDetailId } = useSearchParams();
 
   const [showModal, setShowModal] = useState(false);
 
@@ -42,13 +42,6 @@ export const TemplateListRemoveModal: React.FC<TemplateListRemoveModal> = ({
           )}" was removed`
         );
       queryClient.invalidateQueries({ queryKey: ["templates"] });
-      if (
-        statementId &&
-        entityToRemove &&
-        entityToRemove.class === EntityEnums.Class.Statement
-      ) {
-        queryClient.invalidateQueries({ queryKey: ["statement-templates"] });
-      }
       queryClient.invalidateQueries({ queryKey: ["entity"] });
       setRemoveEntityId(false);
     },

--- a/packages/client/src/pages/Main/containers/TemplateListBox/TemplateListRemoveModal/TemplateListRemoveModal.tsx
+++ b/packages/client/src/pages/Main/containers/TemplateListBox/TemplateListRemoveModal/TemplateListRemoveModal.tsx
@@ -19,8 +19,7 @@ export const TemplateListRemoveModal: React.FC<TemplateListRemoveModal> = ({
   entityToRemove,
 }) => {
   const queryClient = useQueryClient();
-  const { detailIdArray, removeDetailId, statementId, selectedDetailId } =
-    useSearchParams();
+  const { detailIdArray, removeDetailId, statementId } = useSearchParams();
 
   const [showModal, setShowModal] = useState(false);
 
@@ -43,10 +42,6 @@ export const TemplateListRemoveModal: React.FC<TemplateListRemoveModal> = ({
           )}" was removed`
         );
       queryClient.invalidateQueries({ queryKey: ["templates"] });
-      if (selectedDetailId) {
-        // TODO: check if entity class is the same as opened detail
-        queryClient.invalidateQueries({ queryKey: ["entity-templates"] });
-      }
       if (
         statementId &&
         entityToRemove &&

--- a/packages/client/src/pages/Main/containers/TerritoryTreeBox/TerritoryTreeBox.tsx
+++ b/packages/client/src/pages/Main/containers/TerritoryTreeBox/TerritoryTreeBox.tsx
@@ -15,7 +15,7 @@ import { setFilterOpen } from "redux/features/territoryTree/filterOpenSlice";
 import { setSelectedTerritoryPath } from "redux/features/territoryTree/selectedTerritoryPathSlice";
 import { setTreeInitialized } from "redux/features/territoryTree/treeInitializeSlice";
 import { useAppDispatch, useAppSelector } from "redux/hooks";
-import { ITerritoryFilter } from "types";
+import { ButtonSize, ITerritoryFilter } from "types";
 import { searchTree } from "utils/utils";
 import { StyledNoResults, StyledTreeWrapper } from "./TerritoryTreeBoxStyles";
 import { TerritoryTreeFilter } from "./TerritoryTreeFilter/TerritoryTreeFilter";
@@ -248,7 +248,7 @@ export const TerritoryTreeBox: React.FC = () => {
     <>
       {showTerritoryTree && (
         <>
-          <ButtonGroup>
+          <ButtonGroup $smallGap>
             {(userRole === UserEnums.Role.Admin || userRole === UserEnums.Role.Owner) && (
               <Button
                 label={!treeWidthTooNarrow ? "new" : ""}
@@ -259,37 +259,35 @@ export const TerritoryTreeBox: React.FC = () => {
                 tooltipLabel={treeWidthTooNarrow ? "create new territory" : ""}
               />
             )}
-            <div style={{ display: "flex", alignItems: "center", width: "100%", gap: "0.2rem" }}>
-              <Button
-                label={!treeWidthTooNarrow ? "filter" : ""}
-                onClick={() => {
-                  if (treeFilterOpen) {
-                    dispatch(setFilterOpen(false));
-                    setFilteredTreeData(treeData);
-                    setFilterSettings(initFilterSettings);
-                    dispatch(setTreeInitialized(false));
-                  } else {
-                    dispatch(setFilterOpen(true));
-                  }
-                }}
-                color="success"
-                inverted={!treeFilterOpen}
-                fullWidth
-                icon={<BsFilter size={14} />}
-                tooltipLabel={treeWidthTooNarrow ? "filter" : ""}
-                tooltipPosition="right"
-              />
-              <Button
-                icon={<FaStar size={14} />}
-                color={filterSettings.starred ? "warning" : "greyer"}
-                inverted={!filterSettings.starred}
-                onClick={() => {
-                  handleFilterChange("starred", !filterSettings.starred);
-                }}
-                tooltipLabel="starred territories"
-                tooltipPosition="right"
-              />
-            </div>
+            <Button
+              label={!treeWidthTooNarrow ? "filter" : ""}
+              onClick={() => {
+                if (treeFilterOpen) {
+                  dispatch(setFilterOpen(false));
+                  setFilteredTreeData(treeData);
+                  setFilterSettings(initFilterSettings);
+                  dispatch(setTreeInitialized(false));
+                } else {
+                  dispatch(setFilterOpen(true));
+                }
+              }}
+              color="success"
+              inverted={!treeFilterOpen}
+              fullWidth
+              icon={<BsFilter size={14} />}
+              tooltipLabel={treeWidthTooNarrow ? "filter" : ""}
+              tooltipPosition="right"
+            />
+            <Button
+              icon={<FaStar size={14} />}
+              color={filterSettings.starred ? "warning" : "greyer"}
+              inverted={!filterSettings.starred}
+              onClick={() => {
+                handleFilterChange("starred", !filterSettings.starred);
+              }}
+              tooltipLabel="starred territories"
+              tooltipPosition="right"
+            />
           </ButtonGroup>
 
           {treeFilterOpen && (

--- a/packages/client/src/pages/Main/containers/TerritoryTreeBox/TerritoryTreeContextMenu/TerritoryTreeContextMenu.tsx
+++ b/packages/client/src/pages/Main/containers/TerritoryTreeBox/TerritoryTreeContextMenu/TerritoryTreeContextMenu.tsx
@@ -6,7 +6,8 @@ import { UseMutationResult, useQueryClient } from "@tanstack/react-query";
 import { rootTerritoryId } from "Theme/constants";
 import { Button } from "components";
 import React, { useEffect, useState } from "react";
-import { FaPlus, FaStar, FaTrashAlt } from "react-icons/fa";
+import { FaPlus, FaStar } from "react-icons/fa";
+import { IcoTrash } from "Theme/icons";
 import { TbArrowsSort } from "react-icons/tb";
 import { ContextMenuSubmitDelete } from "../ContextMenuSubmitDelete/ContextMenuSubmitDelete";
 import { ReorderTerritoryChildrenModal } from "../ReorderTerritoryChildrenModal/ReorderTerritoryChildrenModal";
@@ -173,7 +174,7 @@ export const TerritoryTreeContextMenu: React.FC<TerritoryTreeContextMenu> = ({
                     key="delete"
                     tooltipLabel="delete territory"
                     tooltipPosition="top"
-                    icon={<FaTrashAlt size={14} />}
+                    icon={<IcoTrash size={14} />}
                     color="danger"
                     shape="sharp-square"
                     onClick={() => {

--- a/packages/client/src/pages/Main/containers/TerritoryTreeBox/TerritoryTreeFilter/TerritoryTreeFilter.tsx
+++ b/packages/client/src/pages/Main/containers/TerritoryTreeBox/TerritoryTreeFilter/TerritoryTreeFilter.tsx
@@ -10,7 +10,7 @@ import {
   StyledInputWrap,
   StyledLogicalOperator,
 } from "./TerritoryTreeFilterStyles";
-import { BiSearch } from "react-icons/bi";
+import { IcoSearch } from "Theme/icons";
 
 interface TerritoryTreeFilter {
   filterData: ITerritoryFilter;
@@ -71,7 +71,7 @@ export const TerritoryTreeFilter: React.FC<TerritoryTreeFilter> = ({
             changeOnType
             width="full"
             clearable
-            icon={<BiSearch />}
+            icon={<IcoSearch />}
           />
         </StyledInputWrap>
       </StyledFilterList>

--- a/packages/client/src/pages/Main/hooks/usePanelToggles.ts
+++ b/packages/client/src/pages/Main/hooks/usePanelToggles.ts
@@ -179,11 +179,60 @@ export function usePanelToggles({
   const toggleThirdPanel = () => {
     if (thirdPanelExpanded) {
       dispatch(setThirdPanelExpanded(false));
+
+      // hand the freed third-panel width to the second panel (preferred over the
+      // fourth): move the center separator right and keep the search separator,
+      // so the fourth panel keeps its width. Remember the width to restore it.
+      if (secondPanelExpanded && fourthPanelExpanded) {
+        const freed = panelWidths[2] - COLLAPSED_PANEL_WIDTH;
+        if (freed > 0) {
+          localStorage.setItem(
+            "mainPageThirdPanelRestoreWidth",
+            floorNumberToOneDecimal(panelWidths[2] / onePercentOfLayoutWidth).toString(),
+          );
+          const newCenterPos = centerSeparator.position + freed;
+          centerSeparator.setPosition(newCenterPos);
+          persistSeparator("mainPageCenterSeparatorXPosition", newCenterPos);
+          dispatch(
+            setPanelWidths([
+              panelWidths[0],
+              floorNumberToOneDecimal(newCenterPos - panelWidths[0]),
+              COLLAPSED_PANEL_WIDTH,
+              panelWidths[3],
+            ]),
+          );
+        }
+      }
       return;
     }
 
     dispatch(setThirdPanelExpanded(true));
     queryClient.invalidateQueries({ queryKey: ["document"] });
+
+    // if the third panel's width was previously parked into the second panel,
+    // give it back by moving the center separator left (fourth panel untouched)
+    const storedRestore = localStorage.getItem("mainPageThirdPanelRestoreWidth");
+    if (storedRestore && secondPanelExpanded && fourthPanelExpanded) {
+      localStorage.removeItem("mainPageThirdPanelRestoreWidth");
+      const restoreWidth = Math.max(
+        Number(storedRestore) * onePercentOfLayoutWidth,
+        THIRD_PANEL_MIN_WIDTH,
+      );
+      const minCenterPos = treeSeparator.position + SECOND_PANEL_MIN_WIDTH;
+      const newCenterPos = Math.max(searchSeparator.position - restoreWidth, minCenterPos);
+
+      centerSeparator.setPosition(newCenterPos);
+      persistSeparator("mainPageCenterSeparatorXPosition", newCenterPos);
+      dispatch(
+        setPanelWidths([
+          panelWidths[0],
+          floorNumberToOneDecimal(newCenterPos - panelWidths[0]),
+          floorNumberToOneDecimal(searchSeparator.position - newCenterPos),
+          panelWidths[3],
+        ]),
+      );
+      return;
+    }
 
     let newTreePos = treeSeparator.position;
     let newSearchPos = searchSeparator.position;

--- a/packages/client/src/pages/Main/hooks/usePanelToggles.ts
+++ b/packages/client/src/pages/Main/hooks/usePanelToggles.ts
@@ -202,12 +202,83 @@ export function usePanelToggles({
             ]),
           );
         }
+      } else if (!secondPanelExpanded) {
+        // when second panel is hidden, give ALL freed visual space to first panel
+        // instead of fourth. fourthPanelWidth = layoutWidth - sum(others), so the
+        // only way to keep fourth unchanged is to push all three separators right
+        // until first panel absorbs everything. Save original positions to restore.
+        const desiredTreePos = panelWidths[0] + panelWidths[1] + panelWidths[2] - 2 * COLLAPSED_PANEL_WIDTH;
+        const desiredCenterPos = desiredTreePos + SECOND_PANEL_MIN_WIDTH;
+        const desiredSearchPos = desiredCenterPos + COLLAPSED_PANEL_WIDTH;
+
+        const newSearchPos = Math.min(desiredSearchPos, layoutWidth - FOURTH_PANEL_MIN_WIDTH);
+        const newCenterPos = Math.min(desiredCenterPos, newSearchPos - COLLAPSED_PANEL_WIDTH);
+        const newTreePos = Math.min(desiredTreePos, newCenterPos - SECOND_PANEL_MIN_WIDTH);
+
+        if (newTreePos > treeSeparator.position) {
+          localStorage.setItem(
+            "mainPageThirdPanelRestoreTree",
+            floorNumberToOneDecimal(treeSeparator.position / onePercentOfLayoutWidth).toString(),
+          );
+          localStorage.setItem(
+            "mainPageThirdPanelRestoreCenter",
+            floorNumberToOneDecimal(centerSeparator.position / onePercentOfLayoutWidth).toString(),
+          );
+          localStorage.setItem(
+            "mainPageThirdPanelRestoreSearch",
+            floorNumberToOneDecimal(searchSeparator.position / onePercentOfLayoutWidth).toString(),
+          );
+
+          treeSeparator.setPosition(newTreePos);
+          persistSeparator("mainPageTreeSeparatorXPosition", newTreePos);
+          centerSeparator.setPosition(newCenterPos);
+          persistSeparator("mainPageCenterSeparatorXPosition", newCenterPos);
+          searchSeparator.setPosition(newSearchPos);
+          persistSeparator("mainPageSearchSeparatorXPosition", newSearchPos);
+          dispatch(
+            setPanelWidths([
+              newTreePos,
+              floorNumberToOneDecimal(newCenterPos - newTreePos),
+              COLLAPSED_PANEL_WIDTH,
+              floorNumberToOneDecimal(layoutWidth - newSearchPos),
+            ]),
+          );
+        }
       }
       return;
     }
 
     dispatch(setThirdPanelExpanded(true));
     queryClient.invalidateQueries({ queryKey: ["document"] });
+
+    // if all three separators were shifted right when second panel was hidden,
+    // restore them all to exact pre-collapse positions
+    const savedTree = localStorage.getItem("mainPageThirdPanelRestoreTree");
+    const savedCenter = localStorage.getItem("mainPageThirdPanelRestoreCenter");
+    const savedSearch = localStorage.getItem("mainPageThirdPanelRestoreSearch");
+    if (savedTree && savedCenter && savedSearch && !secondPanelExpanded) {
+      localStorage.removeItem("mainPageThirdPanelRestoreTree");
+      localStorage.removeItem("mainPageThirdPanelRestoreCenter");
+      localStorage.removeItem("mainPageThirdPanelRestoreSearch");
+      const restoreTreePos = Number(savedTree) * onePercentOfLayoutWidth;
+      const restoreCenterPos = Number(savedCenter) * onePercentOfLayoutWidth;
+      const restoreSearchPos = Number(savedSearch) * onePercentOfLayoutWidth;
+      treeSeparator.setPosition(restoreTreePos);
+      persistSeparator("mainPageTreeSeparatorXPosition", restoreTreePos);
+      centerSeparator.setPosition(restoreCenterPos);
+      persistSeparator("mainPageCenterSeparatorXPosition", restoreCenterPos);
+      searchSeparator.setPosition(restoreSearchPos);
+      persistSeparator("mainPageSearchSeparatorXPosition", restoreSearchPos);
+      dispatch(
+        setPanelWidths([
+          restoreTreePos,
+          floorNumberToOneDecimal(restoreCenterPos - restoreTreePos),
+          floorNumberToOneDecimal(restoreSearchPos - restoreCenterPos),
+          floorNumberToOneDecimal(layoutWidth - restoreSearchPos),
+        ]),
+      );
+      return;
+    }
 
     // if the third panel's width was previously parked into the second panel,
     // give it back by moving the center separator left (fourth panel untouched)

--- a/packages/client/src/pages/Query/Explorer/ExplorerTable/Filters/ExplorerTableIdsFilter.tsx
+++ b/packages/client/src/pages/Query/Explorer/ExplorerTable/Filters/ExplorerTableIdsFilter.tsx
@@ -7,7 +7,7 @@ import {
   unparsedRemainder,
 } from "pages/Query/utils";
 import React, { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
-import { BiSearch } from "react-icons/bi";
+import { IcoSearch } from "Theme/icons";
 import { MdClose } from "react-icons/md";
 import { ExploreAction, ExploreActionType } from "../../state";
 import {
@@ -340,7 +340,7 @@ const ExplorerTableIdsFilter: React.FC<ExplorerTableIdsFilterProps> = ({ filters
           aria-expanded={isOpen}
           onClick={() => setIsOpen((open) => !open)}
         >
-          {appliedIds.length > 0 ? <BiSearch size={18} /> : "+ "}
+          {appliedIds.length > 0 ? <IcoSearch size={18} /> : "+ "}
           UUIDs
           {appliedIds.length > 0 && <StyledIdsCountBadge>{appliedIds.length}</StyledIdsCountBadge>}
         </StyledIdsToggleButton>

--- a/packages/client/src/pages/Query/Explorer/ExplorerTable/Filters/ExplorerTableLabelFilter.tsx
+++ b/packages/client/src/pages/Query/Explorer/ExplorerTable/Filters/ExplorerTableLabelFilter.tsx
@@ -2,7 +2,7 @@ import { Explore } from "@inkvisitor/shared/types/query";
 import { Checkbox, Input } from "components";
 import { useDebounce } from "hooks";
 import React, { useCallback, useEffect, useState } from "react";
-import { BiSearch } from "react-icons/bi";
+import { IcoSearch } from "Theme/icons";
 import { LuRegex } from "react-icons/lu";
 import { ExploreAction, ExploreActionType } from "../../state";
 import { StyledLabelFilter, StyledLabelFilterCheckboxWrapper } from "../ExplorerTableStyles";
@@ -60,7 +60,7 @@ const ExplorerTableLabelFilter: React.FC<ExplorerTableLabelFilterProps> = ({
         onChangeFn={setInputValue}
         clearable
         roundCorners
-        icon={<BiSearch />}
+        icon={<IcoSearch />}
         rightContent={
           <StyledLabelFilterCheckboxWrapper>
             <Checkbox

--- a/packages/client/src/pages/Query/ExplorerPage.tsx
+++ b/packages/client/src/pages/Query/ExplorerPage.tsx
@@ -9,7 +9,8 @@ import { LayoutSeparatorHorizontal, LayoutSeparatorVertical } from "components/a
 import { useUserQuery } from "hooks/react-query";
 import { useSearchParams } from "hooks/useSearchParamsContext";
 import { MemoizedEntityDetailBox } from "pages/Main/containers/EntityDetailBox/EntityDetailBox";
-import { BiBarChartAlt2, BiHide, BiRefresh, BiSearch, BiTable } from "react-icons/bi";
+import { BiBarChartAlt2, BiHide, BiRefresh, BiTable } from "react-icons/bi";
+import { IcoSearch } from "Theme/icons";
 import { BsSquareFill, BsSquareHalf } from "react-icons/bs";
 import { RiMenuFoldFill, RiMenuUnfoldFill } from "react-icons/ri";
 import { VscCloseAll } from "react-icons/vsc";
@@ -612,7 +613,7 @@ export const ExplorerPage: React.FC<ExplorerPage> = ({}) => {
                   key="run-search"
                   tooltipLabel="run search (Enter)"
                   label="run search"
-                  icon={<BiSearch />}
+                  icon={<IcoSearch />}
                   disabled={!isSearchPending}
                   onClick={handleRunSearch}
                 />,

--- a/packages/client/src/pages/Query/FloatingSearchContainer/FloatingSearchContainer.tsx
+++ b/packages/client/src/pages/Query/FloatingSearchContainer/FloatingSearchContainer.tsx
@@ -1,7 +1,7 @@
 import { FloatingPortal } from "@floating-ui/react";
 import { Button, Checkbox } from "components";
 import React, { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
-import { BiSearch } from "react-icons/bi";
+import { IcoSearch } from "Theme/icons";
 import { GrClose } from "react-icons/gr";
 import { floorNumberToOneDecimal } from "utils/utils";
 import { ExploreAction, ExploreActionType } from "../Explorer/state";
@@ -379,7 +379,7 @@ export const FloatingSearchContainer: React.FC<FloatingSearchContainer> = ({
           aria-label={isExpanded ? "Close search panel" : "Open search panel"}
           aria-expanded={isExpanded}
         >
-          <BiSearch size={22} />
+          <IcoSearch size={22} />
         </StyledCollapsedButton>
       )}
       {isExpanded && (

--- a/packages/client/src/pages/Query/Query/components/QueryGridNode.tsx
+++ b/packages/client/src/pages/Query/Query/components/QueryGridNode.tsx
@@ -1,6 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 import React, { useMemo, useRef, useState } from "react";
-import { FaPlus, FaTrash } from "react-icons/fa";
+import { FaPlus } from "react-icons/fa";
+import { IcoTrash } from "Theme/icons";
 
 import { entitiesDict } from "@inkvisitor/shared/dictionaries";
 import { classesAll } from "@inkvisitor/shared/dictionaries/entity";
@@ -337,7 +338,7 @@ export const QueryGridNode: React.FC<QueryGridNodeProps> = ({
         {node.gridX !== 0 && node.gridY !== 0 && edge && (
           <div>
             <Button
-              icon={<FaTrash style={{ fontSize: "16px", padding: "2px" }} />}
+              icon={<IcoTrash style={{ fontSize: "16px", padding: "2px" }} />}
               tooltipLabel="remove this node"
               color="warning"
               onClick={() => {

--- a/packages/client/src/pages/Stats/DocumentTable/DocumentTable.tsx
+++ b/packages/client/src/pages/Stats/DocumentTable/DocumentTable.tsx
@@ -8,10 +8,7 @@ import { BaseDropdown, Loader, Table, Timestamp } from "components";
 import { EmptyEntityTag, EntityTag } from "components/advanced";
 import { UserTag } from "components/advanced/UserTag/UserTag";
 import { useResizeObserver } from "hooks";
-import {
-  useDocumentsQuery,
-  useResourcesWithDocumentsQuery,
-} from "hooks/react-query";
+import { useDocumentsQuery, useResourcesWithDocumentsQuery } from "hooks/react-query";
 import { useMemo } from "react";
 import { Column } from "react-table";
 import {
@@ -111,7 +108,7 @@ const AuditChangesCell: React.FC<{ changes: object }> = ({ changes }) => {
               const entity = entitiesById[anchor];
               if (entity) {
                 return (
-                  <div style={{ display: "grid" }}>
+                  <div style={{ display: "grid" }} key={index}>
                     <EntityTag
                       key={`${section.key}-${anchor}-${index}`}
                       entity={entity}
@@ -150,11 +147,9 @@ export const DocumentTable: React.FC<DocumentTableProps> = ({
       debounceDelay: 50,
     });
 
-  const { data: dataDocuments, isLoading: isLoadingDocuments } =
-    useDocumentsQuery();
+  const { data: dataDocuments, isLoading: isLoadingDocuments } = useDocumentsQuery();
 
-  const { data: resources, isLoading: isLoadingResources } =
-    useResourcesWithDocumentsQuery();
+  const { data: resources, isLoading: isLoadingResources } = useResourcesWithDocumentsQuery();
 
   const selectedResource = useMemo(() => {
     if (!selectedDocument?.value || !resources) {

--- a/packages/client/src/pages/Stats/DocumentTable/DocumentTable.tsx
+++ b/packages/client/src/pages/Stats/DocumentTable/DocumentTable.tsx
@@ -8,6 +8,10 @@ import { BaseDropdown, Loader, Table, Timestamp } from "components";
 import { EmptyEntityTag, EntityTag } from "components/advanced";
 import { UserTag } from "components/advanced/UserTag/UserTag";
 import { useResizeObserver } from "hooks";
+import {
+  useDocumentsQuery,
+  useResourcesWithDocumentsQuery,
+} from "hooks/react-query";
 import { useMemo } from "react";
 import { Column } from "react-table";
 import {
@@ -146,24 +150,11 @@ export const DocumentTable: React.FC<DocumentTableProps> = ({
       debounceDelay: 50,
     });
 
-  const { data: dataDocuments, isLoading: isLoadingDocuments } = useQuery({
-    queryKey: ["documents"],
-    queryFn: async () => {
-      const res = await api.documentsGet({});
-      return res.data;
-    },
-  });
+  const { data: dataDocuments, isLoading: isLoadingDocuments } =
+    useDocumentsQuery();
 
-  const { data: resources, isLoading: isLoadingResources } = useQuery({
-    queryKey: ["resourcesWithDocuments"],
-    queryFn: async () => {
-      const res = await api.entitiesSearch({
-        resourceHasDocument: true,
-      });
-      return res.data ?? [];
-    },
-    enabled: api.isLoggedIn(),
-  });
+  const { data: resources, isLoading: isLoadingResources } =
+    useResourcesWithDocumentsQuery();
 
   const selectedResource = useMemo(() => {
     if (!selectedDocument?.value || !resources) {

--- a/packages/client/src/pages/Users/containers/UserList/UserList.tsx
+++ b/packages/client/src/pages/Users/containers/UserList/UserList.tsx
@@ -42,6 +42,7 @@ import {
 import { UserListTableRow } from "./UserListTableRow/UserListTableRow";
 import { UserListUsernameInput } from "./UserListUsernameInput/UserListUsernameInput";
 import { UsersUtils } from "./UsersUtils";
+import { ButtonSize } from "types";
 
 const rolePriority: Record<UserEnums.Role, number> = {
   [UserEnums.Role.Owner]: 1,
@@ -602,6 +603,7 @@ export const UserList: React.FC<UserList> = React.memo(() => {
                   setRemovingUserId(userId);
                 }}
                 shape="sharp-square"
+                size={ButtonSize.Medium}
               />
               <Button
                 icon={<FaKey size={14} />}
@@ -612,6 +614,7 @@ export const UserList: React.FC<UserList> = React.memo(() => {
                   resetPasswordMutation.mutate(userId);
                 }}
                 shape="sharp-square"
+                size={ButtonSize.Medium}
               />
               {canVerifyManually && !verified && (
                 <Button
@@ -631,6 +634,7 @@ export const UserList: React.FC<UserList> = React.memo(() => {
                     );
                   }}
                   shape="sharp-square"
+                  size={ButtonSize.Medium}
                 />
               )}
               <Button
@@ -654,6 +658,7 @@ export const UserList: React.FC<UserList> = React.memo(() => {
                   );
                 }}
                 shape="sharp-square"
+                size={ButtonSize.Medium}
               />
             </StyledUserListButtonGroup>
           );

--- a/packages/client/src/pages/Users/containers/UserList/UserList.tsx
+++ b/packages/client/src/pages/Users/containers/UserList/UserList.tsx
@@ -13,9 +13,9 @@ import {
   FaKey,
   FaToggleOff,
   FaToggleOn,
-  FaTrashAlt,
   FaUserCheck,
 } from "react-icons/fa";
+import { IcoTrash } from "Theme/icons";
 import { CellProps, Column, Row, useTable } from "react-table";
 import { toast } from "react-toastify";
 import { getUserIcon } from "utils/iconUtils";
@@ -385,7 +385,7 @@ export const UserList: React.FC<UserList> = React.memo(() => {
                             <Button
                               key="d"
                               tooltipLabel="remove invalid territory"
-                              icon={<FaTrashAlt />}
+                              icon={<IcoTrash />}
                               color="danger"
                               noBorder
                               onClick={() => {
@@ -461,7 +461,7 @@ export const UserList: React.FC<UserList> = React.memo(() => {
                               <Button
                                 key="d"
                                 tooltipLabel="remove invalid territory"
-                                icon={<FaTrashAlt />}
+                                icon={<IcoTrash />}
                                 color="danger"
                                 noBorder
                                 onClick={() => {
@@ -535,7 +535,7 @@ export const UserList: React.FC<UserList> = React.memo(() => {
                               <Button
                                 key="d"
                                 tooltipLabel="remove invalid resource"
-                                icon={<FaTrashAlt />}
+                                icon={<IcoTrash />}
                                 color="danger"
                                 noBorder
                                 onClick={() => {
@@ -593,7 +593,7 @@ export const UserList: React.FC<UserList> = React.memo(() => {
             <StyledUserListButtonGroup>
               <Button
                 key="r"
-                icon={<FaTrashAlt size={14} />}
+                icon={<IcoTrash size={14} />}
                 color="danger"
                 tooltipLabel={deleteTooltip}
                 disabled={

--- a/packages/client/src/pages/Users/containers/UserList/UserListStyles.tsx
+++ b/packages/client/src/pages/Users/containers/UserList/UserListStyles.tsx
@@ -232,6 +232,7 @@ export const StyledNotActiveText = styled.p`
 export const StyledUserListButtonGroup = styled.div`
   display: flex;
   flex-direction: row;
+  gap: 0.2rem;
   border-radius: ${({ theme }) => theme.borderRadius["rounded-sm"]};
   overflow: hidden;
   z-index: 100;

--- a/packages/client/src/pages/Users/containers/UserList/UsersUtils.tsx
+++ b/packages/client/src/pages/Users/containers/UserList/UsersUtils.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from "react";
+import React, { useState } from "react";
 import { toast } from "react-toastify";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { FaPlus } from "react-icons/fa";

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -7,12 +7,12 @@ import {
   IStatementAction,
   Relation,
 } from "@inkvisitor/shared/types";
-import { ThemeColor } from "Theme/theme";
+import { FlatThemeColor } from "Theme/theme";
 import { AxiosResponse } from "axios";
 
 interface IEntityColor {
   entityClass: EntityEnums.ExtendedClass;
-  color: keyof ThemeColor;
+  color: FlatThemeColor;
   label: string;
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -193,6 +193,9 @@ importers:
       '@redux-devtools/extension':
         specifier: ^3.3.0
         version: 3.3.0(redux@5.0.1)
+      '@tanstack/eslint-plugin-query':
+        specifier: ^5.101.2
+        version: 5.101.2(@typescript/typescript6@6.0.1)(eslint@8.57.1)
       '@tanstack/react-query-devtools':
         specifier: ^5.100.10
         version: 5.100.13(@tanstack/react-query@5.100.13(react@19.2.6))(react@19.2.6)
@@ -1664,6 +1667,15 @@ packages:
   '@standard-schema/utils@0.3.0':
     resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
 
+  '@tanstack/eslint-plugin-query@5.101.2':
+    resolution: {integrity: sha512-cPE99s3XZwlObfn8lCezT4j4JLj2CVzpIEywx0H4hzfPsX/o9QhdwaOwcDXxrQAqx2ds7TbvTinxhB8B/ywb6w==}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: ^5.4.0 || ^6.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   '@tanstack/query-core@5.100.13':
     resolution: {integrity: sha512-mlKVKMTzZWGTKAC1CKOgt7axAjJ921emkEvYIp27I/PdP1yEYL/BteLY8iK35gn8hoYeKB4mgJ/ve3lrDI6/Fw==}
 
@@ -2131,6 +2143,12 @@ packages:
       typescript:
         optional: true
 
+  '@typescript-eslint/project-service@8.62.1':
+    resolution: {integrity: sha512-yQ3RgY5RkSBpsNS1Bx/JQEcA24FOSdfGktoyprAr5u18390UQdtVcfnEv4nIrIshNnavlVyZBKxQwT1fIAE6cg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
   '@typescript-eslint/scope-manager@5.62.0':
     resolution: {integrity: sha512-VXuvVvZeQCQb5Zgf4HAxc04q5j+WrNAtNh9OwCsCgpKqESMTu3tF/jhZ3xG6T4NZwWl65Bg8KuS2uEvhSfLl0w==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -2138,6 +2156,16 @@ packages:
   '@typescript-eslint/scope-manager@6.21.0':
     resolution: {integrity: sha512-OwLUIWZJry80O99zvqXVEioyniJMa+d2GrqpUTqi5/v5D5rOrppJVBPa0yKCblcigC0/aYAzxxqQ1B+DS2RYsg==}
     engines: {node: ^16.0.0 || >=18.0.0}
+
+  '@typescript-eslint/scope-manager@8.62.1':
+    resolution: {integrity: sha512-r4d249KbQ1SFdpeStvob8Ih6aPPIzfqllPVOtvhve6ZcpuVcYo5/7zUWckKpHE7StASX4kTKZTLf0WQm/wPkcg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/tsconfig-utils@8.62.1':
+    resolution: {integrity: sha512-xadytJqX9vJVQ2fdQjkcIVigwaOJNWkpjdLt6cEQ+xPnrI1fkp+/jZE/I97k9KUjqtpd25i0HeyZf3T6dutv2g==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
 
   '@typescript-eslint/type-utils@5.62.0':
     resolution: {integrity: sha512-xsSQreu+VnfbqQpW5vnCJdq1Z3Q0U31qiWmRhr98ONQmcp/yhiPJFPq8MXiJVLiksmOKSjIldZzkebzHuCGzew==}
@@ -2167,6 +2195,10 @@ packages:
     resolution: {integrity: sha512-1kFmZ1rOm5epu9NZEZm1kckCDGj5UJEf7P1kliH4LKu/RkwpsfqqGmY2OOcUs18lSlQBKLDYBOGxRVtrMN5lpg==}
     engines: {node: ^16.0.0 || >=18.0.0}
 
+  '@typescript-eslint/types@8.62.1':
+    resolution: {integrity: sha512-ooCzJFaf+Hg+uG6fA3NRFGuFjlfNlDhBthbv4ZPU/0elCAFUfnyXUvf/WOpHz/jYwSmvU2GkR2LtyUfy1AxZ1Q==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
   '@typescript-eslint/typescript-estree@5.62.0':
     resolution: {integrity: sha512-CmcQ6uY7b9y694lKdRB8FEel7JbU/40iSAPomu++SjLMntB+2Leay2LO6i8VnJk58MtE9/nQSFIH6jpyRWyYzA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -2185,6 +2217,12 @@ packages:
       typescript:
         optional: true
 
+  '@typescript-eslint/typescript-estree@8.62.1':
+    resolution: {integrity: sha512-xMcW9oP9u7fAMXYs9A65CVmtLQe2r//oXINHfi8HV+oiqhih17sbLdhXr4540YWlgpDKQdY854OL5ZrdCiQsAA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
   '@typescript-eslint/utils@5.62.0':
     resolution: {integrity: sha512-n8oxjeb5aIbPFEtmQxQYOLI0i9n5ySBEY/ZEHHZqKQSFnxio1rv6dthascc9dLuwrL0RC5mPCxB7vnAVGAYWAQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -2197,6 +2235,13 @@ packages:
     peerDependencies:
       eslint: ^7.0.0 || ^8.0.0
 
+  '@typescript-eslint/utils@8.62.1':
+    resolution: {integrity: sha512-sHtbPfuKNZCG+ih8SyjjucqRntSVmp8XgL5u6o9mAhiSn8ds5o/M/XdM0abweme2Tln3szOstOrZ9OXitvPh0g==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
   '@typescript-eslint/visitor-keys@5.62.0':
     resolution: {integrity: sha512-07ny+LHRzQXepkGg6w0mFY41fVUNBrL2Roj/++7V1txKugfjm/Ci/qSND03r2RhlJhJYMcTn9AhhSSqQp0Ysyw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -2204,6 +2249,10 @@ packages:
   '@typescript-eslint/visitor-keys@6.21.0':
     resolution: {integrity: sha512-JJtkDduxLi9bivAB+cYOVMtbkqdPOhZ+ZI5LC47MIRrDV4Yn2o+ZnW10Nkmr28xRpSpdJ6Sm42Hjf2+REYXm0A==}
     engines: {node: ^16.0.0 || >=18.0.0}
+
+  '@typescript-eslint/visitor-keys@8.62.1':
+    resolution: {integrity: sha512-4g3BLxfdTMy8iZG0MaBkadnlRrCJ74cQiFbyEVMrkwIoqdyaXXQM22cotDvrl4x28wgIZ9rEJRoM+mmhSJpJ1g==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260421.2':
     resolution: {integrity: sha512-fHv1r3ZmVo6zxuAIFmuX3w9QxbcauoG0SsWhmDwm6VmRubLlOJIcmTtlmV3JAb9oOnq8LuzZljzT7Q39fSMQDw==}
@@ -3567,6 +3616,10 @@ packages:
   eslint-visitor-keys@3.4.3:
     resolution: {integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  eslint-visitor-keys@5.0.1:
+    resolution: {integrity: sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
   eslint@8.57.1:
     resolution: {integrity: sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==}
@@ -6385,6 +6438,12 @@ packages:
     peerDependencies:
       typescript: '>=4.2.0'
 
+  ts-api-utils@2.5.0:
+    resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
+    engines: {node: '>=18.12'}
+    peerDependencies:
+      typescript: '>=4.8.4'
+
   ts-jest@29.1.5:
     resolution: {integrity: sha512-UuClSYxM7byvvYfyWdFI+/2UxMmwNyJb0NPkZPQE2hew3RurV7l7zURgOHAd/1I1ZdPpe3GUsXNXAcN8TFKSIg==}
     engines: {node: ^14.15.0 || ^16.10.0 || ^18.0.0 || >=20.0.0}
@@ -8534,6 +8593,15 @@ snapshots:
 
   '@standard-schema/utils@0.3.0': {}
 
+  '@tanstack/eslint-plugin-query@5.101.2(@typescript/typescript6@6.0.1)(eslint@8.57.1)':
+    dependencies:
+      '@typescript-eslint/utils': 8.62.1(@typescript/typescript6@6.0.1)(eslint@8.57.1)
+      eslint: 8.57.1
+    optionalDependencies:
+      typescript: '@typescript/typescript6@6.0.1'
+    transitivePeerDependencies:
+      - supports-color
+
   '@tanstack/query-core@5.100.13': {}
 
   '@tanstack/query-devtools@5.100.13': {}
@@ -9082,6 +9150,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/project-service@8.62.1(@typescript/typescript6@6.0.1)':
+    dependencies:
+      '@typescript-eslint/tsconfig-utils': 8.62.1(@typescript/typescript6@6.0.1)
+      '@typescript-eslint/types': 8.62.1
+      debug: 4.4.3(supports-color@5.5.0)
+      typescript: '@typescript/typescript6@6.0.1'
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/scope-manager@5.62.0':
     dependencies:
       '@typescript-eslint/types': 5.62.0
@@ -9091,6 +9168,15 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 6.21.0
       '@typescript-eslint/visitor-keys': 6.21.0
+
+  '@typescript-eslint/scope-manager@8.62.1':
+    dependencies:
+      '@typescript-eslint/types': 8.62.1
+      '@typescript-eslint/visitor-keys': 8.62.1
+
+  '@typescript-eslint/tsconfig-utils@8.62.1(@typescript/typescript6@6.0.1)':
+    dependencies:
+      typescript: '@typescript/typescript6@6.0.1'
 
   '@typescript-eslint/type-utils@5.62.0(@typescript/typescript6@6.0.1)(eslint@8.57.1)':
     dependencies:
@@ -9120,6 +9206,8 @@ snapshots:
 
   '@typescript-eslint/types@6.21.0': {}
 
+  '@typescript-eslint/types@8.62.1': {}
+
   '@typescript-eslint/typescript-estree@5.62.0(@typescript/typescript6@6.0.1)':
     dependencies:
       '@typescript-eslint/types': 5.62.0
@@ -9145,6 +9233,21 @@ snapshots:
       semver: 7.8.1
       ts-api-utils: 1.4.3(@typescript/typescript6@6.0.1)
     optionalDependencies:
+      typescript: '@typescript/typescript6@6.0.1'
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/typescript-estree@8.62.1(@typescript/typescript6@6.0.1)':
+    dependencies:
+      '@typescript-eslint/project-service': 8.62.1(@typescript/typescript6@6.0.1)
+      '@typescript-eslint/tsconfig-utils': 8.62.1(@typescript/typescript6@6.0.1)
+      '@typescript-eslint/types': 8.62.1
+      '@typescript-eslint/visitor-keys': 8.62.1
+      debug: 4.4.3(supports-color@5.5.0)
+      minimatch: 10.2.5
+      semver: 7.8.1
+      tinyglobby: 0.2.16
+      ts-api-utils: 2.5.0(@typescript/typescript6@6.0.1)
       typescript: '@typescript/typescript6@6.0.1'
     transitivePeerDependencies:
       - supports-color
@@ -9178,6 +9281,17 @@ snapshots:
       - supports-color
       - typescript
 
+  '@typescript-eslint/utils@8.62.1(@typescript/typescript6@6.0.1)(eslint@8.57.1)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@8.57.1)
+      '@typescript-eslint/scope-manager': 8.62.1
+      '@typescript-eslint/types': 8.62.1
+      '@typescript-eslint/typescript-estree': 8.62.1(@typescript/typescript6@6.0.1)
+      eslint: 8.57.1
+      typescript: '@typescript/typescript6@6.0.1'
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/visitor-keys@5.62.0':
     dependencies:
       '@typescript-eslint/types': 5.62.0
@@ -9187,6 +9301,11 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 6.21.0
       eslint-visitor-keys: 3.4.3
+
+  '@typescript-eslint/visitor-keys@8.62.1':
+    dependencies:
+      '@typescript-eslint/types': 8.62.1
+      eslint-visitor-keys: 5.0.1
 
   '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260421.2':
     optional: true
@@ -10618,6 +10737,8 @@ snapshots:
       estraverse: 5.3.0
 
   eslint-visitor-keys@3.4.3: {}
+
+  eslint-visitor-keys@5.0.1: {}
 
   eslint@8.57.1:
     dependencies:
@@ -14093,6 +14214,10 @@ snapshots:
       tslib: 2.8.1
 
   ts-api-utils@1.4.3(@typescript/typescript6@6.0.1):
+    dependencies:
+      typescript: '@typescript/typescript6@6.0.1'
+
+  ts-api-utils@2.5.0(@typescript/typescript6@6.0.1):
     dependencies:
       typescript: '@typescript/typescript6@6.0.1'
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -136,8 +136,8 @@ importers:
         specifier: ^2.0.5
         version: 2.0.5(react@19.2.6)
       react-icons:
-        specifier: ^5.6.0
-        version: 5.6.0(react@19.2.6)
+        specifier: ^5.7.0
+        version: 5.7.0(react@19.2.6)
       react-json-view:
         specifier: ^1.21.3
         version: 1.21.3(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -176,7 +176,7 @@ importers:
         version: 11.11.4(@types/react@19.2.15)(immer@11.1.8)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       recharts:
         specifier: ^3.8.1
-        version: 3.8.1(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react-is@19.2.6)(react@19.2.6)(redux@5.0.1)
+        version: 3.8.1(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react-is@19.2.7)(react@19.2.6)(redux@5.0.1)
       redux:
         specifier: ^5.0.1
         version: 5.0.1
@@ -571,6 +571,10 @@ packages:
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/code-frame@7.29.7':
+    resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/compat-data@7.29.3':
     resolution: {integrity: sha512-LIVqM46zQWZhj17qA8wb4nW/ixr2y1Nw+r1etiAWgRM6U1IqP+LNhL1yg440jYZR72jCWcWbLWzIosH+uP1fqg==}
     engines: {node: '>=6.9.0'}
@@ -583,6 +587,10 @@ packages:
     resolution: {integrity: sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/generator@7.29.7':
+    resolution: {integrity: sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-annotate-as-pure@7.27.3':
     resolution: {integrity: sha512-fXSwMQqitTGeHLBC08Eq5yXz2m37E4pJX1qAU1+2cNedz/ifv/bVXft90VeSav5nFO61EcNgwr0aJxbyPaWBPg==}
     engines: {node: '>=6.9.0'}
@@ -593,6 +601,10 @@ packages:
 
   '@babel/helper-globals@7.28.0':
     resolution: {integrity: sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-globals@7.29.7':
+    resolution: {integrity: sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-module-imports@7.28.6':
@@ -613,8 +625,16 @@ packages:
     resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-string-parser@7.29.7':
+    resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-validator-identifier@7.28.5':
     resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.29.7':
+    resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-validator-option@7.27.1':
@@ -627,6 +647,11 @@ packages:
 
   '@babel/parser@7.29.3':
     resolution: {integrity: sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/parser@7.29.7':
+    resolution: {integrity: sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -737,16 +762,32 @@ packages:
     resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/runtime@7.29.7':
+    resolution: {integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/template@7.28.6':
     resolution: {integrity: sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/template@7.29.7':
+    resolution: {integrity: sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==}
     engines: {node: '>=6.9.0'}
 
   '@babel/traverse@7.29.0':
     resolution: {integrity: sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/traverse@7.29.7':
+    resolution: {integrity: sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/types@7.29.0':
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.29.7':
+    resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
     engines: {node: '>=6.9.0'}
 
   '@bcoe/v8-coverage@0.2.3':
@@ -1983,6 +2024,9 @@ packages:
 
   '@types/node@24.12.4':
     resolution: {integrity: sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA==}
+
+  '@types/node@24.13.2':
+    resolution: {integrity: sha512-fRa09kZTgu8o71KFcDjUFuc7F+dEbZYZmkI0mg5YBTRs0yMKjYHsq/c0urDKeDb+D5qVgXOdFcuu+DZPKOITwA==}
 
   '@types/nodemailer@6.4.23':
     resolution: {integrity: sha512-aFV3/NsYFLSx9mbb5gtirBSXJnAlrusoKNuPbxsASWc7vrKLmIrTQRpdcxNcSFL3VW2A2XpeLEavwb2qMi6nlQ==}
@@ -5631,8 +5675,8 @@ packages:
     peerDependencies:
       react: ^16.6.0 || ^17.0.0 || ^18.0.0
 
-  react-icons@5.6.0:
-    resolution: {integrity: sha512-RH93p5ki6LfOiIt0UtDyNg/cee+HLVR6cHHtW3wALfo+eOHTp8RnU2kRkI6E+H19zMIs03DyxUG/GfZMOGvmiA==}
+  react-icons@5.7.0:
+    resolution: {integrity: sha512-LBLy340Rzqy6+/yVhZKT3B/QpP1BZaesGqasf09HPOBzRarcDIFH0WwXlXQfE7q7ipxK4MSiC5DIBWURCny6fw==}
     peerDependencies:
       react: '*'
 
@@ -5642,8 +5686,8 @@ packages:
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
 
-  react-is@19.2.6:
-    resolution: {integrity: sha512-XjBR15BhXuylgWGuslhDKqlSayuqvqBX91BP8pauG8kd1zY8kotkNWbXksTCNRarse4kuGbe2kIY05ARtwNIvw==}
+  react-is@19.2.7:
+    resolution: {integrity: sha512-kZFnouyVv7eP/Phmrlo9FK+zcAdriZJvzxXHF1Sl1P377WSGe2G/JxVolhTrB/jeV47lKImhNUsijjHAAbcl/A==}
 
   react-json-view@1.21.3:
     resolution: {integrity: sha512-13p8IREj9/x/Ye4WI/JpjhoIwuzEgUAtgJZNBJckfzJt1qyh24BdTm6UQNGnyTq9dapQdrqvquZTo3dz1X6Cjw==}
@@ -5998,6 +6042,11 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  semver@7.8.5:
+    resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
   send@0.19.2:
     resolution: {integrity: sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==}
     engines: {node: '>= 0.8.0'}
@@ -6046,6 +6095,10 @@ packages:
 
   shell-quote@1.8.4:
     resolution: {integrity: sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==}
+    engines: {node: '>= 0.4'}
+
+  shell-quote@1.9.0:
+    resolution: {integrity: sha512-Iov+JwFv/2HcTpcwNMKd8+IWNb8tboQJNQTkAY/LLVK7gGH9jy+LGkVqPxfekHl+yMmiqXszdGWXgkfml7hjqA==}
     engines: {node: '>= 0.4'}
 
   side-channel-list@1.0.1:
@@ -6374,6 +6427,10 @@ packages:
     resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
     engines: {node: '>=12.0.0'}
 
+  tinyglobby@0.2.17:
+    resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
+    engines: {node: '>=12.0.0'}
+
   tinyrainbow@3.1.0:
     resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
     engines: {node: '>=14.0.0'}
@@ -6636,6 +6693,9 @@ packages:
 
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
+
+  undici-types@7.18.2:
+    resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
 
   undici@7.25.0:
     resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
@@ -7078,6 +7138,10 @@ packages:
     resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
     engines: {node: '>=12'}
 
+  yargs@17.7.3:
+    resolution: {integrity: sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==}
+    engines: {node: '>=12'}
+
   yn@3.1.1:
     resolution: {integrity: sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==}
     engines: {node: '>=6'}
@@ -7116,8 +7180,8 @@ packages:
       react:
         optional: true
 
-  zustand@5.0.13:
-    resolution: {integrity: sha512-efI2tVaVQPqtOh114loML/Z80Y4NP3yc+Ff0fYiZJPauNeWZeIp/bRFD7I9bfmCOYBh/PHxlglQ9+wvlwnPikQ==}
+  zustand@5.0.14:
+    resolution: {integrity: sha512-/8tAspM5LMPr28b3fwLYrtdj77ECpfZviaP75CMTnwO8ISyaE4GDIG/9rDDYq/cH9D2Xw2A2RXglLInmVBQB/g==}
     engines: {node: '>=12.20.0'}
     peerDependencies:
       '@types/react': '>=18.0.0'
@@ -7188,6 +7252,12 @@ snapshots:
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
+  '@babel/code-frame@7.29.7':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.29.7
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
   '@babel/compat-data@7.29.3': {}
 
   '@babel/core@7.29.0':
@@ -7218,6 +7288,14 @@ snapshots:
       '@jridgewell/trace-mapping': 0.3.31
       jsesc: 3.1.0
 
+  '@babel/generator@7.29.7':
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+      jsesc: 3.1.0
+
   '@babel/helper-annotate-as-pure@7.27.3':
     dependencies:
       '@babel/types': 7.29.0
@@ -7231,6 +7309,8 @@ snapshots:
       semver: 6.3.1
 
   '@babel/helper-globals@7.28.0': {}
+
+  '@babel/helper-globals@7.29.7': {}
 
   '@babel/helper-module-imports@7.28.6':
     dependencies:
@@ -7252,7 +7332,11 @@ snapshots:
 
   '@babel/helper-string-parser@7.27.1': {}
 
+  '@babel/helper-string-parser@7.29.7': {}
+
   '@babel/helper-validator-identifier@7.28.5': {}
+
+  '@babel/helper-validator-identifier@7.29.7': {}
 
   '@babel/helper-validator-option@7.27.1': {}
 
@@ -7264,6 +7348,10 @@ snapshots:
   '@babel/parser@7.29.3':
     dependencies:
       '@babel/types': 7.29.0
+
+  '@babel/parser@7.29.7':
+    dependencies:
+      '@babel/types': 7.29.7
 
   '@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.29.0)':
     dependencies:
@@ -7362,11 +7450,19 @@ snapshots:
 
   '@babel/runtime@7.29.2': {}
 
+  '@babel/runtime@7.29.7': {}
+
   '@babel/template@7.28.6':
     dependencies:
       '@babel/code-frame': 7.29.0
       '@babel/parser': 7.29.3
       '@babel/types': 7.29.0
+
+  '@babel/template@7.29.7':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
 
   '@babel/traverse@7.29.0':
     dependencies:
@@ -7380,10 +7476,27 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/traverse@7.29.7':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/generator': 7.29.7
+      '@babel/helper-globals': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/template': 7.29.7
+      '@babel/types': 7.29.7
+      debug: 4.4.3(supports-color@5.5.0)
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/types@7.29.0':
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
+
+  '@babel/types@7.29.7':
+    dependencies:
+      '@babel/helper-string-parser': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
 
   '@bcoe/v8-coverage@0.2.3': {}
 
@@ -8260,12 +8373,12 @@ snapshots:
   '@react-native/codegen@0.85.3(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/parser': 7.29.3
+      '@babel/parser': 7.29.7
       hermes-parser: 0.33.3
       invariant: 2.2.4
       nullthrows: 1.1.1
-      tinyglobby: 0.2.16
-      yargs: 17.7.2
+      tinyglobby: 0.2.17
+      yargs: 17.7.3
 
   '@react-native/community-cli-plugin@0.85.3':
     dependencies:
@@ -8275,7 +8388,7 @@ snapshots:
       metro: 0.84.4
       metro-config: 0.84.4
       metro-core: 0.84.4
-      semver: 7.8.1
+      semver: 7.8.5
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -8400,7 +8513,7 @@ snapshots:
 
   '@react-three/fiber@9.6.1(@types/react@19.2.15)(immer@11.1.8)(react-dom@19.2.6(react@19.2.6))(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)(three@0.184.0)':
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.29.7
       '@types/webxr': 0.5.24
       base64-js: 1.5.1
       buffer: 6.0.3
@@ -8411,7 +8524,7 @@ snapshots:
       suspend-react: 0.1.3(react@19.2.6)
       three: 0.184.0
       use-sync-external-store: 1.6.0(react@19.2.6)
-      zustand: 5.0.13(@types/react@19.2.15)(immer@11.1.8)(react@19.2.6)(use-sync-external-store@1.6.0(react@19.2.6))
+      zustand: 5.0.14(@types/react@19.2.15)(immer@11.1.8)(react@19.2.6)(use-sync-external-store@1.6.0(react@19.2.6))
     optionalDependencies:
       react-dom: 19.2.6(react@19.2.6)
       react-native: 0.85.3(@babel/core@7.29.0)(@types/react@19.2.15)(react@19.2.6)
@@ -8953,6 +9066,10 @@ snapshots:
   '@types/node@24.12.4':
     dependencies:
       undici-types: 7.16.0
+
+  '@types/node@24.13.2':
+    dependencies:
+      undici-types: 7.18.2
 
   '@types/nodemailer@6.4.23':
     dependencies:
@@ -10001,7 +10118,7 @@ snapshots:
 
   chrome-launcher@0.15.2:
     dependencies:
-      '@types/node': 20.19.41
+      '@types/node': 24.13.2
       escape-string-regexp: 4.0.0
       is-wsl: 2.2.0
       lighthouse-logger: 1.4.2
@@ -10012,7 +10129,7 @@ snapshots:
 
   chromium-edge-launcher@0.3.0:
     dependencies:
-      '@types/node': 20.19.41
+      '@types/node': 24.13.2
       escape-string-regexp: 4.0.0
       is-wsl: 2.2.0
       lighthouse-logger: 1.4.2
@@ -12762,13 +12879,13 @@ snapshots:
 
   metro-runtime@0.84.4:
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.29.7
       flow-enums-runtime: 0.0.6
 
   metro-source-map@0.84.4:
     dependencies:
-      '@babel/traverse': 7.29.0
-      '@babel/types': 7.29.0
+      '@babel/traverse': 7.29.7
+      '@babel/types': 7.29.7
       flow-enums-runtime: 0.0.6
       invariant: 2.2.4
       metro-symbolicate: 0.84.4
@@ -12793,9 +12910,9 @@ snapshots:
   metro-transform-plugins@0.84.4:
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/generator': 7.29.1
-      '@babel/template': 7.28.6
-      '@babel/traverse': 7.29.0
+      '@babel/generator': 7.29.7
+      '@babel/template': 7.29.7
+      '@babel/traverse': 7.29.7
       flow-enums-runtime: 0.0.6
       nullthrows: 1.1.1
     transitivePeerDependencies:
@@ -12804,9 +12921,9 @@ snapshots:
   metro-transform-worker@0.84.4:
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/generator': 7.29.1
-      '@babel/parser': 7.29.3
-      '@babel/types': 7.29.0
+      '@babel/generator': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
       flow-enums-runtime: 0.0.6
       metro: 0.84.4
       metro-babel-transformer: 0.84.4
@@ -12823,13 +12940,13 @@ snapshots:
 
   metro@0.84.4:
     dependencies:
-      '@babel/code-frame': 7.29.0
+      '@babel/code-frame': 7.29.7
       '@babel/core': 7.29.0
-      '@babel/generator': 7.29.1
-      '@babel/parser': 7.29.3
-      '@babel/template': 7.28.6
-      '@babel/traverse': 7.29.0
-      '@babel/types': 7.29.0
+      '@babel/generator': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/template': 7.29.7
+      '@babel/traverse': 7.29.7
+      '@babel/types': 7.29.7
       accepts: 2.0.0
       ci-info: 2.0.0
       connect: 3.7.0
@@ -12861,7 +12978,7 @@ snapshots:
       source-map: 0.5.7
       throat: 5.0.0
       ws: 7.5.11
-      yargs: 17.7.2
+      yargs: 17.7.3
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -13207,7 +13324,7 @@ snapshots:
       '@jest/schemas': 30.4.1
       ansi-styles: 5.2.0
       react-is-18: react-is@18.3.1
-      react-is-19: react-is@19.2.6
+      react-is-19: react-is@19.2.7
 
   process-nextick-args@2.0.1: {}
 
@@ -13295,7 +13412,7 @@ snapshots:
 
   react-devtools-core@6.1.5:
     dependencies:
-      shell-quote: 1.8.4
+      shell-quote: 1.9.0
       ws: 7.5.11
     transitivePeerDependencies:
       - bufferutil
@@ -13345,7 +13462,7 @@ snapshots:
       react-fast-compare: 3.2.2
       shallowequal: 1.1.0
 
-  react-icons@5.6.0(react@19.2.6):
+  react-icons@5.7.0(react@19.2.6):
     dependencies:
       react: 19.2.6
 
@@ -13353,7 +13470,7 @@ snapshots:
 
   react-is@18.3.1: {}
 
-  react-is@19.2.6: {}
+  react-is@19.2.7: {}
 
   react-json-view@1.21.3(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     dependencies:
@@ -13410,12 +13527,12 @@ snapshots:
       react-refresh: 0.14.2
       regenerator-runtime: 0.13.11
       scheduler: 0.27.0
-      semver: 7.8.1
+      semver: 7.8.5
       stacktrace-parser: 0.1.11
-      tinyglobby: 0.2.16
+      tinyglobby: 0.2.17
       whatwg-fetch: 3.6.20
       ws: 7.5.11
-      yargs: 17.7.2
+      yargs: 17.7.3
     optionalDependencies:
       '@types/react': 19.2.15
     transitivePeerDependencies:
@@ -13605,7 +13722,7 @@ snapshots:
 
   readline@1.3.0: {}
 
-  recharts@3.8.1(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react-is@19.2.6)(react@19.2.6)(redux@5.0.1):
+  recharts@3.8.1(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react-is@19.2.7)(react@19.2.6)(redux@5.0.1):
     dependencies:
       '@reduxjs/toolkit': 2.12.0(react-redux@9.3.0(@types/react@19.2.15)(react@19.2.6)(redux@5.0.1))(react@19.2.6)
       clsx: 2.1.1
@@ -13615,7 +13732,7 @@ snapshots:
       immer: 10.2.0
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
-      react-is: 19.2.6
+      react-is: 19.2.7
       react-redux: 9.3.0(@types/react@19.2.15)(react@19.2.6)(redux@5.0.1)
       reselect: 5.1.1
       tiny-invariant: 1.3.3
@@ -13780,6 +13897,8 @@ snapshots:
 
   semver@7.8.1: {}
 
+  semver@7.8.5: {}
+
   send@0.19.2:
     dependencies:
       debug: 2.6.9
@@ -13846,6 +13965,8 @@ snapshots:
   shebang-regex@3.0.0: {}
 
   shell-quote@1.8.4: {}
+
+  shell-quote@1.9.0: {}
 
   side-channel-list@1.0.1:
     dependencies:
@@ -14167,6 +14288,11 @@ snapshots:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
 
+  tinyglobby@0.2.17:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+
   tinyrainbow@3.1.0: {}
 
   tldts-core@6.1.86: {}
@@ -14421,6 +14547,8 @@ snapshots:
   undici-types@6.21.0: {}
 
   undici-types@7.16.0: {}
+
+  undici-types@7.18.2: {}
 
   undici@7.25.0: {}
 
@@ -14858,6 +14986,16 @@ snapshots:
       y18n: 5.0.8
       yargs-parser: 21.1.1
 
+  yargs@17.7.3:
+    dependencies:
+      cliui: 8.0.1
+      escalade: 3.2.0
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      string-width: 4.2.3
+      y18n: 5.0.8
+      yargs-parser: 21.1.1
+
   yn@3.1.1: {}
 
   yocto-queue@0.1.0: {}
@@ -14880,7 +15018,7 @@ snapshots:
       immer: 11.1.8
       react: 19.2.6
 
-  zustand@5.0.13(@types/react@19.2.15)(immer@11.1.8)(react@19.2.6)(use-sync-external-store@1.6.0(react@19.2.6)):
+  zustand@5.0.14(@types/react@19.2.15)(immer@11.1.8)(react@19.2.6)(use-sync-external-store@1.6.0(react@19.2.6)):
     optionalDependencies:
       '@types/react': 19.2.15
       immer: 11.1.8


### PR DESCRIPTION
# Summary

General goal of this issue is to minimize the amount of requests on BE while at the same time ensure fresh data.

This PR reduces redundant API calls across all data types by consolidating React Query usage and adding proper cache staleness control + lazy-load for cases where the data are not on the screen (either down the scroll or visible after dropdown or suggester click).

## Query deduplication & API-call reduction

- Templates share a single cached query, filtering by class/label client-side instead of refetching per view; statement-templates folded into it
- Documents and documentsWithResources queries deduplicated; document refetched on annotator box open
- Statement/document fetches deduplicated; templates refetch only when the apply-template dropdown opens and data is stale
- territoryActants in EntitySuggester lazy-loaded, then fetched on suggester focus; cache seeded from StatementEditor territory data instead of refetching
- Per-breadcrumb entity fetch skipped when the territory is already in the tree cache
- Fourth-panel API calls minimized by gating queries on panel visibility; lazy calls gated more broadly, bookmark staleTime raised
- Entity fetches batched in entity detail box; Message entity fetch moved to useQuery

## Caching (staleTime / targeted refetch)

- Added staleTime to queries that aren't updated often
- Audit data fetches only when its section is in viewport, dedupes user lookups, and reuses already-loaded audit data when switching detail tabs
- Statement-to-detail lookup reads from the editor cache when only checking whether it's open in the editor

## UI/behavior fixes

- Collapsing the third panel now expands the second panel (was expanding the fourth)
- setThirdPanelExpanded dispatched correctly on statementId change
- Extracted useBookmarksQuery / useDetailQuery hooks, replacing inline useQuery calls in EntityBookmarkBox, EntityDetailBox, and ApplyTemplateModal
- Fixed default territory not loading in the user customization modal; simplified that logic and removed unused useQuery variables
- Bookmark folder polish: modal icon/label/width tweaks, SVG close button in annotator settings overlay, table alignment, icon interaction styles
- Icon cleanup: centralized used icons, unified search/trash icons, replaced IcoTrash with lighter IcoTrashSimple (StatementList + TemplateListBox scroll fix)
- StatementList refactor: checkbox size, unified checkbox sizing, odd/even row color swap; StatementListDocumentLine UI improved
- Search box label input full width; WarningIconStyles padding/border-radius consistency
- Various polish: user customization modal layout, UserList buttons, ButtonGroup smallGap prop, tree header button layout

## Other

- Entity colors typed as FlatThemeColor, dropping an unsafe cast
- Added @tanstack/eslint-plugin-query

Close #2931