### PR TITLE
fix(annotator): sort selection anchors from inside outwards (#2051)

### DIFF
--- a/packages/annotator/src/getAnnotationsOrdering.test.ts
+++ b/packages/annotator/src/getAnnotationsOrdering.test.ts
@@ -1,0 +1,116 @@
+import { Annotator } from "./lib/Annotator";
+import { SegmentPosition } from "./lib/Text";
+
+/**
+ * Regression tests for issue #2051: anchors listed for a selection must be
+ * ordered "from inside outwards" — the innermost / most specific anchor first,
+ * then the enclosing ones — while anchors that sit next to each other
+ * (parallel / same-level) keep their order of appearance.
+ */
+
+const mk = (text: string): Annotator => {
+  const c = document.createElement("canvas");
+  c.style.width = "800px";
+  c.style.height = "600px";
+  document.body.appendChild(c);
+  return new Annotator(c, text);
+};
+
+// getAnnotations() only reads `segmentIndex` and `rawTextIndex` from its
+// position arguments, so we can build the selection bounds directly from raw
+// (segment-relative) string offsets.
+const posSeg = (segmentIndex: number, rawTextIndex: number): SegmentPosition => ({
+  segmentIndex,
+  lineIndex: 0,
+  charInLineIndex: 0,
+  parsedTextIndex: 0,
+  rawTextIndex,
+});
+
+// Shorthand for single-segment (single-line) texts.
+const pos = (rawTextIndex: number): SegmentPosition => posSeg(0, rawTextIndex);
+
+const names = (a: Annotator, start: SegmentPosition, end: SegmentPosition) =>
+  a.getAnnotations(start, end).map((tag) => tag.getTagName());
+
+describe("getAnnotations ordering (issue #2051)", () => {
+  test("nested anchors are ordered from inside outwards", () => {
+    // <T1><S1><L1>word</L1></S1></T1>
+    const text = "<T1><S1><L1>word</L1></S1></T1>";
+    const a = mk(text);
+
+    const start = pos(text.indexOf("word"));
+    const end = pos(text.indexOf("word") + "word".length);
+
+    // innermost (Location) first, then its Statement, then the Territory
+    expect(names(a, start, end)).toEqual(["L1", "S1", "T1"]);
+  });
+
+  test("parallel (same-level) anchors keep their order of appearance", () => {
+    // <A>aa</A> <B>bb</B>
+    const text = "<A>aa</A> <B>bb</B>";
+    const a = mk(text);
+
+    const start = pos(text.indexOf("aa"));
+    const end = pos(text.indexOf("bb")); // selection spans both anchors
+
+    expect(names(a, start, end)).toEqual(["A", "B"]);
+  });
+
+  test("mixes nesting and parallel siblings: each branch closes before its parent", () => {
+    // <T><S1>a</S1><S2>b<L1>c</L1>d</S2></T>
+    const text = "<T><S1>a</S1><S2>b<L1>c</L1>d</S2></T>";
+    const a = mk(text);
+
+    const start = pos(text.indexOf("a"));
+    const end = pos(text.indexOf("d") + 1);
+
+    // S1 closes first, then the inner L1, then its parent S2, then T
+    expect(names(a, start, end)).toEqual(["S1", "L1", "S2", "T"]);
+  });
+
+  test("nested anchors whose closing tags are on later lines are still inside->out", () => {
+    // The common real case: a word-level anchor whose enclosing Statement /
+    // Territory anchors close on a later line (later segment). Their closing
+    // tags are never scanned, yet the order must stay inside -> outside.
+    // segment 0: "<T3><T2><S1><L1>Rome"
+    // segment 1: "more text</L1></S1></T2></T3>"
+    const text = "<T3><T2><S1><L1>Rome\nmore text</L1></S1></T2></T3>";
+    const a = mk(text);
+
+    const start = pos(text.indexOf("Rome"));
+    const end = pos(text.indexOf("Rome") + "Rome".length);
+
+    expect(names(a, start, end)).toEqual(["L1", "S1", "T2", "T3"]);
+  });
+
+  test("inner anchor closing in-segment sorts before enclosing anchors closing later", () => {
+    // <L> closes within the selection's segment (finite closing position),
+    // while <S> and <T> stay open into a later segment.
+    // segment 0: "<T><S><L>Rome</L> and more"
+    // segment 1: "text</S></T>"
+    const text = "<T><S><L>Rome</L> and more\ntext</S></T>";
+    const a = mk(text);
+
+    const start = pos(text.indexOf("Rome"));
+    const end = pos(text.indexOf("Rome") + "Rome".length);
+
+    expect(names(a, start, end)).toEqual(["L", "S", "T"]);
+  });
+
+  test("selection spanning several segments: enclosing anchors closing later segments stay inside->out", () => {
+    // The selection itself crosses segment boundaries (end.segmentIndex > 0), so
+    // the enclosing anchors' closing tags fall *inside* the scanned range and are
+    // paired as finite closing positions rather than +Infinity.
+    // segment 0: "<T><S><L>aa"
+    // segment 1: "bb</L> cc"   (</L> closes here)
+    // segment 2: "dd</S></T>"  (</S>, </T> close here)
+    const text = "<T><S><L>aa\nbb</L> cc\ndd</S></T>";
+    const a = mk(text);
+
+    const start = posSeg(0, "<T><S><L>aa".indexOf("aa")); // "aa" in segment 0
+    const end = posSeg(2, "dd</S></T>".indexOf("dd") + "dd".length); // after "dd" in segment 2
+
+    expect(names(a, start, end)).toEqual(["L", "S", "T"]);
+  });
+});

--- a/packages/annotator/src/lib/Annotator.ts
+++ b/packages/annotator/src/lib/Annotator.ts
@@ -2218,18 +2218,51 @@ export class Annotator {
       }
     }
 
-    // Sort tags by their absolute position for consistent ordering
+    // Order the anchors "from inside outwards" (issue #2051): the innermost /
+    // most specific anchor (e.g. a Location on a single word) should come first,
+    // then the enclosing anchors (its Statement, the Territory the Statement is
+    // in, its parent Territory, ...). Anchors that do not nest but sit next to
+    // each other (parallel / same-level) keep their order of appearance.
+    //
+    // We achieve both by sorting on the position where each anchor *closes*
+    // rather than where it opens: a nested anchor always closes before the one
+    // enclosing it, while parallel anchors close in their order of appearance.
+    const openingToClosing = new Map<Tag, Tag>();
+    for (const [closingTag, openingTag] of closingToOpeningMap) {
+      openingToClosing.set(openingTag, closingTag);
+    }
+
+    const getOpenAbsolutePosition = (tag: Tag): number =>
+      tag.segmentIndex !== -1 ? getAbsoluteTextIndex(tag) : tag.position;
+
+    const getCloseAbsolutePosition = (openingTag: Tag): number => {
+      const closingTag = openingToClosing.get(openingTag);
+      // The scan only visits segments up to `end.segmentIndex`, so anchors that
+      // close in a later segment are never paired here. Those are exactly the
+      // anchors that stay open past the selection — the enclosing containers —
+      // so they sort last (their internal order is handled by the tie-break).
+      if (!closingTag) {
+        return Number.POSITIVE_INFINITY;
+      }
+      return getAbsoluteTextIndex(closingTag);
+    };
+
     return processedFinalTags.sort((a, b) => {
-      // Use the segmentIndex from the tags
-      const aSegmentIndex = a.segmentIndex;
-      const bSegmentIndex = b.segmentIndex;
-
-      const aAbsolutePosition =
-        aSegmentIndex !== -1 ? getAbsoluteTextIndex(a) : a.position;
-      const bAbsolutePosition =
-        bSegmentIndex !== -1 ? getAbsoluteTextIndex(b) : b.position;
-
-      return aAbsolutePosition - bAbsolutePosition;
+      const aClose = getCloseAbsolutePosition(a);
+      const bClose = getCloseAbsolutePosition(b);
+      if (aClose !== bClose) {
+        return aClose - bClose;
+      }
+      // Same closing position. Anchors that stay open past the selection (their
+      // closing tag was never scanned) are enclosing containers that form a
+      // proper nesting chain — the one that opened *later* is nested more deeply
+      // and must come first (inside -> outside).
+      if (aClose === Number.POSITIVE_INFINITY) {
+        return getOpenAbsolutePosition(b) - getOpenAbsolutePosition(a);
+      }
+      // Genuine equal closing position (e.g. broken / asymmetrical anchors):
+      // keep them in order of appearance.
+      return getOpenAbsolutePosition(a) - getOpenAbsolutePosition(b);
     });
   }
 


### PR DESCRIPTION
Order the annotator's "Anchors in selection" list from inside outwards-innermost/most specific anchor first (e.g. Location -> Statement -> Territory -> parent Territory), with parallel same-level anchors keeping their order of appearance-by sorting on each anchor's closing position rather than its opening position (closes #2051).

eg
<img width="435" height="564" alt="image" src="https://github.com/user-attachments/assets/10f94f21-31b4-4543-abf0-edc824b474fb" />
