### PR TITLE
Make T anchors visible in annotator (#2887)

### DIFF
--- a/packages/annotator/src/anchorMarker.test.ts
+++ b/packages/annotator/src/anchorMarker.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Issue #2887 — Territory anchor corner markers.
+ *
+ * `drawAnchorMarker` is the single glyph primitive: a vertical arm centred on
+ * the line, plus a top arm running right for `start` (┌) or a bottom arm
+ * running left for `end` (┘). These tests pin the exact path so the corner
+ * orientation and stacking offsets stay stable.
+ */
+import { drawAnchorMarker } from "./lib/AnchorMarker";
+
+type Op =
+  | { op: "moveTo"; x: number; y: number }
+  | { op: "lineTo"; x: number; y: number }
+  | { op: "beginPath" }
+  | { op: "stroke" };
+
+const mkCtx = () => {
+  const ops: Op[] = [];
+  const state = { strokeStyle: "", lineWidth: 0, globalAlpha: -1, gco: "" };
+  const ctx = {
+    beginPath: () => ops.push({ op: "beginPath" }),
+    moveTo: (x: number, y: number) => ops.push({ op: "moveTo", x, y }),
+    lineTo: (x: number, y: number) => ops.push({ op: "lineTo", x, y }),
+    stroke: () => ops.push({ op: "stroke" }),
+    save: () => {},
+    restore: () => {},
+    set strokeStyle(v: string) {
+      state.strokeStyle = v;
+    },
+    set lineWidth(v: number) {
+      state.lineWidth = v;
+    },
+    set globalAlpha(v: number) {
+      state.globalAlpha = v;
+    },
+    set globalCompositeOperation(v: string) {
+      state.gco = v;
+    },
+  } as unknown as CanvasRenderingContext2D;
+  return { ctx, ops, state };
+};
+
+const style = { armH: 10, armW: 4, lineWidth: 2, color: "#2079DF" };
+
+describe("drawAnchorMarker", () => {
+  test("start marker draws ┌ — vertical arm + top arm running right", () => {
+    const { ctx, ops } = mkCtx();
+    drawAnchorMarker(ctx, 100, 50, "start", style);
+
+    const lines = ops.filter((o) => o.op === "moveTo" || o.op === "lineTo");
+    expect(lines).toEqual([
+      { op: "moveTo", x: 100, y: 45 }, // vertical arm top (yMid 50 - half 5)
+      { op: "lineTo", x: 100, y: 55 }, // vertical arm bottom
+      { op: "moveTo", x: 100, y: 45 }, // top arm origin
+      { op: "lineTo", x: 104, y: 45 }, // top arm runs right by armW
+    ]);
+  });
+
+  test("end marker draws └ — vertical arm + bottom arm running right", () => {
+    const { ctx, ops } = mkCtx();
+    drawAnchorMarker(ctx, 100, 50, "end", style);
+
+    const lines = ops.filter((o) => o.op === "moveTo" || o.op === "lineTo");
+    expect(lines).toEqual([
+      { op: "moveTo", x: 100, y: 45 }, // vertical arm top
+      { op: "lineTo", x: 100, y: 55 }, // vertical arm bottom
+      { op: "moveTo", x: 100, y: 55 }, // bottom arm origin
+      { op: "lineTo", x: 104, y: 55 }, // bottom arm runs right by armW
+    ]);
+  });
+
+  test("uses the passed colour and line width, and strokes once", () => {
+    const { ctx, ops, state } = mkCtx();
+    drawAnchorMarker(ctx, 10, 20, "start", style);
+    expect(state.strokeStyle).toBe("#2079DF");
+    expect(state.lineWidth).toBe(2);
+    expect(state.globalAlpha).toBe(1); // full opacity regardless of prior passes
+    expect(ops.filter((o) => o.op === "stroke")).toHaveLength(1);
+  });
+});

--- a/packages/annotator/src/anchorMarker.test.ts
+++ b/packages/annotator/src/anchorMarker.test.ts
@@ -48,24 +48,26 @@ describe("drawAnchorMarker", () => {
     drawAnchorMarker(ctx, 100, 50, "start", style);
 
     const lines = ops.filter((o) => o.op === "moveTo" || o.op === "lineTo");
+    // x0 = xPx(100) + lineWidth(2)/2 = 101; armW = 4; half = armH(10)/2 = 5.
     expect(lines).toEqual([
-      { op: "moveTo", x: 100, y: 45 }, // vertical arm top (yMid 50 - half 5)
-      { op: "lineTo", x: 100, y: 55 }, // vertical arm bottom
-      { op: "moveTo", x: 100, y: 45 }, // top arm origin
-      { op: "lineTo", x: 104, y: 45 }, // top arm runs right by armW
+      { op: "moveTo", x: 101, y: 45 }, // vertical stem top
+      { op: "lineTo", x: 101, y: 55 }, // vertical stem bottom
+      { op: "moveTo", x: 101, y: 45 }, // top arm origin
+      { op: "lineTo", x: 105, y: 45 }, // top arm runs right by armW
     ]);
   });
 
-  test("end marker draws └ — vertical arm + bottom arm running right", () => {
+  test("end marker draws ┘ — stem shifted right, bottom arm running left to xPx", () => {
     const { ctx, ops } = mkCtx();
     drawAnchorMarker(ctx, 100, 50, "end", style);
 
     const lines = ops.filter((o) => o.op === "moveTo" || o.op === "lineTo");
+    // x0 = 101; stem shifted right by armW(4) → 105; bottom arm runs left to x0.
     expect(lines).toEqual([
-      { op: "moveTo", x: 100, y: 45 }, // vertical arm top
-      { op: "lineTo", x: 100, y: 55 }, // vertical arm bottom
-      { op: "moveTo", x: 100, y: 55 }, // bottom arm origin
-      { op: "lineTo", x: 104, y: 55 }, // bottom arm runs right by armW
+      { op: "moveTo", x: 105, y: 45 }, // vertical stem shifted right by armW
+      { op: "lineTo", x: 105, y: 55 }, // stem bottom
+      { op: "moveTo", x: 105, y: 55 }, // bottom arm origin at the corner
+      { op: "lineTo", x: 101, y: 55 }, // runs left to x0 (leftmost = x0, unclipped)
     ]);
   });
 

--- a/packages/annotator/src/anchorMarker.test.ts
+++ b/packages/annotator/src/anchorMarker.test.ts
@@ -57,18 +57,49 @@ describe("drawAnchorMarker", () => {
     ]);
   });
 
-  test("end marker draws ┘ — stem shifted right, bottom arm running left to xPx", () => {
+  test("end marker draws ┘ — stem at boundary, bottom arm running left over content", () => {
     const { ctx, ops } = mkCtx();
     drawAnchorMarker(ctx, 100, 50, "end", style);
 
     const lines = ops.filter((o) => o.op === "moveTo" || o.op === "lineTo");
-    // x0 = 101; stem shifted right by armW(4) → 105; bottom arm runs left to x0.
+    // Inline (xPx 100 » inset): stem at the boundary (100), arm left to xPx-armW (96).
     expect(lines).toEqual([
-      { op: "moveTo", x: 105, y: 45 }, // vertical stem shifted right by armW
-      { op: "lineTo", x: 105, y: 55 }, // stem bottom
-      { op: "moveTo", x: 105, y: 55 }, // bottom arm origin at the corner
-      { op: "lineTo", x: 101, y: 55 }, // runs left to x0 (leftmost = x0, unclipped)
+      { op: "moveTo", x: 100, y: 45 }, // stem top
+      { op: "lineTo", x: 100, y: 55 }, // stem bottom
+      { op: "moveTo", x: 100, y: 55 }, // bottom arm origin at the corner
+      { op: "lineTo", x: 96, y: 55 }, // runs left over the content by armW
     ]);
+  });
+
+  test("end marker clamps at the left margin — nothing drawn at negative x", () => {
+    const { ctx, ops } = mkCtx();
+    drawAnchorMarker(ctx, 0, 50, "end", style); // boundary at the very left edge
+
+    const lines = ops.filter((o) => o.op === "moveTo" || o.op === "lineTo");
+    // leftX = max(0 - armW(4), inset(1)) = 1; stem = 1 + 4 = 5.
+    expect(lines).toEqual([
+      { op: "moveTo", x: 5, y: 45 },
+      { op: "lineTo", x: 5, y: 55 },
+      { op: "moveTo", x: 5, y: 55 },
+      { op: "lineTo", x: 1, y: 55 },
+    ]);
+    expect(lines.every((l) => (l as { x: number }).x >= 0)).toBe(true);
+  });
+
+  test("returns the drawn bounding box (used for the hover hit target)", () => {
+    const { ctx } = mkCtx();
+    expect(drawAnchorMarker(ctx, 100, 50, "start", style)).toEqual({
+      x: 101, // stem at xPx + inset
+      y: 45,
+      w: 4, // armW
+      h: 10, // armH
+    });
+    expect(drawAnchorMarker(ctx, 100, 50, "end", style)).toEqual({
+      x: 96, // leftmost = xPx - armW
+      y: 45,
+      w: 4,
+      h: 10,
+    });
   });
 
   test("uses the passed colour and line width, and strokes once", () => {

--- a/packages/annotator/src/anchorMarker.test.ts
+++ b/packages/annotator/src/anchorMarker.test.ts
@@ -49,10 +49,10 @@ describe("drawAnchorMarker", () => {
 
     const lines = ops.filter((o) => o.op === "moveTo" || o.op === "lineTo");
     // x0 = xPx(100) + lineWidth(2)/2 = 101; armW = 4; half = armH(10)/2 = 5.
+    // One continuous stroke: stem bottom → corner → arm end (shared miter join).
     expect(lines).toEqual([
-      { op: "moveTo", x: 101, y: 45 }, // vertical stem top
-      { op: "lineTo", x: 101, y: 55 }, // vertical stem bottom
-      { op: "moveTo", x: 101, y: 45 }, // top arm origin
+      { op: "moveTo", x: 101, y: 55 }, // vertical stem bottom
+      { op: "lineTo", x: 101, y: 45 }, // up to the corner
       { op: "lineTo", x: 105, y: 45 }, // top arm runs right by armW
     ]);
   });
@@ -63,10 +63,10 @@ describe("drawAnchorMarker", () => {
 
     const lines = ops.filter((o) => o.op === "moveTo" || o.op === "lineTo");
     // Inline (xPx 100 » inset): stem at the boundary (100), arm left to xPx-armW (96).
+    // One continuous stroke: stem top → corner → arm end (shared miter join).
     expect(lines).toEqual([
       { op: "moveTo", x: 100, y: 45 }, // stem top
-      { op: "lineTo", x: 100, y: 55 }, // stem bottom
-      { op: "moveTo", x: 100, y: 55 }, // bottom arm origin at the corner
+      { op: "lineTo", x: 100, y: 55 }, // down to the corner
       { op: "lineTo", x: 96, y: 55 }, // runs left over the content by armW
     ]);
   });
@@ -80,7 +80,6 @@ describe("drawAnchorMarker", () => {
     expect(lines).toEqual([
       { op: "moveTo", x: 5, y: 45 },
       { op: "lineTo", x: 5, y: 55 },
-      { op: "moveTo", x: 5, y: 55 },
       { op: "lineTo", x: 1, y: 55 },
     ]);
     expect(lines.every((l) => (l as { x: number }).x >= 0)).toBe(true);

--- a/packages/annotator/src/anchorMarkerAnnotator.test.ts
+++ b/packages/annotator/src/anchorMarkerAnnotator.test.ts
@@ -77,4 +77,89 @@ describe("Annotator draws Territory anchor markers (#2887)", () => {
 
     expect(markerMock).not.toHaveBeenCalled();
   });
+
+  test("a schema array (FOCUS + ANCHOR) still draws the markers (#2887 active T)", () => {
+    const a = mk("foo <T1>bar</T1> baz");
+    a.setMode(EditMode.HIGHLIGHT);
+    // The active territory returns both a dim wash and the anchor markers.
+    a.onHighlight(() => [
+      { mode: HighlightMode.FOCUS, style: { color: "#000", opacity: 0.08 } },
+      anchorSchema,
+    ]);
+    a.draw();
+
+    const kinds = markerMock.mock.calls.map((c) => c[3]);
+    expect(kinds).toEqual(expect.arrayContaining(["start", "end"]));
+  });
+});
+
+// #2887 — hover a marker to preview its territory. Hitboxes are recorded in
+// Annotator.drawAnchorMarkers (independent of the mocked glyph draw), so they
+// are populated after draw() and drive the reused onAnchorTagHover channel.
+describe("Territory anchor marker hover (#2887)", () => {
+  const drawWithMarkers = () => {
+    const a = mk("foo <T1>bar</T1> baz");
+    a.setMode(EditMode.HIGHLIGHT);
+    a.onHighlight(() => anchorSchema);
+    a.draw();
+    return a;
+  };
+
+  // Build a pointer event landing at a hitbox centre (inverse of the draw-space
+  // transform: mx = offsetX*ratio, my = offsetY*ratio + scrollOffsetY).
+  const eventAtHitbox = (a: Annotator, hb: { x: number; y: number; w: number; h: number }) => {
+    const ratio = (a as any).ratio as number;
+    const scrollY = (a as any).viewport.scrollOffsetY as number;
+    return {
+      offsetX: (hb.x + hb.w / 2) / ratio,
+      offsetY: (hb.y + hb.h / 2 - scrollY) / ratio,
+      pageX: 111,
+      pageY: 222,
+    } as MouseEvent;
+  };
+
+  test("draw records one hitbox per marker, tagged with the anchor", () => {
+    const a = drawWithMarkers();
+    const boxes = (a as any).anchorMarkerHitboxes as { tag: any }[];
+    expect(boxes).toHaveLength(2); // start + end
+    expect(boxes.every((b) => b.tag.getTagName() === "T1")).toBe(true);
+  });
+
+  test("pointer over a marker resolves its Tag", () => {
+    const a = drawWithMarkers();
+    const boxes = (a as any).anchorMarkerHitboxes;
+    const tag = (a as any).hitTestAnchorMarker(eventAtHitbox(a, boxes[0]));
+    expect(tag?.getTagName()).toBe("T1");
+  });
+
+  test("pointer off every marker resolves null", () => {
+    const a = drawWithMarkers();
+    const tag = (a as any).hitTestAnchorMarker({
+      offsetX: 9999,
+      offsetY: 9999,
+    } as MouseEvent);
+    expect(tag).toBeNull();
+  });
+
+  test("hovering a marker emits (tag, page position) on the tag-hover channel", () => {
+    const a = drawWithMarkers();
+    const hoverCb = jest.fn();
+    a.onAnchorTagHover(hoverCb);
+    const boxes = (a as any).anchorMarkerHitboxes;
+
+    (a as any).detectAndEmitAnchorTagHover(eventAtHitbox(a, boxes[0]));
+
+    expect(hoverCb).toHaveBeenCalledTimes(1);
+    const [tag, pos] = hoverCb.mock.calls[0];
+    expect(tag.getTagName()).toBe("T1");
+    expect(pos).toEqual({ x: 111, y: 222 });
+  });
+
+  test("marker hitboxes are cleared when leaving HIGHLIGHT mode", () => {
+    const a = drawWithMarkers();
+    expect((a as any).anchorMarkerHitboxes.length).toBe(2);
+    a.setMode(EditMode.RAW);
+    a.draw();
+    expect((a as any).anchorMarkerHitboxes.length).toBe(0);
+  });
 });

--- a/packages/annotator/src/anchorMarkerAnnotator.test.ts
+++ b/packages/annotator/src/anchorMarkerAnnotator.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Issue #2887 — Territory anchor markers, end-to-end through Annotator.draw().
+ *
+ * Verifies the wiring the glyph unit test (anchorMarker.test.ts) does not:
+ * an ANCHOR-mode highlight schema returned from onHighlight is resolved to its
+ * two endpoints (getTagPosition → higlightItems) and drawn as a start (┌) and
+ * an end (┘) marker, while span highlight modes are unaffected.
+ */
+import { Annotator } from "./lib/Annotator";
+import { EditMode, HighlightMode } from "./lib/constants";
+import { drawAnchorMarker } from "./lib/AnchorMarker";
+
+jest.mock("./lib/AnchorMarker", () => ({
+  drawAnchorMarker: jest.fn(),
+}));
+
+const markerMock = drawAnchorMarker as jest.Mock;
+
+const mk = (text: string): Annotator => {
+  const c = document.createElement("canvas");
+  c.style.width = "800px";
+  c.style.height = "600px";
+  document.body.appendChild(c);
+  return new Annotator(c, text);
+};
+
+const anchorSchema = {
+  mode: HighlightMode.ANCHOR,
+  style: { color: "#2079DF", opacity: 1 },
+};
+
+beforeEach(() => markerMock.mockClear());
+
+describe("Annotator draws Territory anchor markers (#2887)", () => {
+  test("an ANCHOR schema draws a start and an end marker for the anchor", () => {
+    const a = mk("foo <T1>bar</T1> baz");
+    a.setMode(EditMode.HIGHLIGHT);
+    a.onHighlight(() => anchorSchema);
+    a.draw();
+
+    const kinds = markerMock.mock.calls.map((c) => c[3]); // 4th arg = kind
+    expect(kinds).toContain("start");
+    expect(kinds).toContain("end");
+    expect(kinds).toHaveLength(2);
+  });
+
+  test("start marker sits left of the end marker on the same line", () => {
+    const a = mk("foo <T1>bar</T1> baz");
+    a.setMode(EditMode.HIGHLIGHT);
+    a.onHighlight(() => anchorSchema);
+    a.draw();
+
+    const byKind = (k: string) =>
+      markerMock.mock.calls.find((c) => c[3] === k);
+    const startX = byKind("start")![1]; // 2nd arg = xPx
+    const endX = byKind("end")![1];
+    expect(startX).toBeLessThan(endX);
+  });
+
+  test("passes the schema colour through to the glyph", () => {
+    const a = mk("foo <T1>bar</T1> baz");
+    a.setMode(EditMode.HIGHLIGHT);
+    a.onHighlight(() => anchorSchema);
+    a.draw();
+
+    expect(markerMock).toHaveBeenCalled();
+    for (const call of markerMock.mock.calls) {
+      expect(call[4].color).toBe("#2079DF"); // 5th arg = style
+    }
+  });
+
+  test("no markers drawn when no ANCHOR schema is returned", () => {
+    const a = mk("foo <T1>bar</T1> baz");
+    a.setMode(EditMode.HIGHLIGHT);
+    a.onHighlight(() => undefined);
+    a.draw();
+
+    expect(markerMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/annotator/src/anchorMarkerAnnotator.test.ts
+++ b/packages/annotator/src/anchorMarkerAnnotator.test.ts
@@ -11,7 +11,14 @@ import { EditMode, HighlightMode } from "./lib/constants";
 import { drawAnchorMarker } from "./lib/AnchorMarker";
 
 jest.mock("./lib/AnchorMarker", () => ({
-  drawAnchorMarker: jest.fn(),
+  // Return a plausible bounding box keyed off the draw coords so the recorded
+  // hitboxes reflect distinct positions (the real fn returns its drawn box).
+  drawAnchorMarker: jest.fn((_ctx: unknown, xPx: number, yMid: number) => ({
+    x: xPx,
+    y: yMid - 5,
+    w: 4,
+    h: 10,
+  })),
 }));
 
 const markerMock = drawAnchorMarker as jest.Mock;

--- a/packages/annotator/src/anchorMarkerAnnotator.test.ts
+++ b/packages/annotator/src/anchorMarkerAnnotator.test.ts
@@ -76,6 +76,22 @@ describe("Annotator draws Territory anchor markers (#2887)", () => {
     }
   });
 
+  test("end boundary at column 0 renders at the previous line's end", () => {
+    // The closing tag sits at the start of the second line; drawing the ┘
+    // there would clamp its left-running arm over that line's text, so the
+    // marker is moved after the previous line's last character.
+    const a = mk("<T1>abc\n</T1>xyz");
+    a.setMode(EditMode.HIGHLIGHT);
+    a.onHighlight(() => anchorSchema);
+    a.draw();
+
+    const byKind = (k: string) => markerMock.mock.calls.find((c) => c[3] === k)!;
+    // Same line as the start marker (yMid equal)…
+    expect(byKind("end")[2]).toBe(byKind("start")[2]);
+    // …and to its right, after the line's last character.
+    expect(byKind("end")[1]).toBeGreaterThan(byKind("start")[1]);
+  });
+
   test("no markers drawn when no ANCHOR schema is returned", () => {
     const a = mk("foo <T1>bar</T1> baz");
     a.setMode(EditMode.HIGHLIGHT);

--- a/packages/annotator/src/annotatorProportional.test.ts
+++ b/packages/annotator/src/annotatorProportional.test.ts
@@ -69,4 +69,20 @@ describe("Annotator proportional flag", () => {
     a.setProportional(false);
     expect(a.font).toContain("Roboto Mono");
   });
+
+  test("switching fonts at the document end clamps the viewport scroll", () => {
+    // Proportional wraps to far more lines here (mocked 100px/char against an
+    // 800px budget) than monospace. Park the viewport at the proportional end,
+    // switch back, and the scroll must be clamped to the shrunken document —
+    // not left dangling in empty space past the last line.
+    const text = Array.from({ length: 40 }, () => "abcdefghij klmnopqrs").join("\n");
+    const a = mk(text);
+    a.setProportional(true);
+    a.scrollToLine(a.scrollExtentLineCount());
+    a.setProportional(false);
+
+    const viewport = (a as any).viewport as { lineStart: number; noLines: number };
+    const maxStart = Math.max(0, a.scrollExtentLineCount() - 1 - viewport.noLines);
+    expect(viewport.lineStart).toBeLessThanOrEqual(maxStart);
+  });
 });

--- a/packages/annotator/src/lib/AnchorMarker.ts
+++ b/packages/annotator/src/lib/AnchorMarker.ts
@@ -1,0 +1,76 @@
+/**
+ * Issue #2887 — Territory (T) anchor markers.
+ *
+ * A Territory anchor spans a whole territory's text, so filling it as a span
+ * would flood the fulltext. Instead we draw a corner bracket at each end:
+ * an L-shaped corner at the start and an inverse-L at the end, framing the
+ * span without covering it.
+ *
+ * This module is deliberately free of any Annotator/Text dependency so the
+ * glyph geometry can be unit-tested against a mocked 2D context.
+ */
+
+export type AnchorMarkerKind = "start" | "end";
+
+export interface AnchorMarkerStyle {
+  /** Vertical arm length in device px. */
+  armH: number;
+  /** Horizontal arm length in device px. */
+  armW: number;
+  /** Stroke width in device px. */
+  lineWidth: number;
+  /** Stroke colour (Territory blue). */
+  color: string;
+}
+
+/**
+ * Strokes a single corner marker.
+ *
+ * The vertical arm is centred on `yMidPx` and spans `armH`. Both arms run
+ * right: a `start` marker caps the top (`┌`) and an `end` marker caps the
+ * bottom (`└`), so a start/end pair reads as a vertical bracket around the
+ * territory. Rightward arms never clip at the left margin, where most
+ * territory boundaries sit.
+ *
+ * @param ctx    target 2D context (assumed already translated for scroll)
+ * @param xPx    device-px x of the anchor boundary
+ * @param yMidPx device-px y of the vertical centre of the target line
+ * @param kind   which end of the anchor this marker represents
+ * @param style  glyph geometry and colour
+ */
+export function drawAnchorMarker(
+  ctx: CanvasRenderingContext2D,
+  xPx: number,
+  yMidPx: number,
+  kind: AnchorMarkerKind,
+  style: AnchorMarkerStyle
+): void {
+  const half = style.armH / 2;
+  const top = yMidPx - half;
+  const bottom = yMidPx + half;
+
+  ctx.save();
+  // Markers paint crisp at full opacity, independent of the highlight passes
+  // that may have left globalAlpha / compositing in a non-default state.
+  ctx.globalAlpha = 1;
+  ctx.globalCompositeOperation = "source-over";
+  ctx.strokeStyle = style.color;
+  ctx.lineWidth = style.lineWidth;
+
+  ctx.beginPath();
+  // Vertical arm (shared by both kinds).
+  ctx.moveTo(xPx, top);
+  ctx.lineTo(xPx, bottom);
+  if (kind === "start") {
+    // Top arm, running right → ┌
+    ctx.moveTo(xPx, top);
+    ctx.lineTo(xPx + style.armW, top);
+  } else {
+    // Bottom arm, running right → └
+    ctx.moveTo(xPx, bottom);
+    ctx.lineTo(xPx + style.armW, bottom);
+  }
+  ctx.stroke();
+
+  ctx.restore();
+}

--- a/packages/annotator/src/lib/AnchorMarker.ts
+++ b/packages/annotator/src/lib/AnchorMarker.ts
@@ -61,9 +61,17 @@ export function drawAnchorMarker(
   style: AnchorMarkerStyle
 ): AnchorMarkerBox {
   const half = style.armH / 2;
-  const top = yMidPx - half;
-  const bottom = yMidPx + half;
   const inset = style.lineWidth / 2;
+
+  // Snap a stroke centre to the device-pixel grid so its edges land on whole
+  // pixels instead of straddling two columns/rows (which the canvas renders as
+  // a soft, "pixelated"-looking antialiased smear). A stroke of width w centred
+  // at c covers [c - w/2, c + w/2]; we want that lower edge on an integer.
+  const snap = (center: number): number =>
+    Math.round(center - inset) + inset;
+
+  const top = snap(yMidPx - half);
+  const bottom = snap(yMidPx + half);
 
   ctx.save();
   // Markers paint crisp at full opacity, independent of the highlight passes
@@ -72,26 +80,31 @@ export function drawAnchorMarker(
   ctx.globalCompositeOperation = "source-over";
   ctx.strokeStyle = style.color;
   ctx.lineWidth = style.lineWidth;
+  // A single continuous polyline per glyph: the stem and arm share one mitered
+  // corner instead of being two separately-capped subpaths whose ends overlap
+  // into a ragged notch. `butt` caps keep the free ends flush to the box.
+  ctx.lineJoin = "miter";
+  ctx.lineCap = "butt";
 
   let leftX: number;
   ctx.beginPath();
   if (kind === "start") {
     // ┌ : stem at the boundary (inset off the edge), top arm running right.
-    const stemX = xPx + inset;
+    const stemX = snap(xPx + inset);
     leftX = stemX;
-    ctx.moveTo(stemX, top);
-    ctx.lineTo(stemX, bottom);
-    ctx.moveTo(stemX, top);
+    // bottom of stem → corner → right end of arm, in one stroke.
+    ctx.moveTo(stemX, bottom);
+    ctx.lineTo(stemX, top);
     ctx.lineTo(stemX + style.armW, top);
   } else {
     // ┘ : stem at the boundary, bottom arm running left over the content. The
     // leftmost point is clamped to `inset` so at the left margin the whole
     // glyph shifts right just enough to stay on-screen.
     leftX = Math.max(xPx - style.armW, inset);
-    const stemX = leftX + style.armW;
+    const stemX = snap(leftX + style.armW);
+    // top of stem → corner → left end of arm, in one stroke.
     ctx.moveTo(stemX, top);
     ctx.lineTo(stemX, bottom);
-    ctx.moveTo(stemX, bottom);
     ctx.lineTo(leftX, bottom);
   }
   ctx.stroke();

--- a/packages/annotator/src/lib/AnchorMarker.ts
+++ b/packages/annotator/src/lib/AnchorMarker.ts
@@ -26,10 +26,11 @@ export interface AnchorMarkerStyle {
 /**
  * Strokes a single corner marker.
  *
- * The vertical arm is centred on `yMidPx` and spans `armH`. Both arms run
- * right: a `start` marker caps the top (`┌`) and an `end` marker caps the
- * bottom (`└`), so a start/end pair reads as a vertical bracket around the
- * territory. Rightward arms never clip at the left margin, where most
+ * A `start` marker is a top-left corner (`┌`: stem on the left, top arm right);
+ * an `end` marker is the horizontally-mirrored bottom-right corner (`┘`: stem
+ * on the right, bottom arm left). A start/end pair frames the territory span.
+ * Both glyphs occupy the x-range `[xPx, xPx + armW]` — the end marker is shifted
+ * right so its leftward arm never clips past the left margin, where most
  * territory boundaries sit.
  *
  * @param ctx    target 2D context (assumed already translated for scroll)
@@ -48,6 +49,12 @@ export function drawAnchorMarker(
   const half = style.armH / 2;
   const top = yMidPx - half;
   const bottom = yMidPx + half;
+  // Strokes are centred on the path, so a stem sitting exactly on the boundary
+  // column (xPx == 0 at the left margin) would have half its width clipped by
+  // the canvas edge and render thinner. Nudge every x right by half the stroke
+  // so the leftmost stem edge lands on xPx — applied to both kinds so the start
+  // (┌) and end (┘) strokes are equally sized.
+  const x0 = xPx + style.lineWidth / 2;
 
   ctx.save();
   // Markers paint crisp at full opacity, independent of the highlight passes
@@ -58,17 +65,21 @@ export function drawAnchorMarker(
   ctx.lineWidth = style.lineWidth;
 
   ctx.beginPath();
-  // Vertical arm (shared by both kinds).
-  ctx.moveTo(xPx, top);
-  ctx.lineTo(xPx, bottom);
   if (kind === "start") {
-    // Top arm, running right → ┌
-    ctx.moveTo(xPx, top);
-    ctx.lineTo(xPx + style.armW, top);
+    // ┌ : vertical stem on the left at x0, top arm running right.
+    ctx.moveTo(x0, top);
+    ctx.lineTo(x0, bottom);
+    ctx.moveTo(x0, top);
+    ctx.lineTo(x0 + style.armW, top);
   } else {
-    // Bottom arm, running right → └
-    ctx.moveTo(xPx, bottom);
-    ctx.lineTo(xPx + style.armW, bottom);
+    // ┘ : vertical stem on the right, bottom arm running left back to x0. The
+    // glyph is shifted right by armW so its leftmost point is x0 (the boundary
+    // column) — the leftward arm never crosses the left edge into negative x.
+    const stemX = x0 + style.armW;
+    ctx.moveTo(stemX, top);
+    ctx.lineTo(stemX, bottom);
+    ctx.moveTo(stemX, bottom);
+    ctx.lineTo(x0, bottom);
   }
   ctx.stroke();
 

--- a/packages/annotator/src/lib/AnchorMarker.ts
+++ b/packages/annotator/src/lib/AnchorMarker.ts
@@ -23,21 +23,35 @@ export interface AnchorMarkerStyle {
   color: string;
 }
 
+/** Axis-aligned bounding box of a drawn marker (device px). */
+export interface AnchorMarkerBox {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+}
+
 /**
- * Strokes a single corner marker.
+ * Strokes a single corner marker and returns the box it occupied (so the caller
+ * can build a matching hover hit target).
  *
- * A `start` marker is a top-left corner (`┌`: stem on the left, top arm right);
- * an `end` marker is the horizontally-mirrored bottom-right corner (`┘`: stem
- * on the right, bottom arm left). A start/end pair frames the territory span.
- * Both glyphs occupy the x-range `[xPx, xPx + armW]` — the end marker is shifted
- * right so its leftward arm never clips past the left margin, where most
- * territory boundaries sit.
+ * A `start` marker is a top-left corner (`┌`: stem at the boundary, top arm
+ * running right into the content). An `end` marker is the mirrored bottom-right
+ * corner (`┘`: stem at the boundary, bottom arm running left over the content).
+ * Both arms point inward, framing the span — and neither sits over the text that
+ * follows the anchor.
+ *
+ * Left-margin safety: strokes are centred on the path, so a stem on the boundary
+ * column (`xPx == 0`) would be half-clipped by the canvas edge. The `start` stem
+ * is nudged right by half the stroke; the `end` glyph's leftmost point is
+ * clamped to that same inset, so its leftward arm never crosses into negative x.
  *
  * @param ctx    target 2D context (assumed already translated for scroll)
  * @param xPx    device-px x of the anchor boundary
  * @param yMidPx device-px y of the vertical centre of the target line
  * @param kind   which end of the anchor this marker represents
  * @param style  glyph geometry and colour
+ * @returns the device-px bounding box of the strokes drawn
  */
 export function drawAnchorMarker(
   ctx: CanvasRenderingContext2D,
@@ -45,16 +59,11 @@ export function drawAnchorMarker(
   yMidPx: number,
   kind: AnchorMarkerKind,
   style: AnchorMarkerStyle
-): void {
+): AnchorMarkerBox {
   const half = style.armH / 2;
   const top = yMidPx - half;
   const bottom = yMidPx + half;
-  // Strokes are centred on the path, so a stem sitting exactly on the boundary
-  // column (xPx == 0 at the left margin) would have half its width clipped by
-  // the canvas edge and render thinner. Nudge every x right by half the stroke
-  // so the leftmost stem edge lands on xPx — applied to both kinds so the start
-  // (┌) and end (┘) strokes are equally sized.
-  const x0 = xPx + style.lineWidth / 2;
+  const inset = style.lineWidth / 2;
 
   ctx.save();
   // Markers paint crisp at full opacity, independent of the highlight passes
@@ -64,24 +73,30 @@ export function drawAnchorMarker(
   ctx.strokeStyle = style.color;
   ctx.lineWidth = style.lineWidth;
 
+  let leftX: number;
   ctx.beginPath();
   if (kind === "start") {
-    // ┌ : vertical stem on the left at x0, top arm running right.
-    ctx.moveTo(x0, top);
-    ctx.lineTo(x0, bottom);
-    ctx.moveTo(x0, top);
-    ctx.lineTo(x0 + style.armW, top);
+    // ┌ : stem at the boundary (inset off the edge), top arm running right.
+    const stemX = xPx + inset;
+    leftX = stemX;
+    ctx.moveTo(stemX, top);
+    ctx.lineTo(stemX, bottom);
+    ctx.moveTo(stemX, top);
+    ctx.lineTo(stemX + style.armW, top);
   } else {
-    // ┘ : vertical stem on the right, bottom arm running left back to x0. The
-    // glyph is shifted right by armW so its leftmost point is x0 (the boundary
-    // column) — the leftward arm never crosses the left edge into negative x.
-    const stemX = x0 + style.armW;
+    // ┘ : stem at the boundary, bottom arm running left over the content. The
+    // leftmost point is clamped to `inset` so at the left margin the whole
+    // glyph shifts right just enough to stay on-screen.
+    leftX = Math.max(xPx - style.armW, inset);
+    const stemX = leftX + style.armW;
     ctx.moveTo(stemX, top);
     ctx.lineTo(stemX, bottom);
     ctx.moveTo(stemX, bottom);
-    ctx.lineTo(x0, bottom);
+    ctx.lineTo(leftX, bottom);
   }
   ctx.stroke();
 
   ctx.restore();
+
+  return { x: leftX, y: top, w: style.armW, h: style.armH };
 }

--- a/packages/annotator/src/lib/Annotator.ts
+++ b/packages/annotator/src/lib/Annotator.ts
@@ -2476,24 +2476,24 @@ export class Annotator {
       const xPx = toPx(p.yLine, p.xLine) + idx * stackStep;
       const yMid = (relLine + 0.5) * this.lineHeight;
 
-      drawAnchorMarker(this.ctx, xPx, yMid, p.kind, {
+      const box = drawAnchorMarker(this.ctx, xPx, yMid, p.kind, {
         armH,
         armW,
         lineWidth,
         color: p.color,
       });
 
-      // Record a padded hit target (glyph box grown by the pad on each side)
-      // so the tiny corner is comfortably hoverable. Coordinates match the
-      // draw space; detectAndEmitAnchorTagHover converts the pointer to match.
+      // Record a padded hit target around the box actually drawn — start and
+      // end glyphs sit on opposite sides of the boundary, so the drawer reports
+      // its own bounds. Coordinates match the draw space;
+      // detectAndEmitAnchorTagHover converts the pointer to match.
       if (p.tag) {
-        const half = armH / 2;
         const pad = ANCHOR_MARKER_HIT_PAD_PX * this.ratio;
         this.anchorMarkerHitboxes.push({
-          x: xPx - pad,
-          y: yMid - half - pad,
-          w: armW + 2 * pad,
-          h: armH + 2 * pad,
+          x: box.x - pad,
+          y: box.y - pad,
+          w: box.w + 2 * pad,
+          h: box.h + 2 * pad,
           tag: p.tag,
         });
       }

--- a/packages/annotator/src/lib/Annotator.ts
+++ b/packages/annotator/src/lib/Annotator.ts
@@ -1036,6 +1036,15 @@ export class Annotator {
       this.proportional ? this.width : undefined
     );
 
+    // The re-wrap can shrink the document (the new font wraps to fewer lines);
+    // clamp the scroll so a viewport parked near the old end doesn't dangle
+    // in empty space past the new last line.
+    const maxStart = Math.max(0, this.scrollExtentLineCount() - 1 - this.viewport.noLines);
+    if (this.viewport.lineStart > maxStart) {
+      this.viewport.lineStart = maxStart;
+      this.viewport.scrollOffsetY = 0;
+    }
+
     this.cursor.syncVisualFromOffset(this.text);
     if (redraw) {
       this.draw();

--- a/packages/annotator/src/lib/Annotator.ts
+++ b/packages/annotator/src/lib/Annotator.ts
@@ -15,6 +15,7 @@ import { AsymmetricalAnchor, Warnings, WarningData } from "./warnings";
 import {
   ANCHOR_MARKER_ARM_H_RATIO,
   ANCHOR_MARKER_ARM_W_RATIO,
+  ANCHOR_MARKER_HIT_PAD_PX,
   ANCHOR_MARKER_LINE_WIDTH_PX,
   ANCHOR_MARKER_STACK_STEP_PX,
   DEFAULT_FONT,
@@ -240,7 +241,10 @@ export class Annotator {
 
   // callbacks
   onSelectTextCb?: (text: Selected) => void;
-  onHighlightCb?: (entityId: string) => HighlightSchema | void;
+  // A tag may map to several treatments at once (#2887): the active territory
+  // is both dimmed (FOCUS) and marked at its ends (ANCHOR). Returning an array
+  // draws each; a single schema (or void) keeps the original behaviour.
+  onHighlightCb?: (entityId: string) => HighlightSchema | HighlightSchema[] | void;
   onTextChangeCb?: (text: string) => void;
   onScrollCb?: (line: number) => void;
   onAnchorHoverCb?: (tags: Tag[]) => void; // Part 2 of #2835
@@ -248,6 +252,21 @@ export class Annotator {
     tag: Tag | null,
     position: { x: number; y: number } | null
   ) => void;
+
+  /**
+   * #2887 — hit rectangles for the Territory anchor markers drawn this frame,
+   * in draw coordinates (device px, before the scroll translate), each paired
+   * with its anchor Tag. Repopulated every draw; consumed by
+   * detectAndEmitAnchorTagHover so hovering a marker previews its territory
+   * through the same channel the RAW `<id>` markup hover already uses.
+   */
+  private anchorMarkerHitboxes: {
+    x: number;
+    y: number;
+    w: number;
+    h: number;
+    tag: Tag;
+  }[] = [];
 
   clickCount: number;
   clickTimeout?: NodeJS.Timeout;
@@ -821,10 +840,21 @@ export class Annotator {
   /**
    * Detects whether the mouse is over tag markup (`<tag>` or `</tag>`) and
    * emits the owning opening Tag, or null when not over any markup.
-   * Only meaningful in RAW mode since HIGHLIGHT mode hides tag markup.
+   *
+   * In RAW mode this reports `<id>` markup under the pointer. In HIGHLIGHT mode
+   * markup is hidden, but Territory anchor corner markers (#2887) are drawn and
+   * hit-tested here first, so hovering a marker previews its territory through
+   * the same channel. The marker hitbox list is empty outside HIGHLIGHT, so the
+   * prefix is inert there — no mode branch required.
    */
   private detectAndEmitAnchorTagHover(e: MouseEvent) {
     if (!this.onAnchorTagHoverCb) {
+      return;
+    }
+
+    const markerTag = this.hitTestAnchorMarker(e);
+    if (markerTag) {
+      this.onAnchorTagHoverCb(markerTag, { x: e.pageX, y: e.pageY });
       return;
     }
 
@@ -950,7 +980,9 @@ export class Annotator {
     this.onCanvasResize();
   }
 
-  onHighlight(cb: (entityId: string) => HighlightSchema | void): void {
+  onHighlight(
+    cb: (entityId: string) => HighlightSchema | HighlightSchema[] | void
+  ): void {
     this.onHighlightCb = cb;
   }
 
@@ -2372,6 +2404,7 @@ export class Annotator {
       schema: HighlightSchema;
       start: IAbsCoordinates;
       end: IAbsCoordinates;
+      tag?: Tag;
     }[]
   ): void {
     const anchorItems = higlightItems.filter(
@@ -2380,6 +2413,9 @@ export class Annotator {
     if (anchorItems.length === 0) {
       return;
     }
+    // Note: this.anchorMarkerHitboxes is cleared once per frame at the top of
+    // draw() (so it empties even in RAW/SEMI where this method never runs); we
+    // only append here.
 
     const armH = ANCHOR_MARKER_ARM_H_RATIO * this.lineHeight;
     const armW = ANCHOR_MARKER_ARM_W_RATIO * this.charWidth;
@@ -2403,6 +2439,7 @@ export class Annotator {
       xLine: number;
       kind: "start" | "end";
       color: string;
+      tag?: Tag;
     }[] = [];
     for (const it of anchorItems) {
       points.push({
@@ -2410,12 +2447,14 @@ export class Annotator {
         xLine: it.start.xLine,
         kind: "start",
         color: it.schema.style.color,
+        tag: it.tag,
       });
       points.push({
         yLine: it.end.yLine,
         xLine: it.end.xLine,
         kind: "end",
         color: it.schema.style.color,
+        tag: it.tag,
       });
     }
 
@@ -2443,7 +2482,44 @@ export class Annotator {
         lineWidth,
         color: p.color,
       });
+
+      // Record a padded hit target (glyph box grown by the pad on each side)
+      // so the tiny corner is comfortably hoverable. Coordinates match the
+      // draw space; detectAndEmitAnchorTagHover converts the pointer to match.
+      if (p.tag) {
+        const half = armH / 2;
+        const pad = ANCHOR_MARKER_HIT_PAD_PX * this.ratio;
+        this.anchorMarkerHitboxes.push({
+          x: xPx - pad,
+          y: yMid - half - pad,
+          w: armW + 2 * pad,
+          h: armH + 2 * pad,
+          tag: p.tag,
+        });
+      }
     }
+  }
+
+  /**
+   * #2887 — is the pointer over a Territory anchor marker drawn this frame?
+   * Returns the marker's Tag, or null. Pointer offsets (CSS px, canvas-local)
+   * are converted to the marker draw space: ×ratio for device px, and +scroll
+   * offset on Y to undo the draw-time `translate(0, -scrollOffsetY)`. Markers
+   * are only populated during a HIGHLIGHT-mode draw, so this is inert (empty
+   * list) in RAW/SEMI without any explicit mode check.
+   */
+  private hitTestAnchorMarker(e: MouseEvent): Tag | null {
+    if (this.anchorMarkerHitboxes.length === 0) {
+      return null;
+    }
+    const mx = e.offsetX * this.ratio;
+    const my = e.offsetY * this.ratio + this.viewport.scrollOffsetY;
+    for (const hb of this.anchorMarkerHitboxes) {
+      if (mx >= hb.x && mx <= hb.x + hb.w && my >= hb.y && my <= hb.y + hb.h) {
+        return hb.tag;
+      }
+    }
+    return null;
   }
 
   /**
@@ -2458,6 +2534,10 @@ export class Annotator {
     if (this.showFps) {
       this.updateFps();
     }
+
+    // #2887 — clear last frame's marker hover targets; the HIGHLIGHT draw below
+    // repopulates them. Cleared unconditionally so RAW/SEMI frames leave none.
+    this.anchorMarkerHitboxes = [];
 
     this.syncLineNumbersCanvasToMain();
 
@@ -2574,6 +2654,7 @@ export class Annotator {
         schema: HighlightSchema;
         start: IAbsCoordinates;
         end: IAbsCoordinates;
+        tag?: Tag; // #2887 — carried so ANCHOR markers know their entity for hover
       }[] = [];
       const processedTagNames = new Set<string>();
       for (const tag of annotated) {
@@ -2582,18 +2663,26 @@ export class Annotator {
           continue;
         }
         processedTagNames.add(tagName);
-        const hlSchema = this.onHighlightCb(tagName);
-        if (hlSchema) {
+        const hlResult = this.onHighlightCb(tagName);
+        const schemas = Array.isArray(hlResult)
+          ? hlResult
+          : hlResult
+          ? [hlResult]
+          : [];
+        if (schemas.length) {
           let occurence: IAbsCoordinates[];
           let i = 0;
           do {
             occurence = this.text.getTagPosition(tagName, i);
             if (occurence.length > 1) {
-              higlightItems.push({
-                schema: hlSchema,
-                start: occurence[0],
-                end: occurence[1],
-              });
+              for (const schema of schemas) {
+                higlightItems.push({
+                  schema,
+                  start: occurence[0],
+                  end: occurence[1],
+                  tag,
+                });
+              }
             }
             i++;
           } while (!!occurence.length);

--- a/packages/annotator/src/lib/Annotator.ts
+++ b/packages/annotator/src/lib/Annotator.ts
@@ -132,7 +132,9 @@ export class Annotator {
   bgColor: string = "white";
 
   private _menuColors: MenuColors = LIGHT_MENU_COLORS;
-  get menuColors(): MenuColors { return this._menuColors; }
+  get menuColors(): MenuColors {
+    return this._menuColors;
+  }
   set menuColors(c: MenuColors) {
     this._menuColors = c;
     this.contextMenu.colors = c;
@@ -248,10 +250,7 @@ export class Annotator {
   onTextChangeCb?: (text: string) => void;
   onScrollCb?: (line: number) => void;
   onAnchorHoverCb?: (tags: Tag[]) => void; // Part 2 of #2835
-  onAnchorTagHoverCb?: (
-    tag: Tag | null,
-    position: { x: number; y: number } | null
-  ) => void;
+  onAnchorTagHoverCb?: (tag: Tag | null, position: { x: number; y: number } | null) => void;
 
   /**
    * #2887 — hit rectangles for the Territory anchor markers drawn this frame,
@@ -274,11 +273,9 @@ export class Annotator {
 
   private readonly boundOnMouseMove = (e: MouseEvent) => this.onMouseMove(e);
 
-  private readonly boundOnContextMenu = (e: MouseEvent) =>
-    this.onContextMenu(e);
+  private readonly boundOnContextMenu = (e: MouseEvent) => this.onContextMenu(e);
 
-  private readonly boundOnMouseDoubleClick = (e: MouseEvent) =>
-    this.onMouseDoubleClick(e);
+  private readonly boundOnMouseDoubleClick = (e: MouseEvent) => this.onMouseDoubleClick(e);
 
   private readonly boundOnCanvasMouseLeave = () => {
     if (this.hoverDebounceTimeout) {
@@ -322,11 +319,7 @@ export class Annotator {
     this.endHandleDrag(e);
   };
 
-  constructor(
-    element: HTMLCanvasElement,
-    inputText: string,
-    ratio: number = 1
-  ) {
+  constructor(element: HTMLCanvasElement, inputText: string, ratio: number = 1) {
     canvasHosts.get(element)?.destroy();
 
     this.element = element;
@@ -348,10 +341,8 @@ export class Annotator {
     this.lineHeight = this.lineHeightForSize(this.fontSize);
 
     this.ctx = ctx;
-    this.width =
-      Number(this.element.style.width.replace("px", "")) * this.ratio;
-    this.height =
-      Number(this.element.style.height.replace("px", "")) * this.ratio;
+    this.width = Number(this.element.style.width.replace("px", "")) * this.ratio;
+    this.height = Number(this.element.style.height.replace("px", "")) * this.ratio;
 
     this.element.width = this.width;
     this.element.height = this.height;
@@ -415,11 +406,7 @@ export class Annotator {
     });
   }
 
-  setSelectStyle(
-    selectColor: string,
-    selectOpacity: number,
-    selectorColor: string
-  ) {
+  setSelectStyle(selectColor: string, selectOpacity: number, selectorColor: string) {
     this.selectColor = selectColor;
     this.selectOpacity = selectOpacity;
 
@@ -524,8 +511,7 @@ export class Annotator {
       const closeSeg = this.text.segments[closeSegIdx];
       const closePos = closeTag.position;
       closeSeg.raw =
-        closeSeg.raw.slice(0, closePos) +
-        closeSeg.raw.slice(closePos + closeTag.getTagLength());
+        closeSeg.raw.slice(0, closePos) + closeSeg.raw.slice(closePos + closeTag.getTagLength());
       changedSegmentIndices.add(closeSegIdx);
     }
 
@@ -545,11 +531,7 @@ export class Annotator {
     this.text.calculateLines();
 
     // Recalculate selection bounds after anchor removal (issue #2899)
-    if (
-      hasSelection &&
-      oldStartIndex !== undefined &&
-      oldEndIndex !== undefined
-    ) {
+    if (hasSelection && oldStartIndex !== undefined && oldEndIndex !== undefined) {
       let newStartIndex = oldStartIndex;
       let newEndIndex = oldEndIndex;
 
@@ -573,8 +555,7 @@ export class Annotator {
       }
 
       // Convert adjusted indices back to segment positions
-      const newStartSegPos =
-        this.text.getSegmentFromAbsTextIndex(newStartIndex);
+      const newStartSegPos = this.text.getSegmentFromAbsTextIndex(newStartIndex);
       const newEndSegPos = this.text.getSegmentFromAbsTextIndex(newEndIndex);
 
       if (newStartSegPos && newEndSegPos) {
@@ -604,7 +585,7 @@ export class Annotator {
   /**
    * Highlights all anchors with the given tag name (for statement list hover interaction).
    * Part 1 of issue #2835: When hovering over statement list, highlight the anchor in annotator.
-   * 
+   *
    * @param tagName - The entity/tag name to highlight (e.g., "entity-id-123")
    */
   highlightAnchorByTag(tagName: string) {
@@ -630,9 +611,7 @@ export class Annotator {
     // Find all opening tags with this tag name across all segments
     const matchingTags: Tag[] = [];
     for (const segment of this.text.segments) {
-      const foundTags = segment.openingTags.filter(
-        (tag) => tag.getTagName() === tagName
-      );
+      const foundTags = segment.openingTags.filter((tag) => tag.getTagName() === tagName);
       matchingTags.push(...foundTags);
     }
 
@@ -712,9 +691,7 @@ export class Annotator {
    * @param openTag - Opening tag to match
    * @returns Matching closing tag with its segment index, or null
    */
-  private findMatchingClosingTag(
-    openTag: Tag
-  ): { closeTag: Tag; closeSegIdx: number } | null {
+  private findMatchingClosingTag(openTag: Tag): { closeTag: Tag; closeSegIdx: number } | null {
     const tagName = openTag.getTagName();
     let depth = 0;
 
@@ -769,7 +746,7 @@ export class Annotator {
 
   /**
    * Detects anchors at the current mouse position and emits hover callback. When hovering over anchored text, emit tags to highlight statements.
-   * 
+   *
    * @param e - Mouse event
    */
   private detectAndEmitAnchorHover(e: MouseEvent) {
@@ -789,16 +766,10 @@ export class Annotator {
     );
 
     // Clamp to valid line range
-    tempCursor.yLine = Math.max(
-      0,
-      Math.min(tempCursor.yLine, Math.max(0, this.text.noLines - 1))
-    );
+    tempCursor.yLine = Math.max(0, Math.min(tempCursor.yLine, Math.max(0, this.text.noLines - 1)));
 
     // Get segment position at cursor
-    const segmentPos = this.text.getSegmentPosition(
-      tempCursor.yLine,
-      tempCursor.xLine
-    );
+    const segmentPos = this.text.getSegmentPosition(tempCursor.yLine, tempCursor.xLine);
 
     if (!segmentPos) {
       this.onAnchorHoverCb([]);
@@ -822,9 +793,7 @@ export class Annotator {
         }
 
         const openAbsRawStart = openTag.getAbsoluteTagPosition(this.text.segments);
-        const closeAbsRawStart = match.closeTag.getAbsoluteTagPosition(
-          this.text.segments
-        );
+        const closeAbsRawStart = match.closeTag.getAbsoluteTagPosition(this.text.segments);
         const contentStart = openAbsRawStart + openTag.getTagLength();
         const contentEnd = closeAbsRawStart;
 
@@ -868,15 +837,9 @@ export class Annotator {
       this.proportionalHitTest()
     );
 
-    tempCursor.yLine = Math.max(
-      0,
-      Math.min(tempCursor.yLine, Math.max(0, this.text.noLines - 1))
-    );
+    tempCursor.yLine = Math.max(0, Math.min(tempCursor.yLine, Math.max(0, this.text.noLines - 1)));
 
-    const segmentPos = this.text.getSegmentPosition(
-      tempCursor.yLine,
-      tempCursor.xLine
-    );
+    const segmentPos = this.text.getSegmentPosition(tempCursor.yLine, tempCursor.xLine);
 
     if (!segmentPos) {
       this.onAnchorTagHoverCb(null, null);
@@ -901,9 +864,7 @@ export class Annotator {
           continue;
         }
 
-        const closeStart = match.closeTag.getAbsoluteTagPosition(
-          this.text.segments
-        );
+        const closeStart = match.closeTag.getAbsoluteTagPosition(this.text.segments);
         const closeEnd = closeStart + match.closeTag.getTagLength();
 
         if (hoverAbsRawIndex >= closeStart && hoverAbsRawIndex < closeEnd) {
@@ -917,10 +878,8 @@ export class Annotator {
   }
 
   onCanvasResize() {
-    this.width =
-      Number(this.element.style.width.replace("px", "")) * this.ratio;
-    this.height =
-      Number(this.element.style.height.replace("px", "")) * this.ratio;
+    this.width = Number(this.element.style.width.replace("px", "")) * this.ratio;
+    this.height = Number(this.element.style.height.replace("px", "")) * this.ratio;
 
     this.element.width = this.width;
     this.element.height = this.height;
@@ -934,8 +893,7 @@ export class Annotator {
     const charsAtLine = Math.floor(this.width / this.charWidth);
 
     const extent = this.scrollExtentLineCount();
-    const positionBeforeRel =
-      extent > 0 ? this.viewport.lineStart / Math.max(1, extent) : 0;
+    const positionBeforeRel = extent > 0 ? this.viewport.lineStart / Math.max(1, extent) : 0;
 
     this.viewport.updateLineEnd(noLinesViewport);
     // Keep the proportional wrap budget in sync with the new width
@@ -958,15 +916,10 @@ export class Annotator {
       this.scrollExtentLineCount()
     );
 
-    this.scroller?.setRunnerSize(
-      (this.viewport.noLines / this.scrollExtentLineCount()) * 100
-    );
+    this.scroller?.setRunnerSize((this.viewport.noLines / this.scrollExtentLineCount()) * 100);
 
     this.scroller?.setViewportSize(
-      Math.min(
-        100,
-        (this.viewport.noLines / this.scrollExtentLineCount()) * 100
-      )
+      Math.min(100, (this.viewport.noLines / this.scrollExtentLineCount()) * 100)
     );
 
     if (this.settingsOverlay.isOpen) {
@@ -980,9 +933,7 @@ export class Annotator {
     this.onCanvasResize();
   }
 
-  onHighlight(
-    cb: (entityId: string) => HighlightSchema | HighlightSchema[] | void
-  ): void {
+  onHighlight(cb: (entityId: string) => HighlightSchema | HighlightSchema[] | void): void {
     this.onHighlightCb = cb;
   }
 
@@ -1017,7 +968,7 @@ export class Annotator {
   /**
    * Registers callback for anchor hover events (Part 2 of #2835).
    * Called when user hovers over anchored text in the annotator.
-   * 
+   *
    * @param cb - Callback receiving array of Tags at the hover position
    */
   onAnchorHover(cb: (tags: Tag[]) => void) {
@@ -1030,9 +981,7 @@ export class Annotator {
    * Emits the opening Tag for both opening and closing markup hits, or null
    * when the pointer leaves any tag markup.
    */
-  onAnchorTagHover(
-    cb: (tag: Tag | null, position: { x: number; y: number } | null) => void
-  ) {
+  onAnchorTagHover(cb: (tag: Tag | null, position: { x: number; y: number } | null) => void) {
     this.onAnchorTagHoverCb = cb;
   }
 
@@ -1145,12 +1094,8 @@ export class Annotator {
    * The proportional column→pixel resolver to put on DrawingOptions,
    * or undefined when monospace (so draw keeps using `col * charWidth`).
    */
-  private drawColumnToPixelX():
-    | ((absLine: number, col: number) => number)
-    | undefined {
-    return this.proportional
-      ? (absLine, col) => this.text.columnToPixelX(absLine, col)
-      : undefined;
+  private drawColumnToPixelX(): ((absLine: number, col: number) => number) | undefined {
+    return this.proportional ? (absLine, col) => this.text.columnToPixelX(absLine, col) : undefined;
   }
 
   /**
@@ -1158,9 +1103,7 @@ export class Annotator {
    * (device px → caret column on a given line), or undefined when monospace
    * (so the legacy `xToCharI` is used). Mirror of {@link drawColumnToPixelX}.
    */
-  private proportionalHitTest():
-    | ((absLine: number, deviceX: number) => number)
-    | undefined {
+  private proportionalHitTest(): ((absLine: number, deviceX: number) => number) | undefined {
     return this.proportional
       ? (absLine, deviceX) => this.text.pixelXToColumn(absLine, deviceX)
       : undefined;
@@ -1183,11 +1126,7 @@ export class Annotator {
    */
   private handleToleranceX(pt: IAbsCoordinates): number {
     return this.proportional
-      ? Math.max(
-          1,
-          this.text.glyphWidthAt(pt.yLine, pt.xLine) *
-            SELECTION_HANDLE_GRAB_CHAR_FACTOR
-        )
+      ? Math.max(1, this.text.glyphWidthAt(pt.yLine, pt.xLine) * SELECTION_HANDLE_GRAB_CHAR_FACTOR)
       : this.charWidth * SELECTION_HANDLE_GRAB_CHAR_FACTOR;
   }
 
@@ -1285,18 +1224,14 @@ export class Annotator {
    * selection.
    */
   private selectionHandlesActive(): boolean {
-    return (
-      this.text.mode === EditMode.HIGHLIGHT && this.cursor.isSelected()
-    );
+    return this.text.mode === EditMode.HIGHLIGHT && this.cursor.isSelected();
   }
 
   /**
    * The two absolute visual boundary points (document-ordered start, end) where
    * the handles sit, or null when handles should not be shown.
    */
-  private selectionHandlePoints():
-    | { start: IAbsCoordinates; end: IAbsCoordinates }
-    | null {
+  private selectionHandlePoints(): { start: IAbsCoordinates; end: IAbsCoordinates } | null {
     if (!this.selectionHandlesActive()) {
       return null;
     }
@@ -1312,10 +1247,7 @@ export class Annotator {
    * cursor (unlike applyPointerToCursor). Clamps into the document like a normal
    * click would.
    */
-  private pointerToVisual(
-    clientX: number,
-    clientY: number
-  ): IAbsCoordinates {
+  private pointerToVisual(clientX: number, clientY: number): IAbsCoordinates {
     const rect = this.element.getBoundingClientRect();
     const { ox, oy } = this.clientCoordsToCanvasOffsets(clientX, clientY, rect);
     const tmp = this.scratchCursor;
@@ -1388,14 +1320,8 @@ export class Annotator {
     if (!points) {
       return false;
     }
-    const startOff = this.text.offsetFromVisual(
-      points.start.xLine,
-      points.start.yLine
-    );
-    const endOff = this.text.offsetFromVisual(
-      points.end.xLine,
-      points.end.yLine
-    );
+    const startOff = this.text.offsetFromVisual(points.start.xLine, points.start.yLine);
+    const endOff = this.text.offsetFromVisual(points.end.xLine, points.end.yLine);
     if (startOff < 0 || endOff < 0) {
       return false;
     }
@@ -1409,10 +1335,7 @@ export class Annotator {
    * Bypasses the normal selection path entirely so the existing selection is not
    * collapsed before we move it.
    */
-  private startHandleDrag(
-    mode: "start" | "end" | "span",
-    e: MouseEvent
-  ): void {
+  private startHandleDrag(mode: "start" | "end" | "span", e: MouseEvent): void {
     this.dragHandle = mode;
     this.handleDragMoved = false;
     this.lastSelectPointer = { cx: e.clientX, cy: e.clientY };
@@ -1422,14 +1345,8 @@ export class Annotator {
       const pt = this.pointerToVisual(e.clientX, e.clientY);
       const grabOff = this.text.offsetFromVisual(pt.xLine, pt.yLine);
       if (points && grabOff >= 0) {
-        const startOff = this.text.offsetFromVisual(
-          points.start.xLine,
-          points.start.yLine
-        );
-        const endOff = this.text.offsetFromVisual(
-          points.end.xLine,
-          points.end.yLine
-        );
+        const startOff = this.text.offsetFromVisual(points.start.xLine, points.start.yLine);
+        const endOff = this.text.offsetFromVisual(points.end.xLine, points.end.yLine);
         this.spanDragState = { startOff, endOff, grabOff };
       } else {
         this.spanDragState = null;
@@ -1581,10 +1498,7 @@ export class Annotator {
 
   private readonly tickSelectionEdgeScroll = () => {
     this.selectionScrollRaf = 0;
-    if (
-      (!this.cursor.isSelecting() && !this.dragHandle) ||
-      !this.lastSelectPointer
-    ) {
+    if ((!this.cursor.isSelecting() && !this.dragHandle) || !this.lastSelectPointer) {
       return;
     }
 
@@ -1602,17 +1516,9 @@ export class Annotator {
     const speed = this.lineHeight * SELECTION_EDGE_SCROLL_SPEED;
 
     if (inTopZone) {
-      this.viewport.addScrollOffset(
-        -speed,
-        this.lineHeight,
-        this.scrollExtentLineCount()
-      );
+      this.viewport.addScrollOffset(-speed, this.lineHeight, this.scrollExtentLineCount());
     } else if (inBottomZone) {
-      this.viewport.addScrollOffset(
-        speed,
-        this.lineHeight,
-        this.scrollExtentLineCount()
-      );
+      this.viewport.addScrollOffset(speed, this.lineHeight, this.scrollExtentLineCount());
     }
 
     const scrolled =
@@ -1622,15 +1528,9 @@ export class Annotator {
     if (scrolled) {
       if (this.dragHandle) {
         this.handleDragMoved = true;
-        this.applyHandleDrag(
-          this.lastSelectPointer.cx,
-          this.lastSelectPointer.cy
-        );
+        this.applyHandleDrag(this.lastSelectPointer.cx, this.lastSelectPointer.cy);
       } else {
-        this.applyPointerToCursor(
-          this.lastSelectPointer.cx,
-          this.lastSelectPointer.cy
-        );
+        this.applyPointerToCursor(this.lastSelectPointer.cx, this.lastSelectPointer.cy);
       }
       this.draw();
     }
@@ -1642,17 +1542,12 @@ export class Annotator {
       inZone &&
       scrolled
     ) {
-      this.selectionScrollRaf = requestAnimationFrame(
-        this.tickSelectionEdgeScroll
-      );
+      this.selectionScrollRaf = requestAnimationFrame(this.tickSelectionEdgeScroll);
     }
   };
 
   private ensureSelectionEdgeScrollRunning() {
-    if (
-      !this.lastSelectPointer ||
-      (!this.cursor.isSelecting() && !this.dragHandle)
-    ) {
+    if (!this.lastSelectPointer || (!this.cursor.isSelecting() && !this.dragHandle)) {
       return;
     }
     if (this.selectionScrollRaf) {
@@ -1661,9 +1556,7 @@ export class Annotator {
     const rect = this.element.getBoundingClientRect();
     const cy = this.lastSelectPointer.cy;
     if (cy < rect.top || cy > rect.bottom) {
-      this.selectionScrollRaf = requestAnimationFrame(
-        this.tickSelectionEdgeScroll
-      );
+      this.selectionScrollRaf = requestAnimationFrame(this.tickSelectionEdgeScroll);
     }
   }
 
@@ -1722,10 +1615,7 @@ export class Annotator {
     this.lastSelectPointer = { cx: e.clientX, cy: e.clientY };
     this.applyPointerToCursor(e.clientX, e.clientY);
 
-    this.annotatedPosition = this.text.cursorToIndex(
-      this.viewport,
-      this.cursor
-    );
+    this.annotatedPosition = this.text.cursorToIndex(this.viewport, this.cursor);
 
     this.draw();
 
@@ -1860,10 +1750,7 @@ export class Annotator {
       }
     }
 
-    const [offsetLeft, offsetRight] = this.text.getCursorWordOffsets(
-      this.viewport,
-      this.cursor
-    );
+    const [offsetLeft, offsetRight] = this.text.getCursorWordOffsets(this.viewport, this.cursor);
     this.cursor.selectStart = {
       xLine: this.cursor.xLine + offsetLeft,
       yLine: this.cursor.yLine,
@@ -1992,15 +1879,20 @@ export class Annotator {
       onChange: (px) => this.setFontSize(px),
     });
 
-    this.settingsOverlay.open(settings, this.element, [
-      {
-        label: "Reset to defaults",
-        onClick: () => {
-          this.resetSettings();
-          this.openSettings(); // re-render so controls show the defaults
+    this.settingsOverlay.open(
+      settings,
+      this.element,
+      [
+        {
+          label: "Reset to defaults",
+          onClick: () => {
+            this.resetSettings();
+            this.openSettings(); // re-render so controls show the defaults
+          },
         },
-      },
-    ], this.menuColors);
+      ],
+      this.menuColors
+    );
   }
 
   /**
@@ -2010,11 +1902,7 @@ export class Annotator {
    */
   onWheel(e: WheelEvent) {
     const deltaBufferPx = e.deltaY * this.ratio;
-    this.viewport.addScrollOffset(
-      deltaBufferPx,
-      this.lineHeight,
-      this.scrollExtentLineCount()
-    );
+    this.viewport.addScrollOffset(deltaBufferPx, this.lineHeight, this.scrollExtentLineCount());
 
     e.preventDefault();
     this.draw();
@@ -2025,19 +1913,11 @@ export class Annotator {
     if (prev && prev !== this) {
       prev.destroy();
     }
-    this.lines = new Lines(
-      canvasElement,
-      this.ratio,
-      this.lineHeight,
-      this.charWidth
-    );
+    this.lines = new Lines(canvasElement, this.ratio, this.lineHeight, this.charWidth);
     linesHosts.set(canvasElement, this);
   }
 
-  getAnnotations(
-    start: SegmentPosition | null,
-    end: SegmentPosition | null
-  ): Tag[] {
+  getAnnotations(start: SegmentPosition | null, end: SegmentPosition | null): Tag[] {
     // Track open/close tag pairs more cleanly using Tag objects
     const tagStack: Tag[] = [];
     const finalTags: Tag[] = [];
@@ -2078,10 +1958,7 @@ export class Annotator {
     };
 
     // Helper function to find the closest opening tag for a given tag name
-    const findClosestOpeningTag = (
-      tagName: string,
-      beforeAbsolutePosition: number
-    ): Tag | null => {
+    const findClosestOpeningTag = (tagName: string, beforeAbsolutePosition: number): Tag | null => {
       let closestTag: Tag | null = null;
       let closestDistance = Infinity;
 
@@ -2089,10 +1966,7 @@ export class Annotator {
         const segment = this.text.segments[i];
         for (const tag of segment.openingTags) {
           const tagAbsolutePosition = getAbsoluteTextIndex(tag);
-          if (
-            tag.getTagName() === tagName &&
-            tagAbsolutePosition < beforeAbsolutePosition
-          ) {
+          if (tag.getTagName() === tagName && tagAbsolutePosition < beforeAbsolutePosition) {
             const distance = beforeAbsolutePosition - tagAbsolutePosition;
             if (distance < closestDistance) {
               closestDistance = distance;
@@ -2142,8 +2016,7 @@ export class Annotator {
           }
         } else {
           const matchingIndex = tagStack.findLastIndex(
-            (stackTag) =>
-              stackTag.getTagName() === tag.getTagName() && !stackTag.closing
+            (stackTag) => stackTag.getTagName() === tag.getTagName() && !stackTag.closing
           );
 
           if (matchingIndex !== -1) {
@@ -2153,10 +2026,8 @@ export class Annotator {
 
             const closingTagInSelection =
               (i > start.segmentIndex ||
-                (i === start.segmentIndex &&
-                  tag.position >= start.rawTextIndex)) &&
-              (i < end.segmentIndex ||
-                (i === end.segmentIndex && tag.position < end.rawTextIndex));
+                (i === start.segmentIndex && tag.position >= start.rawTextIndex)) &&
+              (i < end.segmentIndex || (i === end.segmentIndex && tag.position < end.rawTextIndex));
 
             const openingTagOpenedBeforeEnd =
               matchedOpeningTag.segmentIndex < end.segmentIndex ||
@@ -2167,8 +2038,7 @@ export class Annotator {
               closingTagInSelection ||
               (openingTagOpenedBeforeEnd &&
                 (i > start.segmentIndex ||
-                  (i === start.segmentIndex &&
-                    tag.position >= start.rawTextIndex)));
+                  (i === start.segmentIndex && tag.position >= start.rawTextIndex)));
 
             if (shouldIncludeOpeningTag) {
               addToFinal(matchedOpeningTag);
@@ -2182,10 +2052,8 @@ export class Annotator {
 
           const closingTagInSelection =
             (i > start.segmentIndex ||
-              (i === start.segmentIndex &&
-                tag.position >= start.rawTextIndex)) &&
-            (i < end.segmentIndex ||
-              (i === end.segmentIndex && tag.position < end.rawTextIndex));
+              (i === start.segmentIndex && tag.position >= start.rawTextIndex)) &&
+            (i < end.segmentIndex || (i === end.segmentIndex && tag.position < end.rawTextIndex));
           if (closingTagInSelection) {
             addToFinal(tag);
           }
@@ -2200,8 +2068,7 @@ export class Annotator {
       // Tags that opened after end position should not be included
       const tagOpenedBeforeEnd =
         unclosedTag.segmentIndex < end.segmentIndex ||
-        (unclosedTag.segmentIndex === end.segmentIndex &&
-          unclosedTag.position < end.rawTextIndex);
+        (unclosedTag.segmentIndex === end.segmentIndex && unclosedTag.position < end.rawTextIndex);
 
       if (tagOpenedBeforeEnd) {
         // Tag opened before end position and is still unclosed, so it's active in the selection
@@ -2238,10 +2105,7 @@ export class Annotator {
           const tagSegmentIndex = tag.segmentIndex;
           if (tagSegmentIndex !== -1) {
             const tagAbsolutePosition = getAbsoluteTextIndex(tag);
-            const closestOpening = findClosestOpeningTag(
-              tag.getTagName(),
-              tagAbsolutePosition
-            );
+            const closestOpening = findClosestOpeningTag(tag.getTagName(), tagAbsolutePosition);
             if (closestOpening) {
               const closestOpeningId = getTagId(closestOpening);
               if (!processedTagIds.has(closestOpeningId)) {
@@ -2316,10 +2180,7 @@ export class Annotator {
     this.scroller.setFocusTarget(this.element);
     this.scroller.onChange((percentage: number) => {
       const viewportLines = this.viewport.lineEnd - this.viewport.lineStart;
-      const scrollableLines = Math.max(
-        0,
-        this.scrollExtentLineCount() - viewportLines
-      );
+      const scrollableLines = Math.max(0, this.scrollExtentLineCount() - viewportLines);
       const scrollablePx = scrollableLines * this.lineHeight;
       const targetPx = (percentage / 100) * scrollablePx;
       const targetLineFrac = scrollablePx > 0 ? targetPx / this.lineHeight : 0;
@@ -2332,9 +2193,7 @@ export class Annotator {
       );
       this.draw();
     });
-    this.scroller?.setRunnerSize(
-      (this.viewport.noLines / this.scrollExtentLineCount()) * 100
-    );
+    this.scroller?.setRunnerSize((this.viewport.noLines / this.scrollExtentLineCount()) * 100);
 
     const viewportSize = this.viewport.noLines / this.scrollExtentLineCount();
     this.scroller?.setViewportSize(Math.min(100, viewportSize * 100));
@@ -2362,25 +2221,20 @@ export class Annotator {
     };
 
     const mainCssW = parseCssPx(mainEl.style.width) || mainEl.clientWidth || 1;
-    const gutterCssW =
-      parseCssPx(lineEl.style.width) || lineEl.clientWidth || 50;
+    const gutterCssW = parseCssPx(lineEl.style.width) || lineEl.clientWidth || 50;
 
     if (mainEl.style.height) {
       lineEl.style.height = mainEl.style.height;
     }
 
-    const scale =
-      mainEl.width > 0 && mainCssW > 0 ? mainEl.width / mainCssW : this.ratio;
+    const scale = mainEl.width > 0 && mainCssW > 0 ? mainEl.width / mainCssW : this.ratio;
     const nextW = Math.max(1, Math.round(gutterCssW * scale));
     const nextH =
       mainEl.height > 0
         ? mainEl.height
         : Math.max(
             1,
-            Math.round(
-              (parseCssPx(mainEl.style.height) || mainEl.clientHeight) *
-                this.ratio
-            )
+            Math.round((parseCssPx(mainEl.style.height) || mainEl.clientHeight) * this.ratio)
           );
 
     if (lineEl.width !== nextW || lineEl.height !== nextH) {
@@ -2407,9 +2261,7 @@ export class Annotator {
       tag?: Tag;
     }[]
   ): void {
-    const anchorItems = higlightItems.filter(
-      (it) => it.schema.mode === HighlightMode.ANCHOR
-    );
+    const anchorItems = higlightItems.filter((it) => it.schema.mode === HighlightMode.ANCHOR);
     if (anchorItems.length === 0) {
       return;
     }
@@ -2430,8 +2282,7 @@ export class Annotator {
     // endpoint is off-screen is simply skipped (a multi-screen territory shows
     // ┌ on its first visible line and ┘ on its last).
     const lastVisibleRel =
-      Math.min(this.viewport.lineEnd, this.text.noLines) -
-      this.viewport.lineStart;
+      Math.min(this.viewport.lineEnd, this.text.noLines) - this.viewport.lineStart;
 
     // Expand each anchor into its two endpoint markers, in list order.
     const points: {
@@ -2608,19 +2459,12 @@ export class Annotator {
     // if (this.onSelectTextCb && this.cursor.isSelected()) {
     if (this.onSelectTextCb) {
       const [start, end] = this.cursor.getAbsBounds();
-      if (
-        start &&
-        end &&
-        (start.xLine !== end.xLine || start?.yLine !== end?.yLine)
-      ) {
+      if (start && end && (start.xLine !== end.xLine || start?.yLine !== end?.yLine)) {
         const startSegment = this.text.getSegmentPosition(
           start.yLine,
           start.xLine
         ) as SegmentPosition;
-        const endSegment = this.text.getSegmentPosition(
-          end.yLine,
-          end.xLine
-        ) as SegmentPosition;
+        const endSegment = this.text.getSegmentPosition(end.yLine, end.xLine) as SegmentPosition;
         const annotated = this.getAnnotations(startSegment, endSegment);
         this.onSelectTextCb({
           text: this.text.getRangeText(start, end),
@@ -2639,15 +2483,8 @@ export class Annotator {
     }
 
     if (this.text.mode === EditMode.HIGHLIGHT && this.onHighlightCb) {
-      const startPos = this.text.getSegmentPosition(
-        this.viewport.lineStart,
-        0,
-        true
-      );
-      const endPos = this.text.getSegmentPosition(
-        this.viewport.lineEnd,
-        this.text.charsAtLine
-      );
+      const startPos = this.text.getSegmentPosition(this.viewport.lineStart, 0, true);
+      const endPos = this.text.getSegmentPosition(this.viewport.lineEnd, this.text.charsAtLine);
 
       const annotated: Tag[] = this.getAnnotations(startPos, endPos);
       const higlightItems: {
@@ -2664,11 +2501,7 @@ export class Annotator {
         }
         processedTagNames.add(tagName);
         const hlResult = this.onHighlightCb(tagName);
-        const schemas = Array.isArray(hlResult)
-          ? hlResult
-          : hlResult
-          ? [hlResult]
-          : [];
+        const schemas = Array.isArray(hlResult) ? hlResult : hlResult ? [hlResult] : [];
         if (schemas.length) {
           let occurence: IAbsCoordinates[];
           let i = 0;
@@ -2726,6 +2559,21 @@ export class Annotator {
       }
 
       this.drawAnchorMarkers(higlightItems);
+
+      // #2887 — highlights and anchor markers paint after the collapsed caret
+      // above, so a caret sharing a marker's cell is hidden underneath. Repaint
+      // it on top. Guarded to the collapsed case: cursor.draw then strokes only
+      // the caret, so selection rects are never lifted over the highlights.
+      if (textSegment && !this.cursor.isSelected()) {
+        this.cursor.draw(this.ctx, this.viewport, this.text, {
+          lineHeight: this.lineHeight,
+          charWidth: this.charWidth,
+          charsAtLine: this.text.charsAtLine,
+          caretWidth: this.caretWidth * this.ratio,
+          caretVisible: this.canvasFocused && this.caretBlink.isVisible(),
+          columnToPixelX: this.drawColumnToPixelX(),
+        });
+      }
     }
 
     // Issue #3108 — draw the draggable handles on top of the selection. Inside
@@ -2780,9 +2628,7 @@ export class Annotator {
   private loadSettings(): void {
     let parsed: PersistedSettings | null = null;
     try {
-      const raw =
-        typeof localStorage !== "undefined" &&
-        localStorage.getItem(SETTINGS_STORAGE_KEY);
+      const raw = typeof localStorage !== "undefined" && localStorage.getItem(SETTINGS_STORAGE_KEY);
       if (raw) {
         parsed = JSON.parse(raw) as PersistedSettings;
       }
@@ -2839,9 +2685,7 @@ export class Annotator {
     // Default to the first host-supplied option (e.g. "Sans (app)") so the
     // picker shows a valid value; fall back to the generic when none supplied.
     this.proportionalFontFamily =
-      this.fontFamilyOptions.length > 0
-        ? this.fontFamilyOptions[0].value
-        : PROPORTIONAL_FONT;
+      this.fontFamilyOptions.length > 0 ? this.fontFamilyOptions[0].value : PROPORTIONAL_FONT;
 
     try {
       if (typeof localStorage !== "undefined") {
@@ -2881,10 +2725,7 @@ export class Annotator {
    * shows the real default rather than black.
    */
   getHighlightColor(): string {
-    return (
-      this.highlightColor ??
-      this.cssColorToHex(this.cursor.style.color as string)
-    );
+    return this.highlightColor ?? this.cssColorToHex(this.cursor.style.color as string);
   }
 
   /**
@@ -2931,17 +2772,13 @@ export class Annotator {
    * during activity and dips after idle gaps.
    */
   private updateFps() {
-    const now =
-      typeof performance !== "undefined" ? performance.now() : Date.now();
+    const now = typeof performance !== "undefined" ? performance.now() : Date.now();
     if (this.lastFrameTime > 0) {
       const dt = now - this.lastFrameTime;
       if (dt > 0) {
         const instantaneous = 1000 / dt;
         // Exponential moving average smooths jitter between on-demand redraws.
-        this.fps =
-          this.fps === 0
-            ? instantaneous
-            : this.fps * 0.8 + instantaneous * 0.2;
+        this.fps = this.fps === 0 ? instantaneous : this.fps * 0.8 + instantaneous * 0.2;
       }
     }
     this.lastFrameTime = now;
@@ -2997,10 +2834,7 @@ export class Annotator {
       const absLine = segment.lineStart + newPos.lineIndex;
       this.viewport.lineStart = Math.max(
         0,
-        Math.min(
-          absLine,
-          Math.max(0, this.scrollExtentLineCount() - 1 - this.viewport.noLines)
-        )
+        Math.min(absLine, Math.max(0, this.scrollExtentLineCount() - 1 - this.viewport.noLines))
       );
       this.viewport.scrollOffsetY = scrollOffsetBefore;
     }
@@ -3082,18 +2916,13 @@ export class Annotator {
         maxTagEnd = Math.max(maxTagEnd, m.index + m[0].length);
       }
       const selectionEncompassesAllTags =
-        minTagStart <= maxTagEnd &&
-        indexStart <= minTagStart &&
-        indexEnd >= maxTagEnd;
+        minTagStart <= maxTagEnd && indexStart <= minTagStart && indexEnd >= maxTagEnd;
       if (selectionEncompassesAllTags) {
         if (indexStart === 0) {
           indexEnd = raw.length;
         }
       } else {
-        [indexStart, indexEnd] = this.sanitizeEnvelopeRange(
-          indexStart,
-          indexEnd
-        );
+        [indexStart, indexEnd] = this.sanitizeEnvelopeRange(indexStart, indexEnd);
       }
 
       // could be '<tag>text .... text</tag> (closing tag always included if present)
@@ -3104,12 +2933,7 @@ export class Annotator {
       const openTagString = openTag.getTag();
       const closeTagString = closeTag.getTag();
 
-      this.text.value =
-        beforeText +
-        openTagString +
-        selectedRawText +
-        closeTagString +
-        afterText;
+      this.text.value = beforeText + openTagString + selectedRawText + closeTagString + afterText;
 
       this.text.prepareSegments();
       this.text.calculateLines();
@@ -3208,8 +3032,7 @@ export class Annotator {
 
     // Scroll to where the anchored content starts (just past the opening tag).
     this.scrollCaretToRawIndex(
-      openingTag.getAbsoluteTagPosition(this.text.segments) +
-        openingTag.getTagLength()
+      openingTag.getAbsoluteTagPosition(this.text.segments) + openingTag.getTagLength()
     );
   }
 
@@ -3250,16 +3073,9 @@ export class Annotator {
 
     // Preserve fluent scroll offset (deltaY) so updating text (e.g. discard)
     // doesn't snap the viewport to the top of a line.
-    const maxLineStart = Math.max(
-      0,
-      this.scrollExtentLineCount() - 1 - this.viewport.noLines
-    );
-    const clampedLineStart = Math.max(
-      0,
-      Math.min(positionBeforeChange, maxLineStart)
-    );
-    const desiredLineStart =
-      clampedLineStart + (scrollOffsetBeforeChange || 0) / this.lineHeight;
+    const maxLineStart = Math.max(0, this.scrollExtentLineCount() - 1 - this.viewport.noLines);
+    const clampedLineStart = Math.max(0, Math.min(positionBeforeChange, maxLineStart));
+    const desiredLineStart = clampedLineStart + (scrollOffsetBeforeChange || 0) / this.lineHeight;
 
     this.viewport.setScrollPosition(
       desiredLineStart,
@@ -3276,19 +3092,11 @@ export class Annotator {
    * @param isRegex
    * @returns
    */
-  search(
-    toFind: string,
-    isRegex: boolean = false,
-    isCaseSensitive: boolean = true
-  ): Occurrence[] {
+  search(toFind: string, isRegex: boolean = false, isCaseSensitive: boolean = true): Occurrence[] {
     const occurrences = [];
     const normalizedTerm = isCaseSensitive ? toFind : toFind.toLowerCase();
 
-    const collectLiteralOccurrences = (
-      line: string,
-      segmentIndex: number,
-      lineIndex: number
-    ) => {
+    const collectLiteralOccurrences = (line: string, segmentIndex: number, lineIndex: number) => {
       const normalizedLine = isCaseSensitive ? line : line.toLowerCase();
       let startIndex = 0;
 
@@ -3328,18 +3136,10 @@ export class Annotator {
             }
           } catch (error) {
             // If regex is invalid, treat as literal string
-            collectLiteralOccurrences(
-              line,
-              parseInt(segmentI, 10),
-              parseInt(lineI, 10)
-            );
+            collectLiteralOccurrences(line, parseInt(segmentI, 10), parseInt(lineI, 10));
           }
         } else {
-          collectLiteralOccurrences(
-            line,
-            parseInt(segmentI, 10),
-            parseInt(lineI, 10)
-          );
+          collectLiteralOccurrences(line, parseInt(segmentI, 10), parseInt(lineI, 10));
         }
       }
     }
@@ -3352,9 +3152,7 @@ export class Annotator {
    * @param occurence
    */
   selectSearchOccurrence(occurence: Occurrence) {
-    const absY =
-      this.text.segments[occurence.segmentIndex].lineStart +
-      occurence.lineIndex;
+    const absY = this.text.segments[occurence.segmentIndex].lineStart + occurence.lineIndex;
     this.cursor.xLine = occurence.end;
     this.cursor.yLine = absY;
 
@@ -3379,10 +3177,7 @@ export class Annotator {
           start.yLine,
           start.xLine
         ) as SegmentPosition;
-        const endSegment = this.text.getSegmentPosition(
-          end.yLine,
-          end.xLine
-        ) as SegmentPosition;
+        const endSegment = this.text.getSegmentPosition(end.yLine, end.xLine) as SegmentPosition;
         const annotated = this.getAnnotations(startSegment, endSegment);
         this.onSelectTextCb({
           text: this.text.getRangeText(start, end),
@@ -3429,11 +3224,7 @@ export class Annotator {
     this.keys.scrollCursorIntoView();
     this.runWarningChecks();
 
-    if (
-      changed &&
-      this.text.mode !== EditMode.HIGHLIGHT &&
-      this.onTextChangeCb
-    ) {
+    if (changed && this.text.mode !== EditMode.HIGHLIGHT && this.onTextChangeCb) {
       this.onTextChangeCb(this.text.value);
     }
     this.draw();
@@ -3508,10 +3299,7 @@ export class Annotator {
         // Place the caret at insert-offset + length via the offset model. Unlike
         // move(len, 0) — which only shifts xLine and mishandles pasted newlines —
         // this lands correctly for multi-line text and stays in bounds.
-        const insertOffset = this.text.offsetFromVisual(
-          this.cursor.xLine,
-          this.cursor.yLine
-        );
+        const insertOffset = this.text.offsetFromVisual(this.cursor.xLine, this.cursor.yLine);
         this.text.insertText(this.viewport, this.cursor, clipText);
         const pasteAt = insertOffset >= 0 ? insertOffset : this.cursor.head;
         this.cursor.moveToOffset(this.text, pasteAt + clipText.length);
@@ -3539,10 +3327,7 @@ export class Annotator {
       this.cursor.setPosition(area[0].xLine, area[0].yLine);
     }
     // See onPasteText: offset-based caret placement handles multi-line text.
-    const insertOffset = this.text.offsetFromVisual(
-      this.cursor.xLine,
-      this.cursor.yLine
-    );
+    const insertOffset = this.text.offsetFromVisual(this.cursor.xLine, this.cursor.yLine);
     this.text.insertText(this.viewport, this.cursor, text);
     const insertAt = insertOffset >= 0 ? insertOffset : this.cursor.head;
     this.cursor.moveToOffset(this.text, insertAt + text.length);
@@ -3637,10 +3422,7 @@ export class Annotator {
    * @param indexEnd The current end index of the text range
    * @returns Adjusted [indexStart, indexEnd] to ensure proper nesting
    */
-  private sanitizeEnvelopeRange(
-    indexStart: number,
-    indexEnd: number
-  ): [number, number] {
+  private sanitizeEnvelopeRange(indexStart: number, indexEnd: number): [number, number] {
     const raw = this.text.value;
 
     // Utility functions
@@ -3661,14 +3443,8 @@ export class Annotator {
       const searchText = raw.slice(rangeStart, rangeEnd);
 
       // Use existing regexes to find all tags in the search range
-      const openingRegex = new RegExp(
-        openingTagRegex.source,
-        openingTagRegex.flags
-      );
-      const closingRegex = new RegExp(
-        closingTagRegex.source,
-        closingTagRegex.flags
-      );
+      const openingRegex = new RegExp(openingTagRegex.source, openingTagRegex.flags);
+      const closingRegex = new RegExp(closingTagRegex.source, closingTagRegex.flags);
 
       // Find all opening tags
       let match;
@@ -3757,9 +3533,7 @@ export class Annotator {
         const closingTag = tagPositions.find(
           (t) => !t.isOpen && t.name === tag.name && t.start > tag.start
         );
-        return (
-          closingTag != null && start <= tag.start && end >= closingTag.end
-        );
+        return closingTag != null && start <= tag.start && end >= closingTag.end;
       });
 
       if (hasCompleteTagPairFullyContained) {
@@ -3786,11 +3560,7 @@ export class Annotator {
         }
 
         // If we found valid content boundaries, use them
-        if (
-          contentStart < contentEnd &&
-          contentStart >= start &&
-          contentEnd <= end
-        ) {
+        if (contentStart < contentEnd && contentStart >= start && contentEnd <= end) {
           return [clamp(contentStart), clamp(contentEnd)];
         }
       }
@@ -3799,9 +3569,7 @@ export class Annotator {
     }
 
     // Find tags that overlap with our selection
-    const overlappingTags = tagPositions.filter(
-      (tag) => tag.start < end && tag.end > start
-    );
+    const overlappingTags = tagPositions.filter((tag) => tag.start < end && tag.end > start);
 
     // Remove immediate closing nodes from the left neighbor group
     // This handles cases where selection starts with closing tags that should be excluded
@@ -3828,10 +3596,7 @@ export class Annotator {
       if (nextOpeningTag && end > nextOpeningTag.end) {
         // Check if the selection ends with the matching closing tag for this opening tag
         const matchingClosingTag = tagPositions.find(
-          (t) =>
-            !t.isOpen &&
-            t.name === nextOpeningTag.name &&
-            t.start > nextOpeningTag.start
+          (t) => !t.isOpen && t.name === nextOpeningTag.name && t.start > nextOpeningTag.start
         );
 
         // Only remove the opening tag if the selection doesn't include the complete tag pair
@@ -3846,14 +3611,12 @@ export class Annotator {
       // Also check for closing tags at the end that should be removed
       // But only remove them if they're not part of a complete tag pair
       let adjustedEnd = end;
-      const closingTagsAtEnd = overlappingTags.filter(
-        (tag) => !tag.isOpen && tag.end === end
-      );
+      const closingTagsAtEnd = overlappingTags.filter((tag) => !tag.isOpen && tag.end === end);
 
       if (closingTagsAtEnd.length > 0) {
         // Find the leftmost closing tag at the end
-        const leftmostClosingTagAtEnd = closingTagsAtEnd.reduce(
-          (min, current) => (current.start < min.start ? current : min)
+        const leftmostClosingTagAtEnd = closingTagsAtEnd.reduce((min, current) =>
+          current.start < min.start ? current : min
         );
 
         // Check if this closing tag is part of a complete tag pair
@@ -3865,11 +3628,12 @@ export class Annotator {
               t.name === leftmostClosingTagAtEnd.name &&
               t.start < leftmostClosingTagAtEnd.start
           )
-          .reduce(
-            (closest, current) =>
-              current.start > closest.start ? current : closest,
-            { start: -1, end: -1, name: "", isOpen: false }
-          );
+          .reduce((closest, current) => (current.start > closest.start ? current : closest), {
+            start: -1,
+            end: -1,
+            name: "",
+            isOpen: false,
+          });
 
         // Only remove the closing tag if it's not part of a complete tag pair
         if (!matchingOpeningTag || matchingOpeningTag.start < adjustedStart) {
@@ -3911,10 +3675,7 @@ export class Annotator {
       let isSeparate = true;
       for (let i = 0; i < openTags.length - 1; i++) {
         for (let j = i + 1; j < openTags.length; j++) {
-          if (
-            openTags[i].start < openTags[j].start &&
-            openTags[j].end < openTags[i].end
-          ) {
+          if (openTags[i].start < openTags[j].start && openTags[j].end < openTags[i].end) {
             isSeparate = false;
             break;
           }
@@ -3939,11 +3700,7 @@ export class Annotator {
     let newEnd = end;
 
     // If selection starts before the tag and ends after the tag starts
-    if (
-      start <= innermostTag.start &&
-      end > innermostTag.start &&
-      end <= innermostTag.end
-    ) {
+    if (start <= innermostTag.start && end > innermostTag.start && end <= innermostTag.end) {
       // Move start to after the tag (exclude the tag)
       newStart = innermostTag.end;
     }
@@ -3953,11 +3710,7 @@ export class Annotator {
       newStart = innermostTag.end;
     }
     // If selection starts before the tag ends and ends after the tag
-    else if (
-      start >= innermostTag.start &&
-      start < innermostTag.end &&
-      end >= innermostTag.end
-    ) {
+    else if (start >= innermostTag.start && start < innermostTag.end && end >= innermostTag.end) {
       // Move end to before the tag (exclude the tag)
       newEnd = innermostTag.start;
     }
@@ -3967,10 +3720,7 @@ export class Annotator {
       if (innermostTag.isOpen) {
         // This is an opening tag, find its closing tag
         const closingTag = tagPositions.find(
-          (t) =>
-            !t.isOpen &&
-            t.name === innermostTag.name &&
-            t.start > innermostTag.start
+          (t) => !t.isOpen && t.name === innermostTag.name && t.start > innermostTag.start
         );
         if (closingTag) {
           newStart = innermostTag.end;
@@ -3979,10 +3729,7 @@ export class Annotator {
       } else {
         // This is a closing tag, find its opening tag
         const openingTag = tagPositions.find(
-          (t) =>
-            t.isOpen &&
-            t.name === innermostTag.name &&
-            t.start < innermostTag.start
+          (t) => t.isOpen && t.name === innermostTag.name && t.start < innermostTag.start
         );
         if (openingTag) {
           newStart = openingTag.end;
@@ -3996,11 +3743,7 @@ export class Annotator {
     if (newStart === start && newEnd === end) {
       // Find closing tags that are before the innermost tag and within our selection
       for (const tag of overlappingTags) {
-        if (
-          !tag.isOpen &&
-          tag.end <= innermostTag.start &&
-          tag.start >= start
-        ) {
+        if (!tag.isOpen && tag.end <= innermostTag.start && tag.start >= start) {
           // This is a closing tag before the innermost tag, move start past it
           newStart = Math.max(newStart, tag.end);
         }
@@ -4011,9 +3754,7 @@ export class Annotator {
     // move the start to exclude the closing tag
     if (newStart === start && newEnd === end) {
       // Check if selection starts with a closing tag
-      const startingClosingTag = overlappingTags.find(
-        (tag) => !tag.isOpen && tag.start === start
-      );
+      const startingClosingTag = overlappingTags.find((tag) => !tag.isOpen && tag.start === start);
 
       if (startingClosingTag) {
         // Check if the end matches a complete tag pair
@@ -4024,10 +3765,7 @@ export class Annotator {
         if (endingTag) {
           // Find the matching closing tag for the ending tag
           const matchingClosingTag = tagPositions.find(
-            (t) =>
-              !t.isOpen &&
-              t.name === endingTag.name &&
-              t.start > endingTag.start
+            (t) => !t.isOpen && t.name === endingTag.name && t.start > endingTag.start
           );
 
           if (matchingClosingTag && matchingClosingTag.end === end) {
@@ -4060,11 +3798,7 @@ export class Annotator {
       }
 
       // If we found valid content boundaries, use them
-      if (
-        contentStart < contentEnd &&
-        contentStart >= start &&
-        contentEnd <= end
-      ) {
+      if (contentStart < contentEnd && contentStart >= start && contentEnd <= end) {
         newStart = contentStart;
         newEnd = contentEnd;
       }
@@ -4098,10 +3832,7 @@ export class Annotator {
     segmentIndex: number
   ): { tag: Tag; issue: AsymmetricalAnchor } | undefined {
     const issue = this.validateAnchors().find(
-      (i) =>
-        i.tagName === tagName &&
-        i.position === position &&
-        i.segmentIndex === segmentIndex
+      (i) => i.tagName === tagName && i.position === position && i.segmentIndex === segmentIndex
     );
     if (!issue) {
       return undefined;
@@ -4112,13 +3843,8 @@ export class Annotator {
       return undefined;
     }
 
-    const tags =
-      issue.type === "orphaned-opening"
-        ? segment.openingTags
-        : segment.closingTags;
-    const tag = tags.find(
-      (t) => t.getTagName() === tagName && t.position === issue.position
-    );
+    const tags = issue.type === "orphaned-opening" ? segment.openingTags : segment.closingTags;
+    const tag = tags.find((t) => t.getTagName() === tagName && t.position === issue.position);
 
     return tag ? { tag, issue } : undefined;
   }
@@ -4150,11 +3876,7 @@ export class Annotator {
    * Remove an asymmetrical (broken) anchor identified by tag name, per-segment
    * position and segment index. Returns true if successfully removed.
    */
-  removeAsymmetricalAnchor(
-    tagName: string,
-    position: number,
-    segmentIndex: number
-  ): boolean {
+  removeAsymmetricalAnchor(tagName: string, position: number, segmentIndex: number): boolean {
     const found = this.findAsymmetricalTag(tagName, position, segmentIndex);
     if (!found) {
       return false;
@@ -4192,18 +3914,12 @@ export class Annotator {
    * both orphaned opening and orphaned closing tags. Intended to be used in RAW
    * mode, where the tag markup is visible and line positions match raw text.
    */
-  scrollToAsymmetricalAnchor(
-    tagName: string,
-    position: number,
-    segmentIndex: number
-  ): void {
+  scrollToAsymmetricalAnchor(tagName: string, position: number, segmentIndex: number): void {
     const found = this.findAsymmetricalTag(tagName, position, segmentIndex);
     if (!found) {
       return;
     }
-    this.scrollCaretToRawIndex(
-      found.tag.getAbsoluteTagPosition(this.text.segments)
-    );
+    this.scrollCaretToRawIndex(found.tag.getAbsoluteTagPosition(this.text.segments));
   }
 
   /**

--- a/packages/annotator/src/lib/Annotator.ts
+++ b/packages/annotator/src/lib/Annotator.ts
@@ -2300,9 +2300,19 @@ export class Annotator {
         color: it.schema.style.color,
         tag: it.tag,
       });
+      // An end boundary at column 0 belongs visually to the previous line —
+      // drawn on its own line, the ┘ arm (running left) would be clamped
+      // rightward over that line's text. Render it after the previous line's
+      // last character instead.
+      let endYLine = it.end.yLine;
+      let endXLine = it.end.xLine;
+      if (endXLine === 0 && endYLine > 0) {
+        endYLine -= 1;
+        endXLine = this.text.getLine(endYLine).length;
+      }
       points.push({
-        yLine: it.end.yLine,
-        xLine: it.end.xLine,
+        yLine: endYLine,
+        xLine: endXLine,
         kind: "end",
         color: it.schema.style.color,
         tag: it.tag,

--- a/packages/annotator/src/lib/Annotator.ts
+++ b/packages/annotator/src/lib/Annotator.ts
@@ -8,10 +8,15 @@ import Keys from "./Keys";
 import { Lines } from "./Lines";
 import Scroller from "./Scroller";
 import Text, { Tag, SegmentPosition, CaretAffinity } from "./Text";
+import { drawAnchorMarker } from "./AnchorMarker";
 import { CanvasMeasurer } from "./TextMeasurer";
 import Viewport from "./Viewport";
 import { AsymmetricalAnchor, Warnings, WarningData } from "./warnings";
 import {
+  ANCHOR_MARKER_ARM_H_RATIO,
+  ANCHOR_MARKER_ARM_W_RATIO,
+  ANCHOR_MARKER_LINE_WIDTH_PX,
+  ANCHOR_MARKER_STACK_STEP_PX,
   DEFAULT_FONT,
   DEFAULT_FONT_SIZE,
   PROPORTIONAL_FONT,
@@ -2353,6 +2358,95 @@ export class Annotator {
   }
 
   /**
+   * Issue #2887 — draw corner markers at the ends of ANCHOR-mode highlights
+   * (Territory anchors). Each item contributes a start (┌) and an end (└)
+   * marker; a filled span is never drawn, so the whole-territory anchor does
+   * not flood the fulltext. Markers sharing an exact position are stacked with
+   * a small horizontal offset (e.g. a book and its first chapter starting on
+   * the same character), preserving the innermost-first order the highlight
+   * list already carries (#2051). Assumes the ctx is translated for scroll,
+   * matching the surrounding draw passes.
+   */
+  private drawAnchorMarkers(
+    higlightItems: {
+      schema: HighlightSchema;
+      start: IAbsCoordinates;
+      end: IAbsCoordinates;
+    }[]
+  ): void {
+    const anchorItems = higlightItems.filter(
+      (it) => it.schema.mode === HighlightMode.ANCHOR
+    );
+    if (anchorItems.length === 0) {
+      return;
+    }
+
+    const armH = ANCHOR_MARKER_ARM_H_RATIO * this.lineHeight;
+    const armW = ANCHOR_MARKER_ARM_W_RATIO * this.charWidth;
+    const lineWidth = ANCHOR_MARKER_LINE_WIDTH_PX * this.ratio;
+    const stackStep = ANCHOR_MARKER_STACK_STEP_PX * this.ratio;
+
+    const columnToPixelX = this.drawColumnToPixelX();
+    const toPx = (yLine: number, xLine: number): number =>
+      columnToPixelX ? columnToPixelX(yLine, xLine) : xLine * this.charWidth;
+
+    // Only rows the main text renderer paints are eligible; a marker whose
+    // endpoint is off-screen is simply skipped (a multi-screen territory shows
+    // ┌ on its first visible line and ┘ on its last).
+    const lastVisibleRel =
+      Math.min(this.viewport.lineEnd, this.text.noLines) -
+      this.viewport.lineStart;
+
+    // Expand each anchor into its two endpoint markers, in list order.
+    const points: {
+      yLine: number;
+      xLine: number;
+      kind: "start" | "end";
+      color: string;
+    }[] = [];
+    for (const it of anchorItems) {
+      points.push({
+        yLine: it.start.yLine,
+        xLine: it.start.xLine,
+        kind: "start",
+        color: it.schema.style.color,
+      });
+      points.push({
+        yLine: it.end.yLine,
+        xLine: it.end.xLine,
+        kind: "end",
+        color: it.schema.style.color,
+      });
+    }
+
+    // Offset successive markers that land on the exact same position/side so
+    // stacked anchors remain individually visible instead of overprinting.
+    const stackIndex = new Map<string, number>();
+    for (const p of points) {
+      const relLine = p.yLine - this.viewport.lineStart;
+      if (relLine < 0 || relLine > lastVisibleRel) {
+        continue;
+      }
+
+      const key = `${p.yLine}:${p.xLine}:${p.kind}`;
+      const idx = stackIndex.get(key) ?? 0;
+      stackIndex.set(key, idx + 1);
+
+      // Stacked markers fan out to the right (both arms point right), so a
+      // stack never runs off the left margin where boundaries commonly sit.
+      const xPx = toPx(p.yLine, p.xLine) + idx * stackStep;
+      const yMid = (relLine + 0.5) * this.lineHeight;
+
+      drawAnchorMarker(this.ctx, xPx, yMid, p.kind, {
+        armH,
+        armW,
+        lineWidth,
+        color: p.color,
+      });
+    }
+  }
+
+  /**
    * draw resets the canvas and redraws the scene anew.
    * First draw lines with text, then allow each component to draw their own logic.
    * TODO - this should be done in conjunction with requestAnimationFrame
@@ -2518,6 +2612,11 @@ export class Annotator {
       });
 
       for (const item of higlightItems) {
+        // ANCHOR items are point markers, not spans — drawn in the dedicated
+        // pass below (#2887), never as a filled range.
+        if (item.schema.mode === HighlightMode.ANCHOR) {
+          continue;
+        }
         const highlighter = new Highlighter(
           this.ratio,
           {
@@ -2536,6 +2635,8 @@ export class Annotator {
           columnToPixelX: this.drawColumnToPixelX(),
         });
       }
+
+      this.drawAnchorMarkers(higlightItems);
     }
 
     // Issue #3108 — draw the draggable handles on top of the selection. Inside

--- a/packages/annotator/src/lib/Highlighter.ts
+++ b/packages/annotator/src/lib/Highlighter.ts
@@ -134,7 +134,10 @@ export default class Highlighter {
     ctx.globalAlpha = this.style.opacity;
 
     if (this.hlMode === "focus") {
-      ctx.globalCompositeOperation = "xor";
+      // source-over (not xor): xor over opaque text just fades by alpha and
+      // ignores the fill colour, so the veil could never be tinted. source-over
+      // lays the actual colour down, so the scrim takes `style.color` (#2887).
+      ctx.globalCompositeOperation = "source-over";
       ctx.fillRect(xStartPx, relLine * lineHeight, width, lineHeight);
     } else if (this.hlMode === "underline") {
       ctx.globalCompositeOperation = "multiply";
@@ -173,8 +176,6 @@ export default class Highlighter {
     text: Text,
     drawingOptions: DrawingOptions
   ) {
-    const { charsAtLine } = drawingOptions;
-
     let [hStart, hEnd] = this.getAbsBounds();
     if (hStart && hEnd) {
       if (hStart.yLine > hEnd.yLine) {
@@ -193,9 +194,30 @@ export default class Highlighter {
         const lastCharX = text.getLine(currY).length;
 
         if (this.hlMode === "focus") {
-          if (currY < hStart.yLine || currY > hEnd.yLine) {
-            rowsToDraw.push({ rowI: i, start: 0, end: charsAtLine });
+          // A line fully outside the focused span is dimmed across the ENTIRE
+          // editor width, in device px (#2887). A column count can't express
+          // "full width" under a proportional font, and it also lets blank or
+          // short trailing lines be covered uniformly instead of collapsing to
+          // a zero-width strip. `currY < text.noLines` skips the phantom row at
+          // index `noLines` (valid lines are [0, noLines-1]) so the veil never
+          // paints one line below the last real line at the end of the document.
+          if (
+            (currY < hStart.yLine || currY > hEnd.yLine) &&
+            currY < text.noLines
+          ) {
+            ctx.globalCompositeOperation = "source-over";
+            ctx.globalAlpha = this.style.opacity;
+            ctx.fillStyle = drawingOptions.color || this.style.color;
+            ctx.fillRect(
+              0,
+              i * drawingOptions.lineHeight,
+              ctx.canvas.width,
+              drawingOptions.lineHeight
+            );
           }
+          // The territory's own start/end lines only dim the portion of the
+          // line outside the span; these stay column-based (correct under a
+          // proportional font via drawLine's columnToPixelX).
           if (currY === hStart.yLine) {
             rowsToDraw.push({ rowI: i, start: 0, end: hStart.xLine });
           }

--- a/packages/annotator/src/lib/Highlighter.ts
+++ b/packages/annotator/src/lib/Highlighter.ts
@@ -145,7 +145,15 @@ export default class Highlighter {
       ctx.globalCompositeOperation = "multiply";
       ctx.fillRect(xStartPx, y, width, height);
     } else if (this.hlMode === "select") {
-      ctx.globalCompositeOperation = "color";
+      // A collapsed caret (width === 0) is painted solid so it stays visible on
+      // top of anchor markers / highlights; the "color" blend only tints them
+      // and the caret vanishes (#2887). Selection spans keep the blend.
+      if (width === 0) {
+        ctx.globalCompositeOperation = "source-over";
+        ctx.globalAlpha = 1;
+      } else {
+        ctx.globalCompositeOperation = "color";
+      }
       // width === 0 means a collapsed caret; honor the configured caret width.
       ctx.fillRect(xStartPx, y, width || options.caretWidth || 1, height);
     }

--- a/packages/annotator/src/lib/constants.ts
+++ b/packages/annotator/src/lib/constants.ts
@@ -112,3 +112,5 @@ export const ANCHOR_MARKER_ARM_W_RATIO = 0.4;
 export const ANCHOR_MARKER_LINE_WIDTH_PX = 1.5;
 /** Horizontal offset per stacked marker at a shared position, in CSS px. */
 export const ANCHOR_MARKER_STACK_STEP_PX = 3;
+/** Padding added around a marker glyph to form its hover hit target, in CSS px. */
+export const ANCHOR_MARKER_HIT_PAD_PX = 4;

--- a/packages/annotator/src/lib/constants.ts
+++ b/packages/annotator/src/lib/constants.ts
@@ -105,7 +105,7 @@ export const SELECTION_HANDLE_GRAB_CHAR_FACTOR = 1;
  * pixel ratio at draw time.
  */
 /** Vertical arm length as a fraction of one line height. */
-export const ANCHOR_MARKER_ARM_H_RATIO = 0.4;
+export const ANCHOR_MARKER_ARM_H_RATIO = 0.7;
 /** Horizontal arm length as a fraction of one character width. */
 export const ANCHOR_MARKER_ARM_W_RATIO = 0.4;
 /** Stroke width of the corner glyph, in CSS px (scaled by ratio at draw time). */

--- a/packages/annotator/src/lib/constants.ts
+++ b/packages/annotator/src/lib/constants.ts
@@ -15,6 +15,12 @@ export enum HighlightMode {
   BACKGROUND = "background",
   FOCUS = "focus",
   UNDERLINE = "underline",
+  /**
+   * Point marker at each end of an anchor instead of a span fill (#2887).
+   * Used for Territory anchors, whose span covers a whole territory and would
+   * flood the fulltext if filled — only the start/end corner brackets are drawn.
+   */
+  ANCHOR = "anchor",
 }
 export const LINE_HEIGHT = 23;
 
@@ -91,3 +97,18 @@ export const SELECTION_HANDLE_KNOB_RADIUS_PX = 4.5;
  * handle comfortably catchable on a monospace grid.
  */
 export const SELECTION_HANDLE_GRAB_CHAR_FACTOR = 1;
+
+/**
+ * Issue #2887 — Territory (T) anchor markers. An L-shaped corner at the anchor
+ * start and an inverse-L at the end, framing the territory span without filling
+ * it. All values are in CSS px / line-relative ratios and scaled by the device
+ * pixel ratio at draw time.
+ */
+/** Vertical arm length as a fraction of one line height. */
+export const ANCHOR_MARKER_ARM_H_RATIO = 0.4;
+/** Horizontal arm length as a fraction of one character width. */
+export const ANCHOR_MARKER_ARM_W_RATIO = 0.4;
+/** Stroke width of the corner glyph, in CSS px (scaled by ratio at draw time). */
+export const ANCHOR_MARKER_LINE_WIDTH_PX = 1.5;
+/** Horizontal offset per stacked marker at a shared position, in CSS px. */
+export const ANCHOR_MARKER_STACK_STEP_PX = 3;

--- a/packages/annotator/src/lib/constants.ts
+++ b/packages/annotator/src/lib/constants.ts
@@ -107,7 +107,7 @@ export const SELECTION_HANDLE_GRAB_CHAR_FACTOR = 1;
 /** Vertical arm length as a fraction of one line height. */
 export const ANCHOR_MARKER_ARM_H_RATIO = 0.7;
 /** Horizontal arm length as a fraction of one character width. */
-export const ANCHOR_MARKER_ARM_W_RATIO = 0.4;
+export const ANCHOR_MARKER_ARM_W_RATIO = 0.8;
 /** Stroke width of the corner glyph, in CSS px (scaled by ratio at draw time). */
 export const ANCHOR_MARKER_LINE_WIDTH_PX = 1.5;
 /** Horizontal offset per stacked marker at a shared position, in CSS px. */

--- a/packages/client/src/components/advanced/Annotator/Annotator.tsx
+++ b/packages/client/src/components/advanced/Annotator/Annotator.tsx
@@ -1514,7 +1514,12 @@ export const TextAnnotator = ({
                   }, 200);
                 }}
               >
-                <EntityTagById entityId={xmlMarkupAnchorHover.entityId} disableTooltip={false} />
+                <EntityTagById
+                  entityId={xmlMarkupAnchorHover.entityId}
+                  disableTooltip={false}
+                  disableDoubleClick={false}
+                  tagMaxWidth={theme.space[60]}
+                />
               </div>
             </FloatingPortal>
           )}

--- a/packages/client/src/components/advanced/Annotator/Annotator.tsx
+++ b/packages/client/src/components/advanced/Annotator/Annotator.tsx
@@ -769,12 +769,11 @@ export const TextAnnotator = ({
       });
     };
 
-    // XML markup anchor hover to preview the entity tag when hovering over the <id> markup (RAW mode)
+    // Entity-tag preview on hover: over `<id>` markup in RAW mode, or over a
+    // Territory anchor marker in HIGHLIGHT mode (#2887). The annotator only
+    // emits a tag in those cases, so no edit-mode gate is needed here.
     const registerAnchorTagMarkupHover = (a: Annotator) => {
       a.onAnchorTagHover((tag: Tag | null, position: { x: number; y: number } | null) => {
-        if (annotatorModeRef.current !== EditMode.RAW) {
-          return;
-        }
         const clearScheduled = xmlMarkupAnchorHoverClearTimerRef;
         const cancelClear = () => {
           if (clearScheduled.current !== null) {
@@ -1480,7 +1479,7 @@ export const TextAnnotator = ({
             </FloatingPortal>
           )}
 
-          {xmlMarkupAnchorHover && annotatorMode === EditMode.RAW && api.isLoggedIn() && (
+          {xmlMarkupAnchorHover && api.isLoggedIn() && (
             <FloatingPortal id="page">
               <div
                 style={{

--- a/packages/client/src/components/advanced/Annotator/highlight.ts
+++ b/packages/client/src/components/advanced/Annotator/highlight.ts
@@ -13,7 +13,7 @@ export const annotatorHighlight = (
   data: annotatorHighlightData,
   hlClasses: EntityEnums.Class[],
   theme: DefaultTheme | undefined,
-): HighlightSchema | undefined => {
+): HighlightSchema | HighlightSchema[] | undefined => {
   if (!theme) {
     return undefined;
   }
@@ -22,13 +22,24 @@ export const annotatorHighlight = (
     data.dataDocument?.entityIds ?? {};
 
   if (entityId === data.thisTerritoryEntityId) {
-    return {
-      mode: HighlightMode.FOCUS,
-      style: {
-        color: theme.color["black"],
-        opacity: 0.08,
+    // #2887 — the active territory keeps its dim wash (FOCUS) and also gets the
+    // start/end corner markers (ANCHOR), same as any other territory anchor.
+    return [
+      {
+        mode: HighlightMode.FOCUS,
+        style: {
+          color: theme.color["black"],
+          opacity: 0.08,
+        },
       },
-    };
+      {
+        mode: HighlightMode.ANCHOR,
+        style: {
+          color: theme.color.entityT,
+          opacity: 1,
+        },
+      },
+    ];
   }
 
   const entityClass = Object.keys(dReferenceEntityIds).find((key) =>

--- a/packages/client/src/components/advanced/Annotator/highlight.ts
+++ b/packages/client/src/components/advanced/Annotator/highlight.ts
@@ -28,8 +28,8 @@ export const annotatorHighlight = (
       {
         mode: HighlightMode.FOCUS,
         style: {
-          color: theme.color["black"],
-          opacity: 0.08,
+          color: theme.color.entityT,
+          opacity: 0.1,
         },
       },
       {

--- a/packages/client/src/components/advanced/Annotator/highlight.ts
+++ b/packages/client/src/components/advanced/Annotator/highlight.ts
@@ -46,7 +46,17 @@ export const annotatorHighlight = (
       };
     }
     if (entityClass === EntityEnums.Class.Territory) {
-      return undefined;
+      // #2887 — a Territory anchor spans a whole territory; filling it as a
+      // highlight would flood the fulltext. Draw only corner markers at the
+      // anchor ends (ANCHOR mode) so child/sibling territories stay visible in
+      // basic highlight view without overwhelming the text.
+      return {
+        mode: HighlightMode.ANCHOR,
+        style: {
+          color: theme.color.entityT,
+          opacity: 1,
+        },
+      };
     }
 
     const classItem = EntityColors[entityClass];

--- a/packages/client/src/components/advanced/EntityTag/EntityTag.tsx
+++ b/packages/client/src/components/advanced/EntityTag/EntityTag.tsx
@@ -55,6 +55,8 @@ interface EntityTag {
   parentId?: string;
   showOnly?: "tag" | "label";
   fullWidth?: boolean;
+  /** Override the label's max-width (e.g. theme.space value). */
+  tagMaxWidth?: string;
   button?: ReactNode;
   index?: number;
   moveFn?: (dragIndex: number, hoverIndex: number) => void;
@@ -85,6 +87,7 @@ const EntityTagComponent: React.FC<EntityTag> = ({
   parentId,
   showOnly,
   fullWidth = false,
+  tagMaxWidth,
   button = false,
   index,
   moveFn,
@@ -207,6 +210,7 @@ const EntityTagComponent: React.FC<EntityTag> = ({
           $tagBorderColorKey={entity.status}
           $labelOnly={showOnly === "label"}
           $fullWidth={fullWidth}
+          $maxWidth={tagMaxWidth}
           $isFavorited={isFavorited ?? false}
           $isItalic={isFirstLabelEmpty(entity.labels)}
         >
@@ -214,7 +218,7 @@ const EntityTagComponent: React.FC<EntityTag> = ({
         </StyledLabel>
       </StyledLabelWrap>
     );
-  }, [entity, entityLabel, isSelected, isFavorited, showOnly, fullWidth]);
+  }, [entity, entityLabel, isSelected, isFavorited, showOnly, fullWidth, tagMaxWidth]);
 
   if (!isValidEntityClass(entity.class)) {
     // labels needs to have length and first label needs to be non-empty

--- a/packages/client/src/components/advanced/EntityTag/EntityTagById.tsx
+++ b/packages/client/src/components/advanced/EntityTag/EntityTagById.tsx
@@ -10,6 +10,7 @@ interface EntityTagByIdProps {
   entityId: string;
   entity?: IEntity;
   fullWidth?: boolean;
+  tagMaxWidth?: string;
   disableTooltip?: boolean;
   unlinkButton?: UnlinkButton | false;
   disableToast?: boolean;
@@ -23,6 +24,7 @@ export const EntityTagById: React.FC<EntityTagByIdProps> = ({
   entityId,
   entity: entityProp,
   fullWidth = false,
+  tagMaxWidth,
   disableTooltip = true,
   unlinkButton,
   disableToast = false,
@@ -52,6 +54,7 @@ export const EntityTagById: React.FC<EntityTagByIdProps> = ({
       entity={entity}
       disableTooltip={disableTooltip}
       fullWidth={fullWidth}
+      tagMaxWidth={tagMaxWidth}
       unlinkButton={unlinkButton}
       disableDoubleClick={disableDoubleClick}
     />

--- a/packages/client/src/components/advanced/EntityTag/EntityTagStyles.tsx
+++ b/packages/client/src/components/advanced/EntityTag/EntityTagStyles.tsx
@@ -100,6 +100,7 @@ interface StyledLabel {
   $isFavorited: boolean;
   $labelOnly?: boolean;
   $isItalic: boolean;
+  $maxWidth?: string;
 }
 export const StyledLabel = styled.div<StyledLabel>`
   display: inline-block;
@@ -116,7 +117,8 @@ export const StyledLabel = styled.div<StyledLabel>`
   border-left-color: ${({ theme, $tagBorderColorKey }) =>
     theme.color.tagBorderColor[$tagBorderColorKey]};
   border-left-style: solid;
-  max-width: ${({ theme, $fullWidth }) => ($fullWidth ? "100%" : theme.space[30])};
+  max-width: ${({ theme, $fullWidth, $maxWidth }) =>
+    $maxWidth ? $maxWidth : $fullWidth ? "100%" : theme.space[30]};
   font-weight: ${({ theme, $invertedLabel }) =>
     $invertedLabel ? theme.fontWeight["bold"] : theme.fontWeight["normal"]};
 `;


### PR DESCRIPTION
Makes Territory (T) anchors visible in the annotator's highlight mode as blue corner markers with hover-to-preview, close #2887.

- Render each T anchor's start/end as blue corner markers (┌ / ┘) in highlight mode, since a span highlight would flood the whole fulltext
- Stack markers horizontally where multiple territory boundaries share a position
- Hover a marker to preview which territory, reusing the existing entity-tag hover popover with no new callback or popover
- Show the markers on the active territory too, on top of its focus dim, via a multi-schema highlight return

<img width="141" height="209" alt="image" src="https://github.com/user-attachments/assets/0dbc2b4e-f4c1-46ea-8787-c90d4d15585d" />
