### PR TITLE
Session hardening: per-instance cookies and CSRF protection (#3185)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,8 +33,7 @@ services:
     <<: *logging
     environment:
       NODE_ENV: ${NODE_ENV:-production}
-      # Identifier injected into index.html as window.appConfig.env
-      # (required — the client reads it; without ENV set the page fails to load)
+      # Instance id — session cookie name (inkvisitor.sid.<ENV>). Must match client build mode.
       ENV: ${ENV:-production}
       DOMAIN: ${DOMAIN:-localhost}
       STATIC_PATH: ${STATIC_PATH:-/}

--- a/docs/deployment-tutorial.md
+++ b/docs/deployment-tutorial.md
@@ -115,13 +115,14 @@ MAILER_SENDER=noreply@your-domain.tld
 
 The variables you most commonly want to set:
 
-- `SECRET` — JWT signing key. **The default is a placeholder; replace it before going public.**
-- `DOMAIN` — used in outgoing email links.
+- `SECRET` — session signing key (and short-lived download tokens). **The default is a placeholder; replace it before going public.**
+- `DOMAIN` — hostname used in outgoing email links and as the default allowed browser origin for CORS/CSRF checks.
+- `ENV` — instance identifier (e.g. `sandbox`, `staging`, `production`). Must be unique per deployment on the same domain. Sets the session cookie name (`inkvisitor.sid.<ENV>`) and must match the client build mode for that instance.
 - `IMAGE_TAG` — pick `latest` (default), `production`, `staging`, `sandbox`, etc.
 - `DB_AUTH` — RethinkDB password (leave unset if RethinkDB has no auth). ⚠ Same secret as `DB_PASS` in the database CLI's env file — the two use different variable names.
 - `SMTP_HOST` / `SMTP_PORT` / `SMTP_USER` / `SMTP_SECRET` / `MAILER_SENDER` — SMTP relay for outgoing mail. Leave unset to disable mail features. Mailjet example shown above.
 
-Less commonly overridden: `NODE_ENV` (default `production`), `ENV` (default `production` — server injects this as `window.appConfig.env` into the served `index.html`; required for the client to render), `STATIC_PATH` (default `/`), `PORT` (default `3000`), `DB_NAME` (default `inkvisitor`), `DB_PORT` (default `28015`), `DB_POOL_CONNECTIONS` (default `10`).
+Less commonly overridden: `NODE_ENV` (default `production`; also enables the session cookie `Secure` flag), `STATIC_PATH` (default `/`), `PORT` (default `3000`), `DB_NAME` (default `inkvisitor`), `DB_PORT` (default `28015`), `DB_POOL_CONNECTIONS` (default `10`), `SESSION_COOKIE_SAMESITE` (default `lax`), `CORS_ORIGINS` (default: derived from `DOMAIN`).
 
 ### A.2 Build the image locally
 
@@ -140,11 +141,14 @@ The client is built at **image build time**. Vite reads `packages/client/env/.en
 
 Copy [`packages/client/env/example.env`](https://github.com/DISSINET/InkVisitor/blob/dev/packages/client/env/example.env) to the matching path and fill in:
 
-- `ENV` — short identifier surfaced in the UI as the current environment (e.g. `production`, `staging`). Ignored for `ENV=latest` builds, used everywhere else.
-- `ROOT_URL` — base path the client is served from. Use empty (or `/`) for the root; use `/inkvisitor` if you serve it under a sub-path of your domain.
-- `APIURL` — full URL of the server API. **Leave empty** to make the client call back to the same origin it was loaded from (this is what makes the published `latest` image work as-is when the server hosts both the static files and the API). Set explicitly to e.g. `https://api.your-domain.tld` only if the API lives on a different host than the client.
+- `ROOT_URL` — base path the client is served from. Use empty (or `/`) for the root; use `/apps/inkvisitor-sandbox` if you serve it under a sub-path of your domain.
+- `APIURL` — full URL of the server API. **Leave empty** to make the client call back to the same origin it was loaded from (this is what makes the published `latest` image work as-is when the server hosts both the static files and the API). Set explicitly to e.g. `https://dissinet.cz/inkvisitor-server-sandbox` when the API is reached via a separate path on the same host.
 
-These three are the only variables defined in `example.env`. The client source code reads a few more (`GUEST_MODE`, `GUEST_MODE_USER`, `GUEST_MODE_PASS`, `LOGIN_TITLE`, `LOGIN_TEXT`, `LOGIN_CITATION`, `SHOW_LEGACY_ID`) which are optional UX customisations — add them to your env file if you need them. See the [client README](https://github.com/DISSINET/InkVisitor/blob/dev/packages/client/README.md) for details.
+Do **not** set `NODE_ENV` in client env files — Vite sets it automatically (`development` for `pnpm start`, `production` for `pnpm build:*`). The instance identifier (header colour, localStorage scoping) comes from the vite build **mode** (`sandbox`, `staging`, etc.) and is baked into the bundle at build time. An optional `ENV` in the client env file overrides the mode name; normally you can omit it.
+
+When `STATIC_PATH` is not `/`, the server serves the pre-built client as static files and does **not** inject `window.appConfig` into `index.html` — the client does not depend on that; configuration is baked in at build time.
+
+Set the same instance id on the **server** at runtime (`ENV=sandbox` in the server env) so the session cookie name matches the client build.
 
 #### Build the image
 

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -15,6 +15,13 @@ Package uses different environments - each of them has dedicated `.env.<env>` fi
 
 See [example.env](./env/example.env) file for description of variables.
 
+Per-environment client config lives in `packages/client/env/.env.<mode>` (e.g. `.env.sandbox`). Typical entries:
+
+- `ROOT_URL` — URL path prefix where the client is hosted.
+- `APIURL` — API base URL (same origin path or full URL).
+
+Do not set `NODE_ENV` in these files. The instance id (header colour, auth localStorage keys) is taken from the vite build mode (`pnpm build:sandbox` → `sandbox`) unless you set an explicit `ENV` override.
+
 ## Development
 
 1. `pnpm install`

--- a/packages/client/env/example.env
+++ b/packages/client/env/example.env
@@ -1,4 +1,5 @@
-# Environment - used for identyfing the environment
+# Optional instance id override (defaults to the vite build mode, e.g. sandbox).
+# Do not set NODE_ENV here — vite sets it automatically.
 ENV=
 
 # Assets - used for setting the base path in case your app is available under some non-root path
@@ -6,3 +7,6 @@ ROOT_URL=
 
 # Api - url of api base
 APIURL=
+
+# contact email
+ADMIN_MAIL="admin@inkvisitor.cz"

--- a/packages/client/src/api.tsx
+++ b/packages/client/src/api.tsx
@@ -38,6 +38,12 @@ import { toast } from "react-toastify";
 import io, { Socket } from "socket.io-client";
 import { v4 as uuidv4 } from "uuid";
 import {
+  clearStoredUser,
+  getStoredUserId,
+  getStoredUsername,
+  saveStoredUser,
+} from "utils/userStorage";
+import {
   EntitiesDeleteErrorResponse,
   EntitiesDeleteSuccessResponse,
   RelationsCreateErrorResponse,
@@ -335,7 +341,7 @@ class Api {
           if (!isSignInRequest) {
             // Session is no longer valid - drop stale local user state so route
             // guards (isLoggedIn) reflect reality, then bounce to login.
-            this.clearStoredUser();
+            clearStoredUser();
             // if handled by react router, then the toast could be visible
             window.location.pathname = (process.env.ROOT_URL || "") + "/login";
           }
@@ -469,21 +475,13 @@ class Api {
   // the DB-loaded user. A stale value just means the next request 401s and the
   // response interceptor clears it and redirects to login.
   isLoggedIn = () => {
-    const storedUserId = localStorage.getItem("userid");
-    const storedUsername = localStorage.getItem("username");
+    const storedUserId = getStoredUserId();
+    const storedUsername = getStoredUsername();
     return storedUserId && storedUsername ? true : false;
   };
 
-  private clearStoredUser() {
-    localStorage.removeItem("username");
-    localStorage.removeItem("userid");
-    localStorage.removeItem("userrole");
-  }
-
   saveLogin(newUserName: string, newUserId: string, newUserRole: string) {
-    localStorage.setItem("username", newUserName);
-    localStorage.setItem("userid", newUserId);
-    localStorage.setItem("userrole", newUserRole);
+    saveStoredUser(newUserName, newUserId, newUserRole);
     // Re-handshake so the server can re-evaluate role-gated channels (db:stats)
     // for the new cookie session without requiring a page refresh.
     this.reconnectWs();
@@ -538,7 +536,7 @@ class Api {
 
   async signOut() {
     const wasLoggedIn = this.isLoggedIn();
-    this.clearStoredUser();
+    clearStoredUser();
 
     // Tell the server to destroy the session (clears the cookie). Best-effort:
     // local state is already gone, and the endpoint is public so a dead session

--- a/packages/client/src/api.tsx
+++ b/packages/client/src/api.tsx
@@ -112,6 +112,7 @@ class Api {
 
     this.headers = {
       "Content-Type": "application/json",
+      "X-InkVisitor-Client": "1",
       //"Content-Encoding": "gzip",
     };
 

--- a/packages/client/src/app.tsx
+++ b/packages/client/src/app.tsx
@@ -1,4 +1,5 @@
 import { InterfaceEnums, UserEnums } from "@inkvisitor/shared/enums";
+import { getStoredUserId, getStoredUserRole, getStoredUsername } from "utils/userStorage";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import api from "api";
@@ -71,7 +72,7 @@ export const RequireOwner = ({ children }: { children: React.ReactNode }) => {
   if (!api.isLoggedIn()) {
     return <Navigate to="/login" />;
   }
-  const isOwner = localStorage.getItem("userrole") === UserEnums.Role.Owner;
+  const isOwner = getStoredUserRole() === UserEnums.Role.Owner;
   return isOwner ? children : <Navigate to="/" />;
 };
 

--- a/packages/client/src/components/advanced/Annotator/Annotator.tsx
+++ b/packages/client/src/components/advanced/Annotator/Annotator.tsx
@@ -1,3 +1,4 @@
+import { getStoredUserRole } from "utils/userStorage";
 import {
   autoUpdate,
   flip,
@@ -499,7 +500,7 @@ export const TextAnnotator = ({
           await statementCreateMutation?.mutateAsync(newStatement);
         } else {
           const newStatement: IStatement = CStatement(
-            localStorage.getItem("userrole") as UserEnums.Role,
+            getStoredUserRole() as UserEnums.Role,
             userData.options,
             text,
             "",

--- a/packages/client/src/components/advanced/ApplyTemplateModal/ApplyTemplateModal.tsx
+++ b/packages/client/src/components/advanced/ApplyTemplateModal/ApplyTemplateModal.tsx
@@ -1,4 +1,5 @@
 import { entitiesDictKeys } from "@inkvisitor/shared/dictionaries";
+import { getStoredUserId, getStoredUserRole, getStoredUsername } from "utils/userStorage";
 import { UserEnums } from "@inkvisitor/shared/enums";
 import { IEntity, IResponseGeneric, Relation } from "@inkvisitor/shared/types";
 import { UseMutationResult, useQueryClient } from "@tanstack/react-query";
@@ -71,7 +72,7 @@ export const ApplyTemplateModal: React.FC<ApplyTemplateModal> = ({
       const entityAfterTemplateApplied: IEntity = await applyTemplate(
         templateToApply,
         entity,
-        localStorage.getItem("userrole") as UserEnums.Role
+        getStoredUserRole() as UserEnums.Role
       );
 
       if (entityAfterTemplateApplied) {

--- a/packages/client/src/components/advanced/EntityCreateModal/EntityCreateModal.tsx
+++ b/packages/client/src/components/advanced/EntityCreateModal/EntityCreateModal.tsx
@@ -1,3 +1,4 @@
+import { getStoredUserRole } from "utils/userStorage";
 import {
   actionPartOfSpeechDict,
   conceptPartOfSpeechDict,
@@ -109,7 +110,7 @@ export const EntityCreateModal: React.FC<EntityCreateModal> = ({
     },
   });
 
-  const userRole = localStorage.getItem("userrole") as UserEnums.Role;
+  const userRole = getStoredUserRole() as UserEnums.Role;
 
   // User rights validation for the parent territory is filtered in Suggester for parent territory
   const validateEntityCreation = (skipLabelCheck = false) => {

--- a/packages/client/src/components/advanced/EntityDropzone/EntityDropzone.tsx
+++ b/packages/client/src/components/advanced/EntityDropzone/EntityDropzone.tsx
@@ -1,4 +1,5 @@
 import { EntityEnums, UserEnums } from "@inkvisitor/shared/enums";
+import { getStoredUserId, getStoredUserRole, getStoredUsername } from "utils/userStorage";
 import { IEntity, IStatement, ITerritory } from "@inkvisitor/shared/types";
 import { Dropzone } from "components";
 import { InstTemplate } from "constructors";
@@ -42,7 +43,7 @@ export const EntityDropzone: React.FC<EntityDropzone> = ({
   ) => {
     const newEntity = await InstTemplate(
       templateToDuplicate,
-      localStorage.getItem("userrole") as UserEnums.Role
+      getStoredUserRole() as UserEnums.Role
     );
     if (newEntity) {
       onSelected(newEntity.id);

--- a/packages/client/src/components/advanced/EntitySuggester/EntitySuggester.tsx
+++ b/packages/client/src/components/advanced/EntitySuggester/EntitySuggester.tsx
@@ -1,3 +1,4 @@
+import { getStoredUserRole } from "utils/userStorage";
 import {
   classesAll,
   dropdownWildCard,
@@ -191,7 +192,7 @@ const EntitySuggesterFull: React.FC<
   const { appendDetailId } = useSearchParams();
 
   // get user data
-  const userRole = localStorage.getItem("userrole");
+  const userRole = getStoredUserRole();
   const { data: user } = useUserQuery();
 
   // Suggesions query
@@ -356,7 +357,7 @@ const EntitySuggesterFull: React.FC<
   ): Promise<IEntity | false> => {
     return await InstTemplate(
       territoryToInst,
-      localStorage.getItem("userrole") as UserEnums.Role,
+      getStoredUserRole() as UserEnums.Role,
       territoryParentId,
     );
   };
@@ -379,7 +380,7 @@ const EntitySuggesterFull: React.FC<
     } else {
       newEntity = await InstTemplate(
         templateToDuplicate,
-        localStorage.getItem("userrole") as UserEnums.Role,
+        getStoredUserRole() as UserEnums.Role,
       );
     }
     if (newEntity) {

--- a/packages/client/src/components/advanced/Page/Page.tsx
+++ b/packages/client/src/components/advanced/Page/Page.tsx
@@ -1,4 +1,6 @@
 import { UserEnums } from "@inkvisitor/shared/enums";
+import { getAppEnv } from "utils/appEnv";
+import { getStoredUserId, getStoredUserRole, getStoredUsername } from "utils/userStorage";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import api from "api";
 import { Header, Loader } from "components";
@@ -24,14 +26,14 @@ export const Page: React.FC<Page> = ({ children }) => {
   const dispatch = useAppDispatch();
   const queryClient = useQueryClient();
   const lastClickedIndex: number = useAppSelector((state) => state.statementList.lastClickedIndex);
-  const userId = localStorage.getItem("userid");
-  const userRole = localStorage.getItem("userrole") as UserEnums.Role;
+  const userId = getStoredUserId();
+  const userRole = getStoredUserRole() as UserEnums.Role;
   const { cleanAllParams, setLogoutState } = useSearchParams();
 
   const contentHeight: number = useAppSelector((state) => state.layout.contentHeight);
   const layoutWidth: number = useAppSelector((state) => state.layout.layoutWidth);
 
-  const environmentName = window.appConfig.env || "";
+  const environmentName = getAppEnv();
   const location = useLocation();
   const navigate = useNavigate();
 

--- a/packages/client/src/components/advanced/PageHeader/PageHeader.tsx
+++ b/packages/client/src/components/advanced/PageHeader/PageHeader.tsx
@@ -1,4 +1,5 @@
 import { InterfaceEnums, UserEnums } from "@inkvisitor/shared/enums";
+import { getAppEnv } from "utils/appEnv";
 import { useQueryClient } from "@tanstack/react-query";
 import { heightHeader } from "Theme/constants";
 import { PingColor } from "Theme/theme";
@@ -51,7 +52,7 @@ interface LeftHeader {
   tempLocation: string | false;
 }
 export const LeftHeader: React.FC<LeftHeader> = React.memo(({ tempLocation }) => {
-  const env = window.appConfig.env || "";
+  const env = getAppEnv();
 
   const versionText = `v. ${packageJson.version}${env ? ` | ${env}` : ``} | build: ${
     process.env.BUILD_TIMESTAMP
@@ -331,7 +332,7 @@ export const RightHeader: React.FC<RightHeader> = React.memo(
     handleLogOut,
     userIsFetching = false,
   }) => {
-    const env = window.appConfig.env || "";
+    const env = getAppEnv();
 
     const dispatch = useAppDispatch();
     const selectedThemeId: InterfaceEnums.Theme = useAppSelector((state) => state.theme);

--- a/packages/client/src/components/advanced/UserTag/UserTag.tsx
+++ b/packages/client/src/components/advanced/UserTag/UserTag.tsx
@@ -1,4 +1,5 @@
 import { UserEnums } from "@inkvisitor/shared/enums";
+import { getStoredUserId, getStoredUserRole, getStoredUsername } from "utils/userStorage";
 import { useQuery } from "@tanstack/react-query";
 import api from "api";
 import { Tag } from "components/basic/Tag/Tag";
@@ -29,7 +30,7 @@ export const UserTag: React.FC<UserTagProps> = ({
   disableFetch = false,
 }) => {
   const theme = useTheme();
-  const currentUserId = localStorage.getItem("userid");
+  const currentUserId = getStoredUserId();
   const color = currentUserId === userId ? "primary" : "info";
 
   const { data: dataUser } = useQuery({

--- a/packages/client/src/hooks/react-query/useUserQuery.tsx
+++ b/packages/client/src/hooks/react-query/useUserQuery.tsx
@@ -1,9 +1,10 @@
 // manage user data for current user
 import { useQuery } from "@tanstack/react-query";
+import { getStoredUserId, getStoredUserRole, getStoredUsername } from "utils/userStorage";
 import api from "api";
 
 export function useUserQuery(enabled = true) {
-  const userId = localStorage.getItem("userid");
+  const userId = getStoredUserId();
   return useQuery({
     queryKey: ["user", userId],
     queryFn: async () => {

--- a/packages/client/src/index.tsx
+++ b/packages/client/src/index.tsx
@@ -1,3 +1,4 @@
+import "./init-app-config";
 import * as ReactDOM from "react-dom/client";
 import { Provider } from "react-redux";
 import { StrictMode } from "react";

--- a/packages/client/src/init-app-config.ts
+++ b/packages/client/src/init-app-config.ts
@@ -1,0 +1,3 @@
+import { ensureAppConfig } from "utils/appEnv";
+
+ensureAppConfig();

--- a/packages/client/src/pages/Main/MainPage.tsx
+++ b/packages/client/src/pages/Main/MainPage.tsx
@@ -1,4 +1,5 @@
 import { EntityEnums, UserEnums } from "@inkvisitor/shared/enums";
+import { getStoredUserId, getStoredUserRole, getStoredUsername } from "utils/userStorage";
 import { IStatement } from "@inkvisitor/shared/types";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import api from "api";
@@ -193,7 +194,7 @@ const MainPage: React.FC<MainPage> = ({}) => {
 
   const [showEntityCreateModal, setShowEntityCreateModal] = useState(false);
 
-  const userRole = localStorage.getItem("userrole") as UserEnums.Role;
+  const userRole = getStoredUserRole() as UserEnums.Role;
 
   const addStatementAtTheEndMutation = useMutation({
     mutationFn: async (newStatement: IStatement) => {

--- a/packages/client/src/pages/Main/components/RefreshBoxButton.tsx
+++ b/packages/client/src/pages/Main/components/RefreshBoxButton.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { getStoredUserId, getStoredUserRole, getStoredUsername } from "utils/userStorage";
 import { useQueryClient } from "@tanstack/react-query";
 import { Button } from "components";
 import { BiRefresh } from "react-icons/bi";
@@ -22,7 +23,7 @@ export const RefreshBoxButton: React.FC<RefreshBoxButton> = ({ queriesToRefresh,
       inverted
       icon={<BiRefresh />}
       onClick={async () => {
-        const uid = localStorage.getItem("userid");
+        const uid = getStoredUserId();
         await Promise.all(
           queriesToRefresh.map(async (queryToRefresh) => {
             const queryKey =

--- a/packages/client/src/pages/Main/containers/EntityBookmarkBox/EntityBookmarkFolder/EntityBookmarkFolder.tsx
+++ b/packages/client/src/pages/Main/containers/EntityBookmarkBox/EntityBookmarkFolder/EntityBookmarkFolder.tsx
@@ -1,4 +1,5 @@
 import { classesAll } from "@inkvisitor/shared/dictionaries/entity";
+import { getStoredUserId, getStoredUserRole, getStoredUsername } from "utils/userStorage";
 import { UserEnums } from "@inkvisitor/shared/enums";
 import { IBookmarkFolder, IResponseBookmarkFolder } from "@inkvisitor/shared/types";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
@@ -121,7 +122,7 @@ export const EntityBookmarkFolder: React.FC<EntityBookmarkFolder> = ({
   const [referenceElement, setReferenceElement] = useState<HTMLDivElement | null>(null);
   const [showTooltip, setShowTooltip] = useState(false);
 
-  const userRole = localStorage.getItem("userrole") as UserEnums.Role;
+  const userRole = getStoredUserRole() as UserEnums.Role;
 
   const FolderIcon = empty
     ? open

--- a/packages/client/src/pages/Main/containers/EntityDetailBox/EntityDetail/EntityDetail.tsx
+++ b/packages/client/src/pages/Main/containers/EntityDetailBox/EntityDetail/EntityDetail.tsx
@@ -1,4 +1,5 @@
 import { entitiesDictKeys } from "@inkvisitor/shared/dictionaries";
+import { getStoredUserId, getStoredUserRole, getStoredUsername } from "utils/userStorage";
 import { EntityEnums, RelationEnums, UserEnums } from "@inkvisitor/shared/enums";
 import {
   IEntity,
@@ -599,7 +600,7 @@ export const EntityDetail: React.FC<EntityDetail> = ({ detailId, entity, error, 
   const widthTooNarrow = contentWidth < 516;
 
   const isRootTerritory = selectedDetailId === rootTerritoryId;
-  const isOwner = (localStorage.getItem("userrole") as UserEnums.Role) === UserEnums.Role.Owner;
+  const isOwner = (getStoredUserRole() as UserEnums.Role) === UserEnums.Role.Owner;
   const disableAttributesForNonOwnersInRoot = isRootTerritory && !isOwner;
   const canEditEntity = userCanEdit && !disableAttributesForNonOwnersInRoot;
 

--- a/packages/client/src/pages/Main/containers/EntityDetailBox/EntityDetail/EntityDetailCreateTemplateModal/EntityDetailCreateTemplateModal.tsx
+++ b/packages/client/src/pages/Main/containers/EntityDetailBox/EntityDetail/EntityDetailCreateTemplateModal/EntityDetailCreateTemplateModal.tsx
@@ -1,4 +1,5 @@
 import { UserEnums } from "@inkvisitor/shared/enums";
+import { getStoredUserId, getStoredUserRole, getStoredUsername } from "utils/userStorage";
 import { IEntity, IResponseGeneric } from "@inkvisitor/shared/types";
 import { UseMutationResult, useMutation, useQueryClient } from "@tanstack/react-query";
 import api from "api";
@@ -68,7 +69,7 @@ export const EntityDetailCreateTemplateModal: React.FC<EntityDetailCreateTemplat
   const handleCreateTemplate = () => {
     // create template as a copy of the entity
     const templateEntity = CTemplateEntity(
-      localStorage.getItem("userrole") as UserEnums.Role,
+      getStoredUserRole() as UserEnums.Role,
       entity,
       createTemplateLabel,
     );

--- a/packages/client/src/pages/Main/containers/EntityDetailBox/EntityDetail/EntityDetailFormSection/EntityDetailFormSection.tsx
+++ b/packages/client/src/pages/Main/containers/EntityDetailBox/EntityDetail/EntityDetailFormSection/EntityDetailFormSection.tsx
@@ -1,3 +1,4 @@
+import { getStoredUserRole } from "utils/userStorage";
 import {
   actantLogicalTypeDict,
   actionPartOfSpeechDict,
@@ -122,7 +123,7 @@ export const EntityDetailFormSection: React.FC<EntityDetailFormSection> = ({
     setNewLabel(entity.labels[0]);
   }, [entity.labels[0]]);
 
-  const isOwner = (localStorage.getItem("userrole") as UserEnums.Role) === UserEnums.Role.Owner;
+  const isOwner = (getStoredUserRole() as UserEnums.Role) === UserEnums.Role.Owner;
 
   const [showTActionModal, setShowTActionModal] = useState(false);
   const [moveToParentEntity, setMoveToParentEntity] = useState<IEntity | false>(false);

--- a/packages/client/src/pages/Main/containers/EntityDetailBox/EntityDetail/EntityDetailHeaderRow/EntityDetailHeaderRow.tsx
+++ b/packages/client/src/pages/Main/containers/EntityDetailBox/EntityDetail/EntityDetailHeaderRow/EntityDetailHeaderRow.tsx
@@ -1,4 +1,5 @@
 import { EntityEnums, UserEnums } from "@inkvisitor/shared/enums";
+import { getStoredUserId, getStoredUserRole, getStoredUsername } from "utils/userStorage";
 import { IEntity, IResponseGeneric, IStatement } from "@inkvisitor/shared/types";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import api from "api";
@@ -74,7 +75,7 @@ export const EntityDetailHeaderRow: React.FC<EntityDetailHeaderRow> = ({
       if (territoryParentId) {
         newInstance = await InstTemplate(
           entity,
-          localStorage.getItem("userrole") as UserEnums.Role,
+          getStoredUserRole() as UserEnums.Role,
           territoryParentId
         );
         setShowAddParentModal(false);
@@ -82,7 +83,7 @@ export const EntityDetailHeaderRow: React.FC<EntityDetailHeaderRow> = ({
         toast.info("Cannot create territory without parent");
       }
     } else {
-      newInstance = await InstTemplate(entity, localStorage.getItem("userrole") as UserEnums.Role);
+      newInstance = await InstTemplate(entity, getStoredUserRole() as UserEnums.Role);
     }
 
     if (newInstance) {

--- a/packages/client/src/pages/Main/containers/EntitySearchBox/EntitySearchBox.tsx
+++ b/packages/client/src/pages/Main/containers/EntitySearchBox/EntitySearchBox.tsx
@@ -1,4 +1,5 @@
 import { entityStatusDict } from "@inkvisitor/shared/dictionaries";
+import { getStoredUserId, getStoredUserRole, getStoredUsername } from "utils/userStorage";
 import { entitiesDict } from "@inkvisitor/shared/dictionaries/entity";
 import { EntityEnums, SearchEnums, UserEnums } from "@inkvisitor/shared/enums";
 import { DropdownItem, IEntity } from "@inkvisitor/shared/types";
@@ -238,7 +239,7 @@ export const EntitySearchBox: React.FC = () => {
 
   const [showEntityCreateModal, setShowEntityCreateModal] = useState(false);
 
-  const userRole = localStorage.getItem("userrole");
+  const userRole = getStoredUserRole();
 
   const handleSetExpandedOptions = useCallback(
     (options: SearchEnums.AdvancedOption[]) => {

--- a/packages/client/src/pages/Main/containers/StatementsListBox/StatementListBox.tsx
+++ b/packages/client/src/pages/Main/containers/StatementsListBox/StatementListBox.tsx
@@ -1,4 +1,5 @@
 import { EntityEnums, UserEnums } from "@inkvisitor/shared/enums";
+import { getStoredUserId, getStoredUserRole, getStoredUsername } from "utils/userStorage";
 import {
   IDocument,
   IEntity,
@@ -367,7 +368,7 @@ export const StatementListBox: React.FC = () => {
 
       if (newOrder) {
         const newStatement: IStatement = CStatement(
-          localStorage.getItem("userrole") as UserEnums.Role,
+          getStoredUserRole() as UserEnums.Role,
           userData.options,
           "",
           "",

--- a/packages/client/src/pages/Main/containers/TemplateListBox/TemplateListBox.tsx
+++ b/packages/client/src/pages/Main/containers/TemplateListBox/TemplateListBox.tsx
@@ -1,4 +1,5 @@
 import { entitiesDict, entitiesDictKeys } from "@inkvisitor/shared/dictionaries";
+import { getStoredUserId, getStoredUserRole, getStoredUsername } from "utils/userStorage";
 import { EntityEnums, UserEnums } from "@inkvisitor/shared/enums";
 import { IEntity } from "@inkvisitor/shared/types";
 import { Button, Input, Loader } from "components";
@@ -88,7 +89,7 @@ export const TemplateListBox: React.FC<TemplateListBox> = () => {
     }
   }, [removeEntityId]);
 
-  const userRole = localStorage.getItem("userrole") as UserEnums.Role;
+  const userRole = getStoredUserRole() as UserEnums.Role;
 
   return (
     <StyledBoxContent>

--- a/packages/client/src/pages/Main/containers/TemplateListBox/TemplateListCreateModal/TemplateListCreateModal.tsx
+++ b/packages/client/src/pages/Main/containers/TemplateListBox/TemplateListCreateModal/TemplateListCreateModal.tsx
@@ -1,4 +1,5 @@
 import { entitiesDict } from "@inkvisitor/shared/dictionaries";
+import { getStoredUserId, getStoredUserRole, getStoredUsername } from "utils/userStorage";
 import { EntityEnums, UserEnums } from "@inkvisitor/shared/enums";
 import { IEntity } from "@inkvisitor/shared/types";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
@@ -76,7 +77,7 @@ export const TemplateListCreateModal: React.FC<TemplateListCreateModal> = ({
   const handleCreateNewStatementTemplate = (): IEntity | false => {
     if (user) {
       const newTemplate = CStatement(
-        localStorage.getItem("userrole") as UserEnums.Role,
+        getStoredUserRole() as UserEnums.Role,
         user.options,
         createModalEntityLabel,
         createModalEntityDetail
@@ -110,7 +111,7 @@ export const TemplateListCreateModal: React.FC<TemplateListCreateModal> = ({
 
       if (entity) {
         const templateEntity = CTemplateEntity(
-          localStorage.getItem("userrole") as UserEnums.Role,
+          getStoredUserRole() as UserEnums.Role,
           entity,
           createModalEntityLabel,
           createModalEntityDetail

--- a/packages/client/src/pages/Main/containers/TerritoryTreeBox/TerritoryTreeBox.tsx
+++ b/packages/client/src/pages/Main/containers/TerritoryTreeBox/TerritoryTreeBox.tsx
@@ -1,4 +1,5 @@
 import { EntityEnums, UserEnums } from "@inkvisitor/shared/enums";
+import { getStoredUserId, getStoredUserRole, getStoredUsername } from "utils/userStorage";
 import { IResponseTree, IUser } from "@inkvisitor/shared/types";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import api from "api";
@@ -64,7 +65,7 @@ export const TerritoryTreeBox: React.FC = () => {
     [userData],
   );
 
-  const userId = localStorage.getItem("userid");
+  const userId = getStoredUserId();
 
   const updateUserMutation = useMutation({
     mutationFn: async (changes: Partial<IUser>) => {
@@ -80,7 +81,7 @@ export const TerritoryTreeBox: React.FC = () => {
     },
   });
 
-  const userRole = localStorage.getItem("userrole");
+  const userRole = getStoredUserRole();
   const { territoryId } = useSearchParams();
   const [showCreate, setShowCreate] = useState(false);
 

--- a/packages/client/src/pages/Users/containers/UserList/UserList.tsx
+++ b/packages/client/src/pages/Users/containers/UserList/UserList.tsx
@@ -1,4 +1,5 @@
 import { userRoleDict } from "@inkvisitor/shared/dictionaries";
+import { getStoredUserId, getStoredUserRole, getStoredUsername } from "utils/userStorage";
 import { EntityEnums, UserEnums } from "@inkvisitor/shared/enums";
 import { IResponseUser, IUser, IUserRight } from "@inkvisitor/shared/types";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
@@ -77,7 +78,7 @@ export const UserList: React.FC<UserList> = React.memo(() => {
     };
   }, []);
 
-  const currentUserRole = localStorage.getItem("userrole") as UserEnums.Role;
+  const currentUserRole = getStoredUserRole() as UserEnums.Role;
   const canVerifyManually =
     currentUserRole === UserEnums.Role.Admin || currentUserRole === UserEnums.Role.Owner;
 
@@ -271,7 +272,7 @@ export const UserList: React.FC<UserList> = React.memo(() => {
           const { id, role } = row.original;
           return (
             <AttributeButtonGroup
-              disabled={id === localStorage.getItem("userid") || role === UserEnums.Role.Owner}
+              disabled={id === getStoredUserId() || role === UserEnums.Role.Owner}
               options={
                 role === UserEnums.Role.Owner
                   ? [
@@ -572,7 +573,7 @@ export const UserList: React.FC<UserList> = React.memo(() => {
           let activateTooltip = "activate user";
           if (!verified) {
             activateTooltip = "cannot activate unverified user";
-          } else if (userId === localStorage.getItem("userid")) {
+          } else if (userId === getStoredUserId()) {
             activateTooltip = "cannot deactivate yourself";
           } else if (role === UserEnums.Role.Owner) {
             activateTooltip = "owner must be active";
@@ -581,7 +582,7 @@ export const UserList: React.FC<UserList> = React.memo(() => {
           }
 
           let deleteTooltip = "delete user";
-          if (userId === localStorage.getItem("userid")) {
+          if (userId === getStoredUserId()) {
             deleteTooltip = "cannot delete yourself";
           }
 
@@ -593,7 +594,7 @@ export const UserList: React.FC<UserList> = React.memo(() => {
                 color="danger"
                 tooltipLabel={deleteTooltip}
                 disabled={
-                  userId === localStorage.getItem("userid") || role === UserEnums.Role.Owner
+                  userId === getStoredUserId() || role === UserEnums.Role.Owner
                 }
                 onClick={() => {
                   setRemovingUserId(userId);
@@ -638,7 +639,7 @@ export const UserList: React.FC<UserList> = React.memo(() => {
                 shape="rounded-right-sm"
                 disabled={
                   !verified ||
-                  userId === localStorage.getItem("userid") ||
+                  userId === getStoredUserId() ||
                   role === UserEnums.Role.Owner
                 }
                 color={active ? "success" : "danger"}

--- a/packages/client/src/redux/features/usernameSlice.tsx
+++ b/packages/client/src/redux/features/usernameSlice.tsx
@@ -1,6 +1,8 @@
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 
-const initialState: string | null = localStorage.getItem("username");
+import { getStoredUsername } from "utils/userStorage";
+
+const initialState: string | null = getStoredUsername();
 
 const usernameSlice = createSlice({
   name: "username",

--- a/packages/client/src/utils/appEnv.ts
+++ b/packages/client/src/utils/appEnv.ts
@@ -1,0 +1,5 @@
+export const getAppEnv = (): string => process.env.ENV || "default";
+
+export const ensureAppConfig = (): void => {
+  window.appConfig = { env: getAppEnv() };
+};

--- a/packages/client/src/utils/userStorage.ts
+++ b/packages/client/src/utils/userStorage.ts
@@ -1,0 +1,23 @@
+import { getAppEnv } from "utils/appEnv";
+
+const instanceId = () => getAppEnv();
+
+const storageKey = (name: string) => `${instanceId()}-${name}`;
+
+export const getStoredUserId = () => localStorage.getItem(storageKey("userid"));
+
+export const getStoredUsername = () => localStorage.getItem(storageKey("username"));
+
+export const getStoredUserRole = () => localStorage.getItem(storageKey("userrole"));
+
+export const saveStoredUser = (name: string, id: string, role: string) => {
+  localStorage.setItem(storageKey("username"), name);
+  localStorage.setItem(storageKey("userid"), id);
+  localStorage.setItem(storageKey("userrole"), role);
+};
+
+export const clearStoredUser = () => {
+  localStorage.removeItem(storageKey("username"));
+  localStorage.removeItem(storageKey("userid"));
+  localStorage.removeItem(storageKey("userrole"));
+};

--- a/packages/client/types.d.ts
+++ b/packages/client/types.d.ts
@@ -7,7 +7,7 @@ declare namespace NodeJS {
 }
 
 interface Window {
-  appConfig: {
+  appConfig?: {
     env: string;
   };
   showSaveFilePicker?: (options?: SaveFilePickerOptions) => Promise<FileSystemFileHandle>;

--- a/packages/client/vite.config.ts
+++ b/packages/client/vite.config.ts
@@ -6,6 +6,7 @@ import react from "@vitejs/plugin-react";
 export default defineConfig(({ mode }) => {
   // Load env file based on `mode` in the current working directory.
   const env = loadEnv(mode, "./env", "");
+  const appEnv = env.ENV || mode;
 
   // Ensure base path starts with a slash
   const rootUrl = env.ROOT_URL || "";
@@ -28,6 +29,15 @@ export default defineConfig(({ mode }) => {
           ],
         },
       }),
+      {
+        name: "inject-app-config",
+        transformIndexHtml(html) {
+          return html.replace(
+            "</head>",
+            `    <script>window.appConfig={env:${JSON.stringify(appEnv)}};</script>\n  </head>`
+          );
+        },
+      },
     ],
     resolve: {
       alias: {
@@ -94,13 +104,12 @@ export default defineConfig(({ mode }) => {
     define: {
       "process.env.ROOT_URL": JSON.stringify(env.ROOT_URL || ""),
       "process.env.APIURL": JSON.stringify(env.APIURL || ""),
+      "process.env.ENV": JSON.stringify(appEnv),
       "process.env.BUILD_TIMESTAMP": JSON.stringify(
         process.env.BUILD_TIMESTAMP || ""
       ),
       global: "globalThis",
-      ...(mode === "latest" ? {} : {
-        "window.appConfig": JSON.stringify({ env: env.ENV || mode }),
-      }),
+      "window.appConfig": JSON.stringify({ env: appEnv }),
     },
     test: {
       globals: true,

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -48,14 +48,17 @@ The `build` process transpiles typescript files to javascript.
 
 Make sure to have appropriate `.env.<ENV_FILE>` file accessible (e.g., running `ENV_FILE=production pnpm start:dist` will need `env.production`). You can use the `example.env` file as a template for creating your own `env` file, just check and modify the values here if needed:
 
-- `NODE_ENV` = environment - production/development (security vs logging)
-- `DOMAIN` = identify the instance - points to the domain where the ui should be accessible (used in emails)
+- `NODE_ENV` = environment - production/development (security vs logging). Also controls the session cookie `Secure` flag (enabled when `NODE_ENV=production`, or when `HTTPS=1`).
+- `ENV` = instance identifier (e.g. `sandbox`, `staging`, `production`). Must be unique per deployment on the same domain. Used for the session cookie name (`inkvisitor.sid.<ENV>` by default) and must match the client build mode on that instance.
+- `DOMAIN` = hostname where the UI is accessible (used in emails and as the default allowed CORS origin)
 - `STATIC_PATH` = http relative path to client files served by the server, use '/' for files hosted in root path
 - `BACKUP_DIR` = directory containing the DB backup archives (mounted read-only from the `inkvisitor-backup` PVC in deployments); empty/unset disables the backups API
 - `PORT` = port which should be used for this app
-- `SECRET` = for signing short-lived download tokens
-- `SESSION_SECRET` = session cookie signing secret (defaults to `SECRET`)
+- `SECRET` = signing secret for session cookies and short-lived download tokens
 - `SESSION_MAX_AGE` = session cookie max age in milliseconds (default 30 days)
+- `SESSION_COOKIE_NAME` = optional override for the session cookie name (default `inkvisitor.sid.<ENV>`; set a unique `ENV` per instance when multiple deployments share a domain)
+- `SESSION_COOKIE_SAMESITE` = `lax` (default), `strict`, or `none`
+- `CORS_ORIGINS` = comma-separated allowed browser origins (default: derived from `DOMAIN`). Used for CORS and CSRF origin checks.
 - `SMTP_HOST` / `SMTP_PORT` = SMTP relay (e.g. Mailjet `in-v3.mailjet.com`, port `587`)
 - `SMTP_USER` / `SMTP_SECRET` = SMTP credentials (Mailjet: API key and secret key from the dashboard)
 - `MAILER_SENDER` = From address; must match a verified sender at your provider
@@ -71,9 +74,24 @@ Please refer to exported [postman collection](./postman/inkvisitor_api.postman_c
 
 The API uses HttpOnly cookie sessions stored in RethinkDB. Sign in via `POST /users/signin` with `{ "login", "password" }`; the response includes the user profile and the server sets the session cookie. Sign out via `POST /users/signout`.
 
+### Session cookies
+
+- **Name** — `inkvisitor.sid.<ENV>` by default (`SESSION_COOKIE_NAME` to override). Set a unique `ENV` per instance when several deployments share a domain so cookies do not overwrite each other.
+- **Flags** — `HttpOnly`, `SameSite` (default `lax`), `Secure` when `NODE_ENV=production` or `HTTPS=1`, path `/`.
+- **Storage** — RethinkDB session store; rolling expiry via `SESSION_MAX_AGE` (default 30 days).
+
+### CSRF protection
+
+State-changing API requests (`POST`, `PUT`, `PATCH`, `DELETE` under `/api`) require:
+
+1. The `X-InkVisitor-Client: 1` header (set automatically by the web client).
+2. An `Origin` or `Referer` header matching `DOMAIN` or `CORS_ORIGINS`.
+
+Cross-site form posts cannot set the custom header, so they cannot reuse a victim's session cookie. `SameSite=Lax` provides an additional browser-level guard.
+
 Short-lived signed `?token=` query parameters are still used for one-shot backup download URLs where a cookie cannot be sent.
 
-Tests authenticate with `getAuthenticatedAgent()` from `src/modules/testAuth.ts` (cookie jar via supertest agent).
+Tests authenticate with `getAuthenticatedAgent()` from `src/modules/testAuth.ts` (cookie jar via supertest agent). CSRF checks are skipped when `NODE_ENV=test`.
 
 ## Errors
 

--- a/packages/server/env/example.env
+++ b/packages/server/env/example.env
@@ -1,6 +1,11 @@
 # Environment - used for identyfing the environment
 NODE_ENV=test
 
+# Instance id - must be unique per deployment on the same domain (session cookie
+# name is derived from this). Must match the client build mode for that instance
+# (e.g. server ENV=sandbox + client built with pnpm build:sandbox).
+ENV=inkvisitor-development
+
 # identify the instance - ie. for emails
 DOMAIN=dissinet.cz
 
@@ -29,12 +34,17 @@ DB_NAME=inkvisitor
 DB_AUTH=''
 DB_POOL_CONNECTIONS=10
 
-# For signing short-lived download tokens and session cookies (via SESSION_SECRET fallback)
+# For signing session cookies and short-lived download tokens
 SECRET=123456789
 
 # Optional session settings
-SESSION_SECRET=
 SESSION_MAX_AGE=2592000000
+# Override cookie name (default: inkvisitor.sid.<ENV>)
+SESSION_COOKIE_NAME=
+# lax (default) | strict | none
+SESSION_COOKIE_SAMESITE=lax
+# Comma-separated allowed browser origins (default: derived from DOMAIN)
+CORS_ORIGINS=
 
 # Mails - SMTP (e.g. Mailjet: host in-v3.mailjet.com, user=api key, secret=secret key)
 SMTP_HOST=

--- a/packages/server/postman/inkvisitor_api.postman_collection.json
+++ b/packages/server/postman/inkvisitor_api.postman_collection.json
@@ -4,7 +4,7 @@
 		"name": "inkvisitor api",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
 		"_exporter_id": "4635186",
-		"description": "Authenticate with POST /api/v1/users/signin (login + password). Postman stores the inkvisitor.sid session cookie automatically for subsequent requests."
+		"description": "Authenticate with POST /api/v1/users/signin (login + password). Postman stores the session cookie automatically (default name: inkvisitor.sid.<ENV>)."
 	},
 	"item": [
 		{

--- a/packages/server/src/common/allowedOrigins.test.ts
+++ b/packages/server/src/common/allowedOrigins.test.ts
@@ -1,0 +1,34 @@
+import { getAllowedOrigins, isAllowedOrigin } from "@common/allowedOrigins";
+
+describe("allowedOrigins", () => {
+  const env = process.env;
+
+  beforeEach(() => {
+    process.env = { ...env };
+    delete process.env.CORS_ORIGINS;
+    delete process.env.DOMAIN;
+    delete process.env.NODE_ENV;
+  });
+
+  afterAll(() => {
+    process.env = env;
+  });
+
+  it("builds origins from DOMAIN", () => {
+    process.env.DOMAIN = "dissinet.cz";
+    expect(getAllowedOrigins()).toEqual(
+      expect.arrayContaining(["https://dissinet.cz", "http://dissinet.cz"])
+    );
+  });
+
+  it("strips path from DOMAIN", () => {
+    process.env.DOMAIN = "dissinet.cz/apps/inkvisitor-sandbox";
+    expect(isAllowedOrigin("https://dissinet.cz")).toBe(true);
+  });
+
+  it("builds origins from CORS_ORIGINS", () => {
+    process.env.CORS_ORIGINS = "https://a.test,http://b.test";
+    expect(isAllowedOrigin("https://a.test")).toBe(true);
+    expect(isAllowedOrigin("https://evil.test")).toBe(false);
+  });
+});

--- a/packages/server/src/common/allowedOrigins.ts
+++ b/packages/server/src/common/allowedOrigins.ts
@@ -1,0 +1,48 @@
+function normalizeOrigin(value: string): string {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return "";
+  }
+  const withScheme = trimmed.includes("://") ? trimmed : `https://${trimmed}`;
+  try {
+    return new URL(withScheme).origin;
+  } catch {
+    return "";
+  }
+}
+
+export function getAllowedOrigins(): string[] {
+  const origins = new Set<string>();
+
+  if (process.env.CORS_ORIGINS) {
+    for (const entry of process.env.CORS_ORIGINS.split(",")) {
+      const origin = normalizeOrigin(entry);
+      if (origin) {
+        origins.add(origin);
+      }
+    }
+  }
+
+  if (process.env.DOMAIN) {
+    const origin = normalizeOrigin(process.env.DOMAIN);
+    if (origin) {
+      origins.add(origin);
+      if (origin.startsWith("https://")) {
+        origins.add(origin.replace("https://", "http://"));
+      }
+    }
+  }
+
+  if (process.env.NODE_ENV === "development") {
+    origins.add("http://localhost:8000");
+    origins.add("http://127.0.0.1:8000");
+    origins.add("http://localhost:3000");
+    origins.add("http://127.0.0.1:3000");
+  }
+
+  return [...origins];
+}
+
+export function isAllowedOrigin(origin: string): boolean {
+  return getAllowedOrigins().includes(origin);
+}

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -17,6 +17,7 @@ import {
   cookieParserMiddleware,
   sessionMiddleware,
 } from "@middlewares/session";
+import { getAllowedOrigins } from "@common/allowedOrigins";
 import Document from "@models/document/document";
 
 (async () => {
@@ -57,7 +58,7 @@ import Document from "@models/document/document";
 
   const socketio = new SocketIO(httpServer, {
     cors: {
-      origin: true,
+      origin: getAllowedOrigins(),
       credentials: true,
     },
     path: "/socket.io/",

--- a/packages/server/src/middlewares/cors.ts
+++ b/packages/server/src/middlewares/cors.ts
@@ -1,0 +1,21 @@
+import { getAllowedOrigins, isAllowedOrigin } from "@common/allowedOrigins";
+import cors from "cors";
+
+export const corsMiddleware = cors({
+  origin(origin, callback) {
+    if (!origin) {
+      callback(null, true);
+      return;
+    }
+
+    if (isAllowedOrigin(origin)) {
+      callback(null, true);
+      return;
+    }
+
+    callback(new Error(`CORS origin not allowed: ${origin}`));
+  },
+  credentials: true,
+});
+
+export { getAllowedOrigins };

--- a/packages/server/src/middlewares/csrf.ts
+++ b/packages/server/src/middlewares/csrf.ts
@@ -1,0 +1,60 @@
+import { isAllowedOrigin } from "@common/allowedOrigins";
+import { PermissionDeniedError } from "@inkvisitor/shared/types/errors";
+import { NextFunction, Request, Response } from "express";
+
+export const CSRF_CLIENT_HEADER = "x-inkvisitor-client";
+
+const SAFE_METHODS = new Set(["GET", "HEAD", "OPTIONS"]);
+
+function refererOrigin(referer: string): string | undefined {
+  try {
+    return new URL(referer).origin;
+  } catch {
+    return undefined;
+  }
+}
+
+function hasTrustedOrigin(req: Request): boolean {
+  const origin = req.headers.origin;
+  if (typeof origin === "string" && isAllowedOrigin(origin)) {
+    return true;
+  }
+
+  const referer = req.headers.referer;
+  if (typeof referer === "string") {
+    const fromReferer = refererOrigin(referer);
+    if (fromReferer && isAllowedOrigin(fromReferer)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+export function csrfProtection(
+  req: Request,
+  res: Response,
+  next: NextFunction
+): void {
+  if (process.env.NODE_ENV === "test") {
+    next();
+    return;
+  }
+
+  if (SAFE_METHODS.has(req.method) || !req.path.startsWith("/api")) {
+    next();
+    return;
+  }
+
+  if (req.headers[CSRF_CLIENT_HEADER] !== "1") {
+    next(new PermissionDeniedError("invalid request"));
+    return;
+  }
+
+  if (!hasTrustedOrigin(req)) {
+    next(new PermissionDeniedError("invalid origin"));
+    return;
+  }
+
+  next();
+}

--- a/packages/server/src/middlewares/session.ts
+++ b/packages/server/src/middlewares/session.ts
@@ -11,7 +11,9 @@ const sessionSecret =
 
 export { sessionSecret };
 
-export const sessionCookieName = "inkvisitor.sid";
+export const sessionCookieName =
+  process.env.SESSION_COOKIE_NAME ||
+  `inkvisitor.sid.${process.env.ENV || "default"}`;
 
 export const sessionStore = new RethinkSessionStore(sessionPool);
 

--- a/packages/server/src/middlewares/session.ts
+++ b/packages/server/src/middlewares/session.ts
@@ -6,8 +6,14 @@ import { RethinkSessionStore } from "@service/rethinkSessionStore";
 const SESSION_MAX_AGE_MS =
   parseInt(process.env.SESSION_MAX_AGE || "", 10) || 86400000 * 30;
 
-const sessionSecret =
-  process.env.SESSION_SECRET || process.env.SECRET || "inkvisitor-dev-secret";
+const sessionSecret = process.env.SECRET || "inkvisitor-dev-secret";
+
+const sessionCookieSameSite =
+  (process.env.SESSION_COOKIE_SAMESITE as "lax" | "strict" | "none" | undefined) ||
+  "lax";
+
+const sessionCookieSecure =
+  process.env.HTTPS === "1" || process.env.NODE_ENV === "production";
 
 export { sessionSecret };
 
@@ -26,8 +32,9 @@ export const sessionMiddleware = session({
   rolling: true,
   cookie: {
     httpOnly: true,
-    secure: process.env.NODE_ENV === "production",
-    sameSite: "lax",
+    secure: sessionCookieSecure,
+    sameSite: sessionCookieSameSite,
+    path: "/",
     maxAge: SESSION_MAX_AGE_MS,
   },
 });

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -1,7 +1,8 @@
 import morgan from "morgan";
 import helmet from "helmet";
 import express, { NextFunction, Router } from "express";
-import cors from "cors";
+import { corsMiddleware } from "@middlewares/cors";
+import { csrfProtection } from "@middlewares/csrf";
 import { apiPath, apiPathOld } from "@common/constants";
 import EntitiesRouter from "@modules/entities";
 import AuditsRouter from "@modules/audits";
@@ -51,7 +52,7 @@ server.use(
   })
 );
 
-server.use(cors({ origin: true, credentials: true }));
+server.use(corsMiddleware);
 
 const staticPath = process.env.STATIC_PATH;
 if (staticPath === "/") {
@@ -93,6 +94,7 @@ server.use(headersProtectionMiddleware);
 server.use(profilerMiddleware);
 server.use(cookieParserMiddleware);
 server.use(sessionMiddleware);
+server.use(csrfProtection);
 server.use(apiPath, dbMiddleware);
 
 server.use(authenticateRequest);


### PR DESCRIPTION
Multiple InkVisitor instances on one domain were sharing a single session cookie, so logging into one would log you out of another. This restores per-instance isolation (like the old JWT localStorage keys) and tightens cookie/CSRF defaults.

- per-instance session cookie name from ENV (inkvisitor.sid.<ENV>)
- client localStorage scoped by build mode via userStorage/appEnv
- instance id baked at build time (no server index.html injection needed)
- cookie flags: HttpOnly, Secure in production, configurable SameSite
- CSRF guard on API mutations (X-InkVisitor-Client header + origin check)
- CORS/socket origin whitelist from DOMAIN or CORS_ORIGINS
- session signing uses SECRET only
- updated deployment docs and example env files
