### PR TITLE
fix(annotator): wrap-boundary caret navigation + no leading-whitespace wrapping (#3163)

### DIFF
--- a/packages/annotator/src/arrowWrapBoundary.test.ts
+++ b/packages/annotator/src/arrowWrapBoundary.test.ts
@@ -26,29 +26,34 @@ function setup(value: string): Annotator {
 }
 
 // A soft-wrap boundary is one offset with two visual positions (end of line N,
-// start of line N+1). Plain Left/Right cross to the far side; shift+Left/Right
-// skip that flip so the selection actually grows by a char (#3145).
-describe("ArrowLeft at a soft-wrap boundary (#3145)", () => {
-  test("plain Left from a continuation line start lands AFTER the last char of the previous line", () => {
+// start of line N+1). Plain Left from the continuation-line start skips the
+// phantom end-of-previous-line stop and lands on the SECOND-TO-LAST position of
+// the previous line (Word-style, where the wrap's end and the next line's start
+// are one position). shift+Left already skipped that flip so the selection grows
+// by a char. Here the previous line ends in a trailing wrap space ("aaaa bbbbb "),
+// so its second-to-last position is the column just before that space.
+describe("ArrowLeft at a soft-wrap boundary", () => {
+  test("plain Left from a continuation line start lands on the second-to-last position of the previous line", () => {
     const a = setup("aaaa bbbbb ccccc");
-    expect(a.text.getLine(0)).toBe("aaaa bbbbb");
-    expect(a.text.getLine(1)).toBe(" ccccc");
+    expect(a.text.getLine(0)).toBe("aaaa bbbbb "); // trailing wrap space at the end
+    expect(a.text.getLine(1)).toBe("ccccc");
 
     a.cursor.setPosition(0, 1); // leftmost of the continuation line
     keyDown(a, "ArrowLeft");
 
-    // caret sits just after the last character of the previous line, at the
-    // right margin, and stays within the viewport (visible, not off-screen)
+    // Word-style: the boundary's end == this line's start share one offset, so the
+    // first real position back is the second-to-last column of the previous line
+    // (just before its trailing space), and it stays within the viewport.
     expect(a.cursor.yLine).toBe(0);
-    expect(a.cursor.xLine).toBe(a.text.getLine(0).length); // 10 = after last char
+    expect(a.cursor.xLine).toBe(a.text.getLine(0).length - 1); // 10 = before the trailing space
     expect(a.cursor.xLine).toBeLessThanOrEqual(MAXLEN);
   });
 
-  test("a second plain Left then steps into the previous line content", () => {
+  test("a second plain Left then steps further into the previous line content", () => {
     const a = setup("aaaa bbbbb ccccc");
     a.cursor.setPosition(0, 1);
-    keyDown(a, "ArrowLeft"); // (10,0) after the last char
-    keyDown(a, "ArrowLeft"); // (9,0) into the content
+    keyDown(a, "ArrowLeft"); // (10,0) second-to-last of the previous line
+    keyDown(a, "ArrowLeft"); // (9,0) one more char back
     expect(a.cursor.yLine).toBe(0);
     expect(a.cursor.xLine).toBe(9);
   });
@@ -66,10 +71,11 @@ describe("ArrowLeft at a soft-wrap boundary (#3145)", () => {
     const a = setup("aaaa bbbbb ccccc");
     a.cursor.setPosition(0, 1);
     a.cursor.reconcileOffsetsFromVisual(a.text);
-    expect(a.cursor.head).toBe(10);
+    expect(a.cursor.head).toBe(11); // start of "ccccc"
     keyDown(a, "ArrowLeft", true);
     // shift skips the affinity flip so the selection actually grows by one char
-    expect(a.cursor.head).toBe(9);
+    // (selecting the trailing wrap space)
+    expect(a.cursor.head).toBe(10);
     expect(a.cursor.isSelected()).toBe(true);
   });
 
@@ -82,31 +88,61 @@ describe("ArrowLeft at a soft-wrap boundary (#3145)", () => {
   });
 });
 
-describe("ArrowRight at a soft-wrap boundary, symmetric to ArrowLeft (#3145)", () => {
-  test("plain Right from a wrapped line end lands at the start of the next line", () => {
-    const a = setup("aaaa bbbbb ccccc");
-    expect(a.text.getLine(0)).toBe("aaaa bbbbb");
-    expect(a.text.getLine(1)).toBe(" ccccc");
+// A long word broken across lines wraps mid-word, so the line ends in a VISIBLE
+// char. Right still stops at that line end (after the visible char) when arriving
+// from before it, but from the line end it advances to the SECOND position of the
+// next line — the boundary is one logical position, never a double-stop. This
+// mirrors plain Left landing on the previous line's second-to-last position, so
+// Left and Right are symmetric across the wrap.
+describe("ArrowRight at a soft-wrap boundary ending in a visible char", () => {
+  test("plain Right from a wrapped line end advances to the second position of the next line", () => {
+    // "supercalifragilistic" breaks mid-word, so line 0 ends in a visible 'f'.
+    const a = setup("supercalifragilistic");
+    expect(a.text.getLine(0)).toBe("supercalif");
+    expect(a.text.getLine(1)).toBe("ragilistic");
 
     a.cursor.setPosition(MAXLEN, 0); // end of line 0 (after its last char)
+    a.cursor.reconcileOffsetsFromVisual(a.text);
+    expect(a.cursor.head).toBe(10); // the single boundary offset
+
     keyDown(a, "ArrowRight");
 
-    // mirror of plain Left: it lands just before the first char of the next line
-    expect(a.cursor.yLine).toBe(1);
-    expect(a.cursor.xLine).toBe(0);
-  });
-
-  test("a second plain Right then steps into the next line content", () => {
-    const a = setup("aaaa bbbbb ccccc");
-    a.cursor.setPosition(MAXLEN, 0);
-    keyDown(a, "ArrowRight"); // (0,1) start of next line
-    keyDown(a, "ArrowRight"); // (1,1) into the content
+    // the boundary is one logical position, so Right advances a real char into the
+    // next line (its second position) rather than resting again at its start
+    expect(a.cursor.head).toBe(11);
     expect(a.cursor.yLine).toBe(1);
     expect(a.cursor.xLine).toBe(1);
   });
 
+  test("a second plain Right then steps one more char into the next line", () => {
+    const a = setup("supercalifragilistic");
+    a.cursor.setPosition(MAXLEN, 0);
+    keyDown(a, "ArrowRight"); // (1,1) second position of the next line
+    keyDown(a, "ArrowRight"); // (2,1) one more char in
+    expect(a.cursor.yLine).toBe(1);
+    expect(a.cursor.xLine).toBe(2);
+  });
+
+  test("a long word walks end-of-line -> second-of-next-line without a double-stop", () => {
+    // a single word too long for one line ("supercalif" | "ragilistic"); there is
+    // no whitespace in the raw text, yet the boundary is still one logical position.
+    const a = setup("supercalifragilistic");
+    a.cursor.setPosition(9, 0); // before the last visible char of line 0
+    a.cursor.reconcileOffsetsFromVisual(a.text);
+    expect(a.cursor.head).toBe(9);
+
+    keyDown(a, "ArrowRight"); // -> last position of the first line
+    expect({ x: a.cursor.xLine, y: a.cursor.yLine }).toEqual({ x: 10, y: 0 });
+
+    keyDown(a, "ArrowRight"); // -> SECOND position of the next line, not its start
+    expect({ x: a.cursor.xLine, y: a.cursor.yLine }).toEqual({ x: 1, y: 1 });
+
+    keyDown(a, "ArrowRight"); // -> one more char in
+    expect({ x: a.cursor.xLine, y: a.cursor.yLine }).toEqual({ x: 2, y: 1 });
+  });
+
   test("shift+Right from a wrapped line end extends the selection by one char", () => {
-    const a = setup("aaaa bbbbb ccccc");
+    const a = setup("supercalifragilistic");
     a.cursor.setPosition(MAXLEN, 0);
     a.cursor.reconcileOffsetsFromVisual(a.text);
     expect(a.cursor.head).toBe(10);
@@ -117,11 +153,173 @@ describe("ArrowRight at a soft-wrap boundary, symmetric to ArrowLeft (#3145)", (
   });
 
   test("a normal right move (not at a boundary) still steps exactly one char", () => {
-    const a = setup("aaaa bbbbb ccccc");
-    a.cursor.setPosition(2, 0); // inside "aaaa"
+    const a = setup("supercalifragilistic");
+    a.cursor.setPosition(2, 0); // inside "supercalif"
     a.cursor.reconcileOffsetsFromVisual(a.text);
     expect(a.cursor.head).toBe(2);
     keyDown(a, "ArrowRight");
     expect(a.cursor.head).toBe(3);
+  });
+});
+
+// From the second-to-last position of a wrapped line whose last char is a
+// trailing wrap whitespace, plain Right jumps to the start of the next line
+// (skipping the "after the trailing space" end-of-line position). This mirrors the
+// plain-Left second-to-last landing, so the two are inverses across such a wrap.
+describe("plain Right from second-to-last of a wrapped line ending in whitespace", () => {
+  test("Right jumps to the start of the next line, skipping the trailing wrap space", () => {
+    const a = setup("aaaa bbbb ccccc");
+    expect(a.text.getLine(0)).toBe("aaaa bbbb "); // trailing wrap space at the end
+    expect(a.text.getLine(1)).toBe("ccccc");
+
+    a.cursor.setPosition(9, 0); // second-to-last: just before the trailing space
+    keyDown(a, "ArrowRight");
+
+    // lands at the start of the next line, not at (10,0) after the invisible space
+    expect(a.cursor.yLine).toBe(1);
+    expect(a.cursor.xLine).toBe(0);
+  });
+
+  test("Right from the wrapped line end (after the trailing space) advances into the next line", () => {
+    const a = setup("aaaa bbbb ccccc");
+    // from the very end of the wrapped line — past the trailing space — plain
+    // Right must step into the next line's content, not merely flip affinity and
+    // rest a second time at the same boundary offset.
+    a.cursor.setPosition(MAXLEN, 0); // end of line 0 (after the trailing space)
+    a.cursor.reconcileOffsetsFromVisual(a.text);
+    expect(a.cursor.head).toBe(10); // boundary offset (start of "ccccc")
+
+    keyDown(a, "ArrowRight");
+
+    expect(a.cursor.head).toBe(11); // advanced one real char into "ccccc"
+    expect(a.cursor.yLine).toBe(1);
+    expect(a.cursor.xLine).toBe(1);
+  });
+
+  test("mid-word wrap (last char visible) is unaffected: Right stops at the line end first", () => {
+    const a = setup("supercalifragilistic"); // ["supercalif","ragilistic"], ends with 'f'
+    a.cursor.setPosition(9, 0); // before the last visible char 'f'
+    keyDown(a, "ArrowRight");
+    // no trailing whitespace, so Right still pauses at the end of the wrapped line
+    expect(a.cursor.yLine).toBe(0);
+    expect(a.cursor.xLine).toBe(10);
+  });
+
+  test("Left then Right round-trips across the trailing-space boundary", () => {
+    const a = setup("aaaa bbbb ccccc");
+    a.cursor.setPosition(0, 1); // start of the next line
+    keyDown(a, "ArrowLeft"); // -> (9,0) second-to-last of the previous line
+    expect(a.cursor.yLine).toBe(0);
+    expect(a.cursor.xLine).toBe(9);
+    keyDown(a, "ArrowRight"); // -> back to (0,1) start of the next line
+    expect(a.cursor.yLine).toBe(1);
+    expect(a.cursor.xLine).toBe(0);
+  });
+
+  // Shift is intentionally excluded from the whitespace flip: extending a
+  // selection steps through the trailing space and keeps the endpoint at the line
+  // end, so the space is visibly selected before crossing to the next line.
+  // Mirrors "lorem ipsum " / "dolor": from before the trailing space, shift+Right
+  // goes selection "b" -> "b " (caret at line end) -> "b c" (caret on next line).
+  test("shift+Right steps through the trailing space, keeping the endpoint at the line end", () => {
+    const a = setup("aaaa bbbb ccccc"); // line0 "aaaa bbbb " (trailing space), line1 "ccccc"
+    a.cursor.setPosition(8, 0); // before the last content char 'b'
+    a.cursor.reconcileOffsetsFromVisual(a.text);
+    expect(a.cursor.head).toBe(8);
+
+    keyDown(a, "ArrowRight", true); // selects "b"
+    expect(a.cursor.head).toBe(9);
+    expect({ x: a.cursor.xLine, y: a.cursor.yLine }).toEqual({ x: 9, y: 0 });
+
+    keyDown(a, "ArrowRight", true); // selects "b " — endpoint stays at the line end
+    expect(a.cursor.head).toBe(10);
+    expect({ x: a.cursor.xLine, y: a.cursor.yLine }).toEqual({ x: 10, y: 0 });
+
+    keyDown(a, "ArrowRight", true); // selects "b c" — now crosses to the next line
+    expect(a.cursor.head).toBe(11);
+    expect({ x: a.cursor.xLine, y: a.cursor.yLine }).toEqual({ x: 1, y: 1 });
+    expect(a.cursor.isSelected()).toBe(true);
+  });
+
+  test("shift+Left selects the trailing space with the caret before it", () => {
+    const a = setup("aaaa bbbb ccccc");
+    a.cursor.setPosition(0, 1); // start of the next line
+    a.cursor.reconcileOffsetsFromVisual(a.text);
+    expect(a.cursor.head).toBe(10);
+
+    keyDown(a, "ArrowLeft", true); // shift+Left
+
+    expect(a.cursor.head).toBe(9);
+    expect(a.cursor.yLine).toBe(0);
+    expect(a.cursor.xLine).toBe(9);
+    expect(a.cursor.isSelected()).toBe(true);
+  });
+});
+
+// Across a trailing-space wrap, plain Right walks the caret exactly as it would
+// through the raw text " eodem ipsum dolor" — the trailing space is one char
+// between the words, so neither of its two caret positions is a dead double-stop.
+// Raw walk: " eodem<CUR> ipsum" -> " eodem <CUR>ipsum" -> " eodem i<CUR>psum".
+describe("plain Right walks a trailing-space wrap like the raw text", () => {
+  test("from just before the trailing space, Right lands at the next line start", () => {
+    const a = setup(" eodem ipsum dolor");
+    expect(a.text.getLine(0)).toBe(" eodem "); // trailing wrap space
+    expect(a.text.getLine(1)).toBe("ipsum "); // starts flush with the word
+
+    a.cursor.setPosition(6, 0); // " eodem<CUR> " — before the trailing space
+    a.cursor.reconcileOffsetsFromVisual(a.text);
+    expect(a.cursor.head).toBe(6);
+
+    keyDown(a, "ArrowRight");
+
+    // " eodem <CUR>ipsum": next line start, before 'i'
+    expect(a.cursor.head).toBe(7);
+    expect(a.cursor.yLine).toBe(1);
+    expect(a.cursor.xLine).toBe(0);
+  });
+
+  test("from the line end after the trailing space, Right lands after 'i'", () => {
+    const a = setup(" eodem ipsum dolor");
+
+    a.cursor.setPosition(7, 0); // " eodem <CUR>" — end of line 0, past the space
+    a.cursor.reconcileOffsetsFromVisual(a.text);
+    expect(a.cursor.head).toBe(7);
+
+    keyDown(a, "ArrowRight");
+
+    // " eodem i<CUR>psum": advanced one real char into the next line
+    expect(a.cursor.head).toBe(8);
+    expect(a.cursor.yLine).toBe(1);
+    expect(a.cursor.xLine).toBe(1);
+  });
+
+  test("stepping Right from before the space reaches the same place in two presses", () => {
+    const a = setup(" eodem ipsum dolor");
+    a.cursor.setPosition(6, 0); // before the trailing space
+    a.cursor.reconcileOffsetsFromVisual(a.text);
+
+    keyDown(a, "ArrowRight"); // -> next line start (head 7)
+    keyDown(a, "ArrowRight"); // -> after 'i' (head 8)
+
+    expect(a.cursor.head).toBe(8);
+    expect(a.cursor.yLine).toBe(1);
+    expect(a.cursor.xLine).toBe(1);
+  });
+});
+
+// Plain Backspace routes through onArrowLeft's single-column branch, so the
+// second-to-last change must not make it delete two chars across a soft-wrap boundary.
+describe("plain Backspace at a soft-wrap boundary (regression)", () => {
+  test("Backspace from a continuation line start removes exactly the previous line's last char", () => {
+    const a = setup("supercalifragilistic"); // wraps to ["supercalif","ragilistic"]
+    expect(a.text.getLine(0)).toBe("supercalif");
+    expect(a.text.getLine(1)).toBe("ragilistic");
+
+    a.cursor.setPosition(0, 1); // start of "ragilistic" (offset 10)
+    keyDown(a, "Backspace");
+
+    // deletes only 'f' (offset 9); caret lands where that char was
+    expect(a.text.value).toBe("supercaliragilistic");
+    expect(a.cursor.head).toBe(9);
   });
 });

--- a/packages/annotator/src/characterization/wrap-navigation.test.ts
+++ b/packages/annotator/src/characterization/wrap-navigation.test.ts
@@ -11,9 +11,13 @@
  * preserve (with an affinity bit) or deliberately change — these tests make the
  * choice explicit instead of silent. They assert what the editor does today.
  *
- * #3145: plain ArrowLeft from a continuation line start lands on the previous
- * line's end (just after its last character); only shift+ArrowLeft skips that
- * so a selection grows. Wrapping keeps that end position visible at the margin.
+ * Plain ArrowLeft from a continuation line start skips the phantom
+ * end-of-previous-line stop and lands on the second-to-last position of the
+ * previous line (Word-style); ArrowRight is now its mirror image — from the
+ * wrapped line end it advances to the second position of the next line rather
+ * than resting again at the boundary. The two visual positions of the boundary
+ * offset are still each reachable (e.g. by click, or by Left from the next line),
+ * but neither Left nor Right dead-stops twice on the one boundary offset.
  */
 import { Annotator } from "../lib/Annotator";
 import { EditMode } from "../lib/constants";
@@ -50,19 +54,19 @@ describe("characterization: caret affinity at a soft-wrap boundary", () => {
     expect(a.text.segments[0].lines).toEqual(["supercalif", "ragilistic"]);
   });
 
-  test("ArrowLeft from start of the next line lands after the last char of the wrapped line", () => {
+  test("ArrowLeft from start of the next line lands on the second-to-last position of the wrapped line", () => {
     const a = mk(WRAPPED);
     a.cursor.setPosition(0, 1);
     key(a, "ArrowLeft");
-    expect(pos(a)).toEqual({ x: 10, y: 0 }); // just after "supercalif", visible at margin
+    expect(pos(a)).toEqual({ x: 9, y: 0 }); // one before "supercalif"'s last char (Word-style)
   });
 
-  test("a second ArrowLeft then steps one real char back", () => {
+  test("a second ArrowLeft then steps one more real char back", () => {
     const a = mk(WRAPPED);
     a.cursor.setPosition(0, 1);
-    key(a, "ArrowLeft"); // (10,0) after the last char
-    key(a, "ArrowLeft"); // (9,0) into the content
-    expect(pos(a)).toEqual({ x: 9, y: 0 });
+    key(a, "ArrowLeft"); // (9,0) second-to-last of the wrapped line
+    key(a, "ArrowLeft"); // (8,0) one more char back
+    expect(pos(a)).toEqual({ x: 8, y: 0 });
   });
 
   test("ArrowRight from end of the wrapped line stops at the boundary first", () => {
@@ -72,12 +76,12 @@ describe("characterization: caret affinity at a soft-wrap boundary", () => {
     expect(pos(a)).toEqual({ x: 10, y: 0 }); // pauses at end-of-line, not (0,1)
   });
 
-  test("a second ArrowRight then moves to start of the next line", () => {
+  test("a second ArrowRight then advances to the second position of the next line", () => {
     const a = mk(WRAPPED);
     a.cursor.setPosition(9, 0);
-    key(a, "ArrowRight"); // (10,0)
-    key(a, "ArrowRight"); // (0,1)
-    expect(pos(a)).toEqual({ x: 0, y: 1 });
+    key(a, "ArrowRight"); // (10,0) end of the wrapped line
+    key(a, "ArrowRight"); // (1,1) second position of the next line, not its start
+    expect(pos(a)).toEqual({ x: 1, y: 1 });
   });
 
   test("the end-of-wrapped-line position (10,0) is itself a valid caret position", () => {

--- a/packages/annotator/src/highlightNoVirtualNewline.test.ts
+++ b/packages/annotator/src/highlightNoVirtualNewline.test.ts
@@ -1,0 +1,65 @@
+/**
+ * A multi-line selection highlight ends flush with the last character of
+ * each opening/middle wrapped line. It must NOT paint an extra "virtual" newline
+ * column one past the content (Google-Docs style, which does not highlight a
+ * phantom char at a soft-wrap line break).
+ *
+ * drawLine(ctx, relLine, xStart, xEnd, options, absLine): the highlight rect
+ * spans columns [xStart, xEnd), so xEnd is the load-bearing "how far right" value.
+ */
+import { Annotator } from "./lib/Annotator";
+import { EditMode } from "./lib/constants";
+
+const mk = (text: string): Annotator => {
+  const c = document.createElement("canvas");
+  c.style.width = "800px";
+  c.style.height = "600px";
+  document.body.appendChild(c);
+  const a = new Annotator(c, text);
+  a.setMode(EditMode.RAW);
+  a.text.updateCharsAtLine(10); // wrap at column 10
+  return a;
+};
+
+// The last drawLine call for a given absolute line (the highlight row for it).
+const rowEndFor = (
+  spy: jest.SpyInstance,
+  absLine: number
+): { start: number; end: number } | undefined => {
+  const call = [...spy.mock.calls].reverse().find((args) => args[5] === absLine);
+  return call ? { start: call[2] as number, end: call[3] as number } : undefined;
+};
+
+describe("selection highlight has no virtual newline column", () => {
+  test("the opening line of a multi-line selection ends at the last char, not one past it", () => {
+    const a = mk("supercalifragilistic"); // ["supercalif","ragilistic"]
+    expect(a.text.getLine(0)).toBe("supercalif");
+
+    a.cursor.setSpanByOffsets(a.text, 5, 15); // (5,0) -> (5,1), spans the soft wrap
+    expect(a.cursor.isSelected()).toBe(true);
+
+    const spy = jest.spyOn(a.cursor, "drawLine");
+    a.draw();
+
+    const opening = rowEndFor(spy, 0);
+    expect(opening).toBeDefined();
+    expect(opening!.start).toBe(5);
+    expect(opening!.end).toBe(a.text.getLine(0).length); // 10, not 11
+  });
+
+  test("a fully-selected middle line ends at the last char, not one past it", () => {
+    const a = mk("aaaaaaaaaabbbbbbbbbbcccccccccc"); // 3 lines of 10
+    expect(a.text.getLine(1)).toBe("bbbbbbbbbb");
+
+    a.cursor.setSpanByOffsets(a.text, 2, 22); // (2,0) -> (2,2): line 1 fully inside
+    expect(a.cursor.isSelected()).toBe(true);
+
+    const spy = jest.spyOn(a.cursor, "drawLine");
+    a.draw();
+
+    const middle = rowEndFor(spy, 1);
+    expect(middle).toBeDefined();
+    expect(middle!.start).toBe(0);
+    expect(middle!.end).toBe(a.text.getLine(1).length); // 10, not 11
+  });
+});

--- a/packages/annotator/src/lib/Cursor.ts
+++ b/packages/annotator/src/lib/Cursor.ts
@@ -160,6 +160,27 @@ export default class Cursor
   }
 
   /**
+   * Apply a caret-navigation step (see {@link Text.caretStepLeft} /
+   * {@link Text.caretStepRight}). When `extend` (shift) only the head moves so the
+   * selection grows; otherwise the caret collapses (anchor follows head). The
+   * visual caret + selection are derived via {@link syncVisualFromOffset}.
+   */
+  stepHeadTo(
+    text: Text,
+    offset: number,
+    affinity: CaretAffinity,
+    extend: boolean
+  ) {
+    this.head = offset;
+    this.headAffinity = affinity;
+    if (!extend) {
+      this.anchor = offset;
+      this.anchorAffinity = affinity;
+    }
+    this.syncVisualFromOffset(text);
+  }
+
+  /**
    * Reconcile the canonical `head`/`anchor` offsets with
    * the current VISUAL caret + selection. Needed because `setPosition`,
    * `setMode` and mouse handlers set `xLine`/`yLine` (and `selectStart`/`End`)
@@ -513,8 +534,9 @@ export default class Cursor
         relY >= 0 &&
         relY <= viewport.noLines
       ) {
-        // A wrapped line can run one trailing space past the viewport; clamp the
-        // caret column to the width so it stays visible (no h-scroll, #3145).
+        // A wrapped line can carry trailing wrap whitespace past the viewport
+        // edge (collapsed in the margin); clamp the caret column to the width so
+        // it stays visible even when its offset sits inside that margin run.
         // Monospace only: proportional resolves pixel x from the prefix table.
         const caretX = drawingOptions.columnToPixelX
           ? this.xLine
@@ -543,21 +565,24 @@ export default class Cursor
 
         if (hStart.yLine <= currY && hEnd.yLine >= currY) {
           if (hStart.yLine === currY) {
-            // opening highlight line
+            // opening highlight line — end flush with the last character, without
+            // the extra "virtual" newline/wrap column past it (Google-Docs style,
+            // which does not highlight a phantom char at a line break).
             rowsToDraw.push({
               rowI: i,
               start: hStart.xLine,
-              end: hStart.yLine === hEnd.yLine ? hEnd.xLine : lastCharX + 1,
+              end: hStart.yLine === hEnd.yLine ? hEnd.xLine : lastCharX,
             });
           } else if (hEnd.yLine === currY) {
             // closing highlight line
             rowsToDraw.push({ rowI: i, start: 0, end: hEnd.xLine });
           } else {
-            // full line highlight (between open & end)
+            // full line highlight (between open & end) — likewise no virtual
+            // newline column past the last character.
             rowsToDraw.push({
               rowI: i,
               start: 0,
-              end: lastCharX + 1,
+              end: lastCharX,
             });
           }
         }

--- a/packages/annotator/src/lib/Keys.ts
+++ b/packages/annotator/src/lib/Keys.ts
@@ -650,23 +650,11 @@ export default class Keys {
           Math.min(this.cursor.anchor, this.cursor.head)
         );
       } else {
-        const beforeOffset = this.cursor.head;
-        let next = this.text.stepVisualLeft(this.cursor.xLine, this.cursor.yLine);
-        let info = this.text.offsetWithAffinityFromVisual(next.xLine, next.yLine);
-        // Plain Left lands on the previous line's end (the boundary's two
-        // visual positions share one offset). For shift that flip wouldn't grow
-        // the selection, so step once more so shift+Left selects a char. #3145
-        if (shiftKey && info.offset === beforeOffset) {
-          next = this.text.stepVisualLeft(next.xLine, next.yLine);
-          info = this.text.offsetWithAffinityFromVisual(next.xLine, next.yLine);
-        }
-        this.cursor.head = info.offset;
-        this.cursor.headAffinity = info.affinity;
-        if (!shiftKey) {
-          this.cursor.anchor = info.offset;
-          this.cursor.anchorAffinity = info.affinity;
-        }
-        this.cursor.syncVisualFromOffset(this.text);
+        const info = this.text.caretStepLeft(
+          this.cursor.xLine,
+          this.cursor.yLine
+        );
+        this.cursor.stepHeadTo(this.text, info.offset, info.affinity, !!shiftKey);
       }
       this.scrollCursorIntoView();
       return;
@@ -846,24 +834,13 @@ export default class Keys {
         );
       } else {
         // Step one visible column right (crosses line boundaries, honours the
-        // soft-wrap affinity, clamps at EOF), then store the canonical offset.
-        const beforeOffset = this.cursor.head;
-        let next = this.text.stepVisualRight(this.cursor.xLine, this.cursor.yLine);
-        let info = this.text.offsetWithAffinityFromVisual(next.xLine, next.yLine);
-        // Symmetric to ArrowLeft: plain Right lands on the next line's start;
-        // for shift, step once more so it selects a char instead of just flipping.
-        if (shiftKey && info.offset === beforeOffset) {
-          next = this.text.stepVisualRight(next.xLine, next.yLine);
-          info = this.text.offsetWithAffinityFromVisual(next.xLine, next.yLine);
-        }
-        this.cursor.head = info.offset;
-        this.cursor.headAffinity = info.affinity;
-        if (!shiftKey) {
-          this.cursor.anchor = info.offset;
-          this.cursor.anchorAffinity = info.affinity;
-        }
-        // Derive caret + selectStart/selectEnd from anchor/head.
-        this.cursor.syncVisualFromOffset(this.text);
+        // soft-wrap affinity and the wrap-boundary rules, clamps at EOF).
+        const info = this.text.caretStepRight(
+          this.cursor.xLine,
+          this.cursor.yLine,
+          !!shiftKey
+        );
+        this.cursor.stepHeadTo(this.text, info.offset, info.affinity, !!shiftKey);
       }
       this.scrollCursorIntoView();
       return;

--- a/packages/annotator/src/lib/Text.ts
+++ b/packages/annotator/src/lib/Text.ts
@@ -664,22 +664,12 @@ class Text {
         }
 
         if (cell.space) {
-          // Overflowing whitespace: fill the line's remaining room, then carry
-          // the rest to the next line(s) so it stays visible (no h-scroll). #3145
-          const keep = charsThatFit(cell.text, maxWidth - currentLineLength);
-          if (keep > 0) appendStr(cell.text.slice(0, keep));
-          let rest = cell.text.slice(keep);
-          if (rest.length > 0) {
-            pushLine();
-            // Chunk an over-wide carried run so no single line exceeds the width.
-            while (widthOf(rest) > maxWidth) {
-              const take = Math.max(1, charsThatFit(rest, maxWidth));
-              appendStr(rest.slice(0, take));
-              pushLine();
-              rest = rest.slice(take);
-            }
-            appendStr(rest);
-          }
+          // A soft wrap never starts a line with whitespace (Google-Docs
+          // style): an overflowing inter-word space run stays as trailing
+          // whitespace on the current line, collapsed into the margin past the
+          // visible edge. The next non-space cell then begins the following
+          // line flush-left, so no wrapped line is ever led by a wrap space.
+          appendStr(cell.text);
           continue;
         }
 
@@ -1080,6 +1070,78 @@ class Text {
     }
     const prevLen = (this.getLine(yLine - 1) ?? "").length;
     return { xLine: prevLen, yLine: yLine - 1 };
+  }
+
+  /**
+   * Caret navigation one visible column LEFT. Steps left, and if that
+   * step only flipped affinity across a soft-wrap boundary — it landed on the same
+   * offset, the shared "end of the previous line == start of this line" position —
+   * steps once more so the caret reaches a real earlier column: the second-to-last
+   * position of the previous line, the Word-style behavior where a wrapped line's
+   * end and the next line's start are one position. At a hard newline / mid-line the
+   * first step already changed the offset, so it stops after one step. Used for both
+   * a collapsed caret and a growing (shift) selection.
+   */
+  caretStepLeft(
+    xLine: number,
+    yLine: number
+  ): { offset: number; affinity: CaretAffinity } {
+    const beforeOffset = this.offsetFromVisual(xLine, yLine);
+    let next = this.stepVisualLeft(xLine, yLine);
+    let info = this.offsetWithAffinityFromVisual(next.xLine, next.yLine);
+    if (info.offset === beforeOffset) {
+      next = this.stepVisualLeft(next.xLine, next.yLine);
+      info = this.offsetWithAffinityFromVisual(next.xLine, next.yLine);
+    }
+    return info;
+  }
+
+  /**
+   * Caret navigation one visible column RIGHT. It mirrors {@link caretStepLeft}:
+   * a soft-wrap boundary is ONE logical position (the wrapped line's end and the
+   * next line's start are the same document offset), so the caret walks it as it
+   * would the raw text — one offset per step, never resting twice at that offset.
+   * Just as Left from a continuation-line start lands on the second-to-LAST
+   * position of the previous line, Right from a wrapped line end lands on the
+   * SECOND position of the next line.
+   *
+   * - `extend` (shift-selection): if the step only flipped affinity, step once
+   *   more so the selection grows by a real char (a trailing wrap space is stepped
+   *   through and stays visibly selected).
+   * - Collapsed caret, stepping INTO the boundary from the position just before it:
+   *   if that wrapped line ends in a wrap WHITESPACE, render the boundary at the
+   *   next line's start (DOWNSTREAM) instead of past the invisible trailing space;
+   *   if it ends in a VISIBLE char (a mid-word break), stop at the line end after
+   *   that char. `\s` matches the same whitespace class the wrap tokenizer
+   *   ({@link wrapTokenRegex}) breaks on.
+   * - Collapsed caret, already AT the boundary (the step only flipped affinity to
+   *   the same offset): step once more so the caret advances into the next line
+   *   rather than resting a second time at the one boundary offset. This applies to
+   *   whitespace- and visible-char-ending wraps alike, keeping Left/Right symmetric.
+   */
+  caretStepRight(
+    xLine: number,
+    yLine: number,
+    extend: boolean
+  ): { offset: number; affinity: CaretAffinity } {
+    const beforeOffset = this.offsetFromVisual(xLine, yLine);
+    let next = this.stepVisualRight(xLine, yLine);
+    let info = this.offsetWithAffinityFromVisual(next.xLine, next.yLine);
+    if (extend) {
+      if (info.offset === beforeOffset) {
+        next = this.stepVisualRight(next.xLine, next.yLine);
+        info = this.offsetWithAffinityFromVisual(next.xLine, next.yLine);
+      }
+    } else if (
+      info.affinity === CaretAffinity.UPSTREAM &&
+      /\s$/.test(this.getLine(next.yLine))
+    ) {
+      info = { offset: info.offset, affinity: CaretAffinity.DOWNSTREAM };
+    } else if (info.offset === beforeOffset) {
+      next = this.stepVisualRight(next.xLine, next.yLine);
+      info = this.offsetWithAffinityFromVisual(next.xLine, next.yLine);
+    }
+    return info;
   }
 
   /**

--- a/packages/annotator/src/lineWrapPunctuation.test.ts
+++ b/packages/annotator/src/lineWrapPunctuation.test.ts
@@ -10,10 +10,11 @@ const visibleLen = (line: string) => line.replace(/\s+$/, "").length;
 
 describe("line wrapping - punctuation must not start a wrapped line", () => {
   test("comma after a word stays on the previous wrapped line", () => {
-    // "aaaaaaaaa," fills the width-10 line; the overflow space leads the next
-    // line, but the comma stays put rather than starting the wrapped line (#3145)
+    // "aaaaaaaaa," fills the width-10 line; the following space stays trailing on
+    // that line (collapsed in the margin) so "bbbb" begins the next line flush —
+    // the comma never starts a wrapped line.
     const text = new Text("aaaaaaaaa, bbbb", 10);
-    expect(text.segments[0].lines).toEqual(["aaaaaaaaa,", " bbbb"]);
+    expect(text.segments[0].lines).toEqual(["aaaaaaaaa, ", "bbbb"]);
   });
 
   test("no wrapped line begins with punctuation across many break points", () => {
@@ -29,11 +30,12 @@ describe("line wrapping - punctuation must not start a wrapped line", () => {
     expect(lines.join("")).toBe(input);
   });
 
-  test("an inter-word space that can't render trailing leads the next line (#3145)", () => {
-    // the word fills the line, so the following space can't render trailing and
-    // is carried to the next line's start where it stays visible (no h-scroll)
+  test("an inter-word space that overflows stays trailing on the previous line", () => {
+    // the word fills the line, so the following space can't fit; it stays as
+    // trailing whitespace on that line (invisible in the margin) rather than
+    // leading the next line, which begins flush with "bbbb".
     const text = new Text("aaaaaaaaaa bbbb", 10);
-    expect(text.segments[0].lines).toEqual(["aaaaaaaaaa", " bbbb"]);
+    expect(text.segments[0].lines).toEqual(["aaaaaaaaaa ", "bbbb"]);
     expect(text.segments[0].lines.join("")).toBe("aaaaaaaaaa bbbb");
   });
 

--- a/packages/annotator/src/rewrapCaretFollow.test.ts
+++ b/packages/annotator/src/rewrapCaretFollow.test.ts
@@ -31,7 +31,7 @@ function setup(value: string): Annotator {
   return a;
 }
 
-describe("caret follows the word across a re-wrap (#3145)", () => {
+describe("caret follows the word across a re-wrap", () => {
   test("layout sanity: word wraps to line 1", () => {
     const a = setup("aa bbbb cccccc");
     expect(a.text.getLine(0)).toBe("aa bbbb ");
@@ -87,19 +87,23 @@ describe("caret follows the word across a re-wrap (#3145)", () => {
 
   test("BACKSPACE at the start of a wrapped word deletes the boundary space", () => {
     const a = setup("aaaa bbbbb ccccc");
-    // line 0 fills exactly, so the wrap space leads line 1; "ccccc" starts at
-    // column 1 (after the leading space).
-    expect(a.text.getLine(0)).toBe("aaaa bbbbb");
-    expect(a.text.getLine(1)).toBe(" ccccc");
+    // line 0 fills exactly; the wrap space trails it and "ccccc" starts line 1
+    // flush (column 0), no leading space.
+    expect(a.text.getLine(0)).toBe("aaaa bbbbb ");
+    expect(a.text.getLine(1)).toBe("ccccc");
 
-    // caret at the start of "ccccc" (column 1, after the leading wrap space)
-    a.cursor.setPosition(1, 1);
+    // caret at the start of "ccccc" (offset 11, just after the trailing space)
+    a.cursor.setPosition(0, 1);
 
     keyDown(a, "Backspace");
 
-    // like a normal editor: backspace removes the space before the caret,
-    // merging the words — it must NOT be a silent no-op
+    // like a normal editor: backspace removes the boundary space before the
+    // caret, merging the words — it must NOT be a silent no-op. The merged
+    // "bbbbbccccc" is a 10-char unit, so it wraps whole to line 1.
     expect(a.text.value).toBe("aaaa bbbbbccccc");
+    expect(a.text.getLine(0)).toBe("aaaa ");
+    expect(a.text.getLine(1)).toBe("bbbbbccccc");
+    // caret sits at the merge point, between "bbbbb" and "ccccc"
     expect(a.cursor.yLine).toBe(1);
     expect(a.cursor.xLine).toBe(5);
 

--- a/packages/annotator/src/spaceAtWrappedLineStart.test.ts
+++ b/packages/annotator/src/spaceAtWrappedLineStart.test.ts
@@ -25,44 +25,47 @@ function setup(value: string): Annotator {
   return a;
 }
 
-describe("space typed at the start of a wrapped word (#3145 follow-up)", () => {
-  test("the extra wrap whitespace becomes a visible leading space and the caret moves", () => {
-    const a = setup("aaaa bbbbb ccccc");
-    // line 0 fills exactly, so the wrap space can't render trailing; it leads
-    // line 1 (visible) and "ccccc" follows it.
-    expect(a.text.getLine(0)).toBe("aaaa bbbbb");
-    expect(a.text.getLine(1)).toBe(" ccccc");
+/** Visible content of a line, ignoring trailing whitespace collapsed in the margin. */
+const visibleLen = (line: string) => line.replace(/\s+$/, "").length;
 
-    a.cursor.setPosition(0, 1); // start of the wrapped line (before the lead space)
+describe("space typed at the start of a wrapped word (trails the previous line)", () => {
+  test("a space typed before a wrapped word stays trailing on the previous line", () => {
+    const a = setup("aaaa bbbbb ccccc");
+    // the inter-word space already trails line 0; line 1 begins flush with "ccccc"
+    expect(a.text.getLine(0)).toBe("aaaa bbbbb ");
+    expect(a.text.getLine(1)).toBe("ccccc");
+
+    a.cursor.setPosition(0, 1); // start of the wrapped word
     keyDown(a, " ");
 
     expect(a.text.value).toBe("aaaa bbbbb  ccccc");
-    // the overflow whitespace leads line 1 (now two leading spaces)
-    expect(a.text.getLine(0)).toBe("aaaa bbbbb");
-    expect(a.text.getLine(1)).toBe("  ccccc");
+    // the new space joins the trailing run on line 0; line 1 still starts flush
+    expect(a.text.getLine(0)).toBe("aaaa bbbbb  ");
+    expect(a.text.getLine(1)).toBe("ccccc");
 
-    // caret visibly advanced past the inserted space
+    // the caret stays at the start of the wrapped word — the space collapsed
+    // into the previous line's margin rather than pushing the word right.
     expect(a.cursor.yLine).toBe(1);
-    expect(a.cursor.xLine).toBe(1);
+    expect(a.cursor.xLine).toBe(0);
   });
 
-  test("no visual line ever exceeds the wrap width by more than the single wrap space", () => {
+  test("no visual line's visible content exceeds the wrap width", () => {
     const a = setup("aaaa bbbbb ccccc");
     a.cursor.setPosition(0, 1);
     keyDown(a, " ");
     keyDown(a, " ");
     keyDown(a, " ");
     for (let i = 0; i < a.text.noLines; i++) {
-      expect(a.text.getLine(i).length).toBeLessThanOrEqual(MAXLEN + 1);
+      expect(visibleLen(a.text.getLine(i))).toBeLessThanOrEqual(MAXLEN);
     }
   });
 
-  test("a single wrap space on a full line leads the next line (overflow)", () => {
+  test("a single wrap space on a full line trails it, never leading the next line", () => {
     const a = setup("aaaa bbbbb ccccc");
-    // line 0 is exactly full, so the single wrap space overflows the width and
-    // leads line 1 (visible) rather than sitting off-screen trailing line 0.
-    expect(a.text.getLine(0)).toBe("aaaa bbbbb");
-    expect(a.text.getLine(1)).toBe(" ccccc");
+    // line 0 is exactly full; the single wrap space stays trailing there
+    // (collapsed in the margin) and line 1 begins flush with "ccccc".
+    expect(a.text.getLine(0)).toBe("aaaa bbbbb ");
+    expect(a.text.getLine(1)).toBe("ccccc");
     expect(a.text.noLines).toBe(2);
   });
 });

--- a/packages/annotator/src/typingAtLineEnd.test.ts
+++ b/packages/annotator/src/typingAtLineEnd.test.ts
@@ -34,7 +34,7 @@ describe("typing at end of wrapped line", () => {
     }
   });
 
-  test("space at end of full wrapped line advances cursor to next line", () => {
+  test("space at end of full wrapped line stays trailing; the caret is draw-clamped", () => {
     annotator = new Annotator(mockCanvas, "");
     annotator.setMode(EditMode.RAW);
     const charsAtLine = annotator.text.charsAtLine;
@@ -48,11 +48,15 @@ describe("typing at end of wrapped line", () => {
 
     expect(annotator.text.value.length).toBe(lenBefore + 1);
     expect(annotator.text.value).toContain(" ");
-    expect(annotator.cursor.yLine).toBe(1);
-    expect(annotator.cursor.xLine).toBe(1);
+    // Google-Docs style: the space stays trailing on the full line (no wrap to a
+    // leading-space line); the caret stays on line 0 with its drawn column
+    // clamped to the width, so it never scrolls off-screen.
+    expect(annotator.text.noLines).toBe(1);
+    expect(annotator.cursor.yLine).toBe(0);
+    expect(Math.min(annotator.cursor.xLine, charsAtLine)).toBe(charsAtLine);
   });
 
-  test("repeated spaces at wrapped line end keep advancing", () => {
+  test("repeated spaces at a full wrapped line end accumulate trailing, caret clamped", () => {
     annotator = new Annotator(mockCanvas, "");
     annotator.setMode(EditMode.RAW);
     const charsAtLine = annotator.text.charsAtLine;
@@ -62,7 +66,12 @@ describe("typing at end of wrapped line", () => {
     keyDown(annotator, " ");
     keyDown(annotator, " ");
 
-    expect(annotator.cursor.yLine).toBeGreaterThanOrEqual(1);
+    // both spaces stay trailing on the one line; the caret's drawn column stays
+    // clamped to the width rather than scrolling off-screen
     expect(annotator.text.value.split(" ").length - 1).toBeGreaterThanOrEqual(2);
+    expect(annotator.text.noLines).toBe(1);
+    expect(Math.min(annotator.cursor.xLine, charsAtLine)).toBeLessThanOrEqual(
+      charsAtLine
+    );
   });
 });

--- a/packages/annotator/src/wrapWhitespace.test.ts
+++ b/packages/annotator/src/wrapWhitespace.test.ts
@@ -26,21 +26,27 @@ function setup(value: string): Annotator {
   return a;
 }
 
-// No horizontal scroll: renderable spaces fill the line, overflow wraps to the
-// next visual line so it stays visible (#3145).
-describe("whitespace wrapping model (#3145)", () => {
-  describe("renderable spaces trail, overflow leads/wraps", () => {
-    test("trailing spaces fill the line to the width before overflowing", () => {
-      // 8 content + 3 spaces, width 10: 2 spaces fit, only the 3rd overflows
+/** Visible content of a line, ignoring trailing whitespace collapsed in the margin. */
+const visibleLen = (line: string) => line.replace(/\s+$/, "").length;
+/** The column at which the caret is actually rendered (Cursor.draw clamps to the width). */
+const drawnCaretX = (a: Annotator) => Math.min(a.cursor.xLine, a.text.charsAtLine);
+
+// No horizontal scroll and no wrapped line ever begins with whitespace
+// (Google-Docs style): an overflowing inter-word space run stays trailing on the
+// current line, collapsed into the margin past the visible edge.
+describe("whitespace wrapping model", () => {
+  describe("overflow whitespace trails the previous line, never leads the next", () => {
+    test("overflowing trailing spaces stay on the line, collapsed in the margin", () => {
+      // 8 content + 3 spaces, width 10: all spaces stay trailing on the one line
       const text = new Text("aaaaaaaa   ", 10);
-      expect(text.segments[0].lines).toEqual(["aaaaaaaa  ", " "]);
+      expect(text.segments[0].lines).toEqual(["aaaaaaaa   "]);
     });
 
-    test("two spaces split across the boundary instead of overflowing line 1", () => {
-      // 9 letters + 2 spaces + "cc": one space fits, the second overflows
+    test("an overflowing inter-word space trails line 0; the word starts line 1 flush", () => {
+      // 9 letters + 2 spaces + "cc": the spaces overflow but stay trailing on line 0
       const a = setup("aaaaaaaaa  cc");
-      expect(a.text.getLine(0)).toBe("aaaaaaaaa "); // one trailing space
-      expect(a.text.getLine(1)).toBe(" cc"); // overflow space leads line 2
+      expect(a.text.getLine(0)).toBe("aaaaaaaaa  "); // two trailing spaces, in the margin
+      expect(a.text.getLine(1)).toBe("cc"); // the word starts flush, no leading space
     });
 
     test("a single wrap space on a non-full line still trails (no leading space)", () => {
@@ -51,60 +57,64 @@ describe("whitespace wrapping model (#3145)", () => {
     });
   });
 
-  describe("no visual line is ever wider than the viewport", () => {
-    test("inter-word wrap whitespace keeps every line within the width", () => {
+  describe("no visual line's visible content is ever wider than the viewport", () => {
+    test("inter-word wrap whitespace keeps every line's visible content within the width", () => {
       const a = setup("aaaaaaaaa  cc");
       for (let l = 0; l < a.text.noLines; l++) {
-        expect(a.text.getLine(l).length).toBeLessThanOrEqual(MAXLEN);
+        expect(visibleLen(a.text.getLine(l))).toBeLessThanOrEqual(MAXLEN);
       }
     });
 
-    test("a large inter-word whitespace run wraps instead of overflowing one line", () => {
+    test("a large inter-word whitespace run trails the line; the word stays flush", () => {
       const a = setup("a" + " ".repeat(25) + "b");
+      expect(a.text.getLine(1)).toBe("b"); // the word begins the next line flush
       for (let l = 0; l < a.text.noLines; l++) {
-        expect(a.text.getLine(l).length).toBeLessThanOrEqual(MAXLEN);
+        expect(visibleLen(a.text.getLine(l))).toBeLessThanOrEqual(MAXLEN);
       }
     });
 
-    test("leading indentation before a word wraps instead of overflowing", () => {
+    test("leading indentation is kept and the word after it starts flush", () => {
       const a = setup(" ".repeat(30) + "word");
+      expect(a.text.getLine(1)).toBe("word");
       for (let l = 0; l < a.text.noLines; l++) {
-        expect(a.text.getLine(l).length).toBeLessThanOrEqual(MAXLEN);
+        expect(visibleLen(a.text.getLine(l))).toBeLessThanOrEqual(MAXLEN);
       }
     });
   });
 
   describe("typing spaces never pushes the caret off screen", () => {
-    test("typing the overflowing space keeps the fitting spaces on line 0", () => {
+    test("typing overflowing trailing spaces keeps them on line 0, caret draw-clamped", () => {
       const a = setup("aaaaaa"); // 6 chars, width 10
       a.cursor.setPosition(6, 0);
       for (let i = 0; i < 5; i++) keyDown(a, " ");
-      // 4 spaces fill line 0 up to the width; only the 5th overflows to line 1
-      expect(a.text.getLine(0)).toBe("aaaaaa    ");
-      expect(a.text.getLine(1)).toBe(" ");
+      // all 5 spaces stay trailing on the one line (no wrap to a leading-space line)
+      expect(a.text.segments[0].lines).toEqual(["aaaaaa     "]);
+      expect(a.text.noLines).toBe(1);
+      // the caret's rendered column is clamped to the width so it stays visible
+      expect(drawnCaretX(a)).toBe(MAXLEN);
     });
 
-    test("typing many trailing spaces keeps every wrapped line within the width", () => {
+    test("typing many trailing spaces keeps visible content and the caret within the width", () => {
       const a = setup("ccccc");
       a.cursor.setPosition(5, 0); // end of "ccccc"
       for (let i = 0; i < 25; i++) {
         keyDown(a, " ");
         for (let l = 0; l < a.text.noLines; l++) {
-          expect(a.text.getLine(l).length).toBeLessThanOrEqual(MAXLEN);
+          expect(visibleLen(a.text.getLine(l))).toBeLessThanOrEqual(MAXLEN);
         }
-        // caret must stay inside the visible width
-        expect(a.cursor.xLine).toBeLessThanOrEqual(MAXLEN);
+        // the drawn caret column stays inside the visible width
+        expect(drawnCaretX(a)).toBeLessThanOrEqual(MAXLEN);
       }
     });
 
-    test("trailing spaces on an otherwise empty line wrap instead of running off", () => {
+    test("trailing spaces on an otherwise empty line keep the caret draw-clamped", () => {
       const a = setup("");
       a.cursor.setPosition(0, 0);
       for (let i = 0; i < 25; i++) keyDown(a, " ");
       for (let l = 0; l < a.text.noLines; l++) {
-        expect(a.text.getLine(l).length).toBeLessThanOrEqual(MAXLEN);
+        expect(visibleLen(a.text.getLine(l))).toBeLessThanOrEqual(MAXLEN);
       }
-      expect(a.cursor.xLine).toBeLessThanOrEqual(MAXLEN);
+      expect(drawnCaretX(a)).toBeLessThanOrEqual(MAXLEN);
     });
   });
 
@@ -133,5 +143,32 @@ describe("whitespace wrapping model (#3145)", () => {
       expect(a.cursor.yLine).toBe(0); // caret stays on line 0
       expect(a.cursor.xLine).toBe(7); // just after the two spaces
     });
+  });
+
+  // The core invariant: a soft-wrap never carries whitespace to the start of a
+  // continuation line. The word that would have followed the wrap space begins
+  // the next line flush-left instead (only a segment's first line may keep the
+  // source's own leading whitespace).
+  describe("no wrapped continuation line begins with whitespace", () => {
+    const inputs = [
+      "aaaa bbbbb ccccc",
+      "aaaaaaaaaa bbbb",
+      "aaaaaaaaa, bbbb",
+      "one two three four five six seven eight nine ten",
+      "aaaaaaaaaa          bbbb", // a long inter-word whitespace run
+      "Ianuensi et ab eodem fratre Galvano cytatus iuravit", // mirrors the manuscript wrap
+    ];
+    for (const input of inputs) {
+      test(`"${input}" wraps with every continuation line flush-left`, () => {
+        for (const w of [6, 8, 10, 12, 20]) {
+          const lines = new Text(input, w).segments[0].lines;
+          for (let i = 1; i < lines.length; i++) {
+            expect(lines[i].startsWith(" ")).toBe(false);
+          }
+          // wrapping only moves break points; it never adds or drops characters
+          expect(lines.join("")).toBe(input);
+        }
+      });
+    }
   });
 });


### PR DESCRIPTION
Closes #3163.

Soft wraps now follow Google-Docs conventions, and the caret walks a soft-wrap boundary like the raw text.

**Wrapping**
- An overflowing inter-word space stays **trailing on the previous visual line** (collapsed in the margin) instead of leading the next line, so **no wrapped continuation line ever begins with whitespace**. The caret stays on-screen via the existing monospace draw-clamp.

**Caret navigation**
A soft-wrap boundary is one document offset with two visual positions (end of the wrapped line / start of the next line). It is now treated as a **single logical position**, and Left/Right are symmetric:
- **ArrowLeft** from a continuation-line start lands on the previous line's **second-to-last** position (Word-style).
- **ArrowRight** from a wrapped line end advances to the next line's **second** position — for both trailing-space wraps and mid-word breaks of an over-long word.
- Neither arrow dead-stops twice on the boundary offset; **shift-selection** still steps through a trailing wrap space so it stays visibly selected.
- Dropped the phantom "virtual newline" highlight column past a wrapped line's last character.
