### PR TITLE
fix(client): prevent dangling anchor when creating statement without …

### DIFF
--- a/packages/client/src/components/advanced/Annotator/Annotator.tsx
+++ b/packages/client/src/components/advanced/Annotator/Annotator.tsx
@@ -407,7 +407,7 @@ export const TextAnnotator = ({
       territoryId: string;
       language: EntityEnums.Language;
     },
-  ): Promise<void> => {
+  ): Promise<boolean> => {
     if (dataDocument && statementCreateMutation) {
       // take order from the anchors in the document
       // filter only Statements
@@ -455,6 +455,7 @@ export const TextAnnotator = ({
             newOrder,
           );
           await statementCreateMutation?.mutateAsync(newStatement);
+          return true;
         } else {
           const newStatement: IStatement = CStatement(
             localStorage.getItem("userrole") as UserEnums.Role,
@@ -466,9 +467,11 @@ export const TextAnnotator = ({
             newOrder,
           );
           await statementCreateMutation?.mutateAsync(newStatement);
+          return true;
         }
       }
     }
+    return false;
   };
 
   const [territoryCreateModalType, setTerritoryCreateModalType] =
@@ -1030,7 +1033,7 @@ export const TextAnnotator = ({
       // document is saved first, the new statement's id is dropped from the
       // document's entityIds/anchors tree and the anchor stays invisible (in
       // usedInDocuments) until the document is preprocessed again.
-      await handleCreateStatement(
+      const statementCreated = await handleCreateStatement(
         validatedText,
         newStatementId,
         selectionStartIndex,
@@ -1043,7 +1046,14 @@ export const TextAnnotator = ({
             }
           : undefined,
       );
-      await handleAddAnchor(newStatementId, elvl);
+      // Only anchor the statement into the document once it actually exists.
+      // Otherwise (e.g. no active territory) we would leave a dangling anchor
+      // pointing at a statement that was never created.
+      if (statementCreated) {
+        await handleAddAnchor(newStatementId, elvl);
+      } else {
+        toast.warning("Cannot create statement without an active territory");
+      }
     }
   };
 

--- a/packages/client/src/components/advanced/Annotator/AnnotatorMenu.tsx
+++ b/packages/client/src/components/advanced/Annotator/AnnotatorMenu.tsx
@@ -232,9 +232,11 @@ export const TextAnnotatorMenu = ({
               </StyledAnnotatorItemContentLine>
             </StyledAnnotatorItemContent>
           )}
-          {/* New Statement */}
-          <StyledAnnotatorItemContent>
-            {onCreateStatement && (
+          {/* New Statement - only with an active territory to put the new
+              statement into. Without one, creating a statement would silently
+              fail while still leaving a dangling anchor in the document. */}
+          {onCreateStatement && activeTerritoryId && (
+            <StyledAnnotatorItemContent>
               <StyledAnnotatorItemContentLine>
                 <Button
                   label="New Statement"
@@ -253,8 +255,8 @@ export const TextAnnotatorMenu = ({
                   }}
                 />
               </StyledAnnotatorItemContentLine>
-            )}
-          </StyledAnnotatorItemContent>
+            </StyledAnnotatorItemContent>
+          )}
           {/* Entity Suggester */}
           <StyledAnnotatorItemContent>
             <StyledAnnotatorItemContentLine>


### PR DESCRIPTION
…active territory

Clicking "New Statement" in the annotator added the anchor to the document content even when there was no active territory, so the statement entity was never created and the anchor pointed at a non-existent entity (dropped from the anchors field on read).

fix looks like this - button for statement anchor removed if no territory selected:
<img width="1610" height="1068" alt="image" src="https://github.com/user-attachments/assets/0459cc99-4803-42be-8a28-1a2547c79e35" />
