### PR TITLE
3166 warn before deleting metaprop with child properties

### DIFF
--- a/packages/client/src/components/advanced/UserCustomizationModal/UserCustomizationModal.tsx
+++ b/packages/client/src/components/advanced/UserCustomizationModal/UserCustomizationModal.tsx
@@ -8,6 +8,7 @@ import api from "api";
 import {
   Button,
   ButtonGroup,
+  Checkbox,
   IconWithTooltip,
   Input,
   Loader,
@@ -47,6 +48,7 @@ interface DataObject {
   searchLanguages: EntityEnums.Language[];
   workingLanguages: EntityEnums.Language[];
   defaultTerritory?: string | null;
+  askBeforePropDelete: boolean;
 }
 interface UserCustomizationModal {
   user: IResponseUser;
@@ -82,6 +84,7 @@ export const UserCustomizationModal: React.FC<UserCustomizationModal> = ({
       searchLanguages: options.searchLanguages,
       workingLanguages: options.workingLanguages ?? [],
       defaultTerritory: options.defaultTerritory,
+      askBeforePropDelete: options.askBeforePropDelete !== false,
     };
   }, [user]);
 
@@ -148,6 +151,7 @@ export const UserCustomizationModal: React.FC<UserCustomizationModal> = ({
           searchLanguages: data.searchLanguages.map((sL) => sL),
           workingLanguages: data.workingLanguages.map((wL) => wL),
           defaultTerritory: data.defaultTerritory || "",
+          askBeforePropDelete: data.askBeforePropDelete,
         },
       });
     }
@@ -394,6 +398,21 @@ export const UserCustomizationModal: React.FC<UserCustomizationModal> = ({
                   )}
                 </StyledFieldControl>
                 <StyledFieldHelp />
+
+                <StyledFieldLabel>Ask before deleting metaprop with children</StyledFieldLabel>
+                <StyledFieldControl>
+                  <Checkbox
+                    value={data.askBeforePropDelete}
+                    onChangeFn={(value) => handleChange("askBeforePropDelete", value)}
+                  />
+                </StyledFieldControl>
+                <StyledFieldHelp>
+                  <IconWithTooltip
+                    color="success"
+                    icon={<FaQuestion />}
+                    tooltipLabel="Show a confirmation before deleting a metaprop that has child properties, since they would be deleted too."
+                  />
+                </StyledFieldHelp>
               </StyledFieldGrid>
             </StyledUserCustomizationSection>
             <StyledUserCustomizationSection>

--- a/packages/client/src/pages/Main/containers/PropGroup/PropGroupRow/PropGroupRow.tsx
+++ b/packages/client/src/pages/Main/containers/PropGroup/PropGroupRow/PropGroupRow.tsx
@@ -73,6 +73,12 @@ interface PropGroupRow {
   autoFocusValue?: boolean;
 }
 
+const countAllChildren = (prop: IProp): number =>
+  prop.children.reduce(
+    (sum, child) => sum + 1 + countAllChildren(child),
+    0
+  );
+
 export const PropGroupRow: React.FC<PropGroupRow> = ({
   prop,
   entities,
@@ -356,8 +362,8 @@ export const PropGroupRow: React.FC<PropGroupRow> = ({
       </div>
       <Submit
         title="Delete metaprop"
-        text={`This metaprop has ${prop.children.length} child propert${
-          prop.children.length === 1 ? "y" : "ies"
+        text={`This metaprop has ${countAllChildren(prop)} child propert${
+          countAllChildren(prop) === 1 ? "y" : "ies"
         } which will also be deleted. Do you really want to continue?`}
         submitLabel="Delete"
         show={showDeleteSubmit}

--- a/packages/client/src/pages/Main/containers/PropGroup/PropGroupRow/PropGroupRow.tsx
+++ b/packages/client/src/pages/Main/containers/PropGroup/PropGroupRow/PropGroupRow.tsx
@@ -1,6 +1,7 @@
 import { EntityEnums } from "@inkvisitor/shared/enums";
 import { IEntity, IProp } from "@inkvisitor/shared/types";
-import { AttributeIcon, Button, ButtonGroup } from "components";
+import { AttributeIcon, Button, ButtonGroup, Submit } from "components";
+import { useUserQuery } from "hooks/react-query";
 import React, { useEffect, useRef, useState } from "react";
 import {
   DragSourceMonitor,
@@ -178,8 +179,20 @@ export const PropGroupRow: React.FC<PropGroupRow> = ({
   }, [isDragging]);
 
   const [isExpanded, setIsExpanded] = useState(false);
+  const [showDeleteSubmit, setShowDeleteSubmit] = useState(false);
+
+  const { data: user } = useUserQuery();
+  const askBeforePropDelete = user?.options.askBeforePropDelete !== false;
 
   const opacity = isDragging ? 0.5 : 1;
+
+  const handleDeleteClick = () => {
+    if (prop.children.length > 0 && askBeforePropDelete) {
+      setShowDeleteSubmit(true);
+    } else {
+      removeProp(prop.id);
+    }
+  };
 
   return (
     <>
@@ -332,9 +345,7 @@ export const PropGroupRow: React.FC<PropGroupRow> = ({
                       tooltipLabel="remove prop row"
                       color="plain"
                       inverted
-                      onClick={() => {
-                        removeProp(prop.id);
-                      }}
+                      onClick={handleDeleteClick}
                     />
                   )}
                 </>
@@ -343,6 +354,19 @@ export const PropGroupRow: React.FC<PropGroupRow> = ({
           </StyledPropLineColumn>
         </StyledGrid>
       </div>
+      <Submit
+        title="Delete metaprop"
+        text={`This metaprop has ${prop.children.length} child propert${
+          prop.children.length === 1 ? "y" : "ies"
+        } which will also be deleted. Do you really want to continue?`}
+        submitLabel="Delete"
+        show={showDeleteSubmit}
+        onSubmit={() => {
+          removeProp(prop.id);
+          setShowDeleteSubmit(false);
+        }}
+        onCancel={() => setShowDeleteSubmit(false)}
+      />
     </>
   );
 };

--- a/packages/shared/types/user.ts
+++ b/packages/shared/types/user.ts
@@ -34,6 +34,10 @@ export interface IUserOptions {
 
   // languages the user works with - surfaced first in language dropdowns
   workingLanguages: EntityEnums.Language[];
+
+  // show a confirm modal before deleting a metaprop that has child properties
+  // (undefined is treated as true - warn by default)
+  askBeforePropDelete?: boolean;
 }
 
 export interface IStoredTerritory {


### PR DESCRIPTION
Add a confirm modal when deleting a metaprop that has children, since they'd be silently cascaded away too. Gated behind a new "ask before deleting metaprop with children" toggle in UserCustomizationModal, default on.