### PR TITLE
1.5.4 improvements and fixes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,3 +18,4 @@
 - Always use theme values for colors (including black text: `theme.color["black"]`),
   font sizes, etc. Never hardcode color values — the app supports dark mode
   and hardcoded colors break it.
+- If adding icon, first check Theme/icons.ts if this or similar icon exists in our app

--- a/packages/annotator/src/lib/Annotator.ts
+++ b/packages/annotator/src/lib/Annotator.ts
@@ -138,6 +138,7 @@ export interface DrawingOptions {
   charsAtLine: number;
   color?: string; // override
   caretWidth?: number; // collapsed-caret width in device px (defaults to 1)
+  caretOpacity?: number; // collapsed-caret alpha (defaults to 1); block caret uses 0.5 so the letter under it stays readable
   caretVisible?: boolean; // blink phase: skip painting the collapsed caret when false (#3092)
   /**
    * Minimum fill width in device px for BACKGROUND spans. When set, an empty
@@ -2673,6 +2674,7 @@ export class Annotator {
         charWidth: this.charWidth,
         charsAtLine: this.text.charsAtLine,
         caretWidth: this.caretWidthDevicePx(),
+        caretOpacity: this.caretOpacityValue(),
         caretVisible: this.canvasFocused && this.caretBlink.isVisible(),
         columnToPixelX: this.drawColumnToPixelX(),
       });
@@ -2909,7 +2911,8 @@ export class Annotator {
           lineHeight: this.lineHeight,
           charWidth: this.charWidth,
           charsAtLine: this.text.charsAtLine,
-          caretWidth: this.caretWidth * this.ratio,
+          caretWidth: this.caretWidthDevicePx(),
+          caretOpacity: this.caretOpacityValue(),
           caretVisible: this.canvasFocused && this.caretBlink.isVisible(),
           columnToPixelX: this.drawColumnToPixelX(),
         });
@@ -2962,9 +2965,15 @@ export class Annotator {
    * fills the whole `charWidth` cell — already device-px so it tracks font size;
    * otherwise the fixed px width scaled by `ratio`. */
   private caretWidthDevicePx(): number {
-    return this.caretBlock && !this.proportional
-      ? this.charWidth
-      : this.caretWidth * this.ratio;
+    return this.caretBlock && !this.proportional ? this.charWidth : this.caretWidth * this.ratio;
+  }
+
+  /**
+   * Effective collapsed-caret alpha. The block caret fills the whole char cell,
+   * so it paints mostly transparent to keep the letter under it readable; thin
+   * carets stay solid (#2887). */
+  private caretOpacityValue(): number {
+    return this.caretBlock && !this.proportional ? 0.3 : 1;
   }
 
   /** Set the collapsed-caret width in CSS px (e.g. 1, 2, 3) and redraw. A fixed

--- a/packages/annotator/src/lib/Annotator.ts
+++ b/packages/annotator/src/lib/Annotator.ts
@@ -2660,6 +2660,12 @@ export class Annotator {
     // Blink only while a collapsed caret is shown and the canvas is focused.
     this.caretBlink.sync(this.cursor.hasCaret() && this.canvasFocused);
 
+    // In HIGHLIGHT mode a collapsed caret is repainted after the highlights and
+    // anchor markers below (#2887); painting it here too would stack the
+    // semi-transparent block caret to a doubled opacity, so skip the first pass.
+    const caretRepaintsOverHighlights =
+      this.text.mode === EditMode.HIGHLIGHT && !!this.onHighlightCb && !this.cursor.isSelected();
+
     if (textSegment && !this.selectionHidden) {
       const line = this.text.getLineFromPosition(textSegment);
       if (this.cursor.xLine > line.length) {
@@ -2675,7 +2681,8 @@ export class Annotator {
         charsAtLine: this.text.charsAtLine,
         caretWidth: this.caretWidthDevicePx(),
         caretOpacity: this.caretOpacityValue(),
-        caretVisible: this.canvasFocused && this.caretBlink.isVisible(),
+        caretVisible:
+          this.canvasFocused && this.caretBlink.isVisible() && !caretRepaintsOverHighlights,
         columnToPixelX: this.drawColumnToPixelX(),
       });
     }
@@ -2973,7 +2980,7 @@ export class Annotator {
    * so it paints mostly transparent to keep the letter under it readable; thin
    * carets stay solid (#2887). */
   private caretOpacityValue(): number {
-    return this.caretBlock && !this.proportional ? 0.3 : 1;
+    return this.caretBlock && !this.proportional ? 0.45 : 1;
   }
 
   /** Set the collapsed-caret width in CSS px (e.g. 1, 2, 3) and redraw. A fixed

--- a/packages/annotator/src/lib/Annotator.ts
+++ b/packages/annotator/src/lib/Annotator.ts
@@ -683,9 +683,7 @@ export class Annotator {
     // old highlight dissolves out while the new one fades in (#2835) instead of
     // swapping instantly. Same-tag re-hovers just keep fading toward 1.
     const switching =
-      tagName !== this.hoverTagName &&
-      this.hoverRegions.length > 0 &&
-      this.hoverFade.value() > 0;
+      tagName !== this.hoverTagName && this.hoverRegions.length > 0 && this.hoverFade.value() > 0;
     const previousRegions = this.hoverRegions;
 
     this.hoverTagName = tagName;
@@ -1351,10 +1349,7 @@ export class Annotator {
     this.cursor.reconcileOffsetsFromVisual(this.text);
 
     const pt = this.pointerToVisual(e.clientX, e.clientY);
-    const { offset, affinity } = this.text.offsetWithAffinityFromVisual(
-      pt.xLine,
-      pt.yLine
-    );
+    const { offset, affinity } = this.text.offsetWithAffinityFromVisual(pt.xLine, pt.yLine);
     if (offset >= 0) {
       this.cursor.stepHeadTo(this.text, offset, affinity, true);
     }
@@ -1992,23 +1987,6 @@ export class Annotator {
     const settings: SettingControl[] = [
       {
         type: "segmented",
-        label: "Cursor size",
-        options: [
-          { label: "1px", value: 1 },
-          { label: "2px", value: 2 },
-          { label: "3px", value: 3 },
-        ],
-        value: this.caretWidth,
-        onChange: (px) => this.setCaretWidth(px),
-      },
-      {
-        type: "color",
-        label: "Highlight color",
-        value: this.getHighlightColor(),
-        onChange: (hex) => this.setHighlightColor(hex),
-      },
-      {
-        type: "segmented",
         label: "Font",
         options: [
           { label: "Proportional", value: 1 },
@@ -2024,31 +2002,55 @@ export class Annotator {
 
     // Family picker only when the host supplied options (it's the proportional
     // typeface; monospace always uses the built-in monospace font, so the picker
-    // is disabled until proportional is selected).
+    // is disabled until proportional is selected). While disabled, show the
+    // default host option (e.g. Roboto) rather than the stored proportional
+    // family the user last picked.
     if (this.fontFamilyOptions.length > 0) {
+      const displayedFontFamily = this.proportional
+        ? this.proportionalFontFamily
+        : this.fontFamilyOptions[0]?.value ?? this.proportionalFontFamily;
       settings.push({
         type: "select",
         label: "Font family",
         options: this.fontFamilyOptions,
-        value: this.proportionalFontFamily,
+        value: displayedFontFamily,
         onChange: (family) => this.setFontFamily(family),
         disabled: !this.proportional,
       });
     }
 
-    settings.push({
-      type: "segmented",
-      label: "Font size",
-      options: [
-        { label: "11", value: 11 },
-        { label: "12", value: 12 },
-        { label: "13", value: 13 },
-        { label: "14", value: 14 },
-        { label: "15", value: 15 },
-      ],
-      value: this.fontSize,
-      onChange: (px) => this.setFontSize(px),
-    });
+    settings.push(
+      {
+        type: "segmented",
+        label: "Font size",
+        options: [
+          { label: "11", value: 11 },
+          { label: "12", value: 12 },
+          { label: "13", value: 13 },
+          { label: "14", value: 14 },
+          { label: "15", value: 15 },
+        ],
+        value: this.fontSize,
+        onChange: (px) => this.setFontSize(px),
+      },
+      {
+        type: "color",
+        label: "Highlight color",
+        value: this.getHighlightColor(),
+        onChange: (hex) => this.setHighlightColor(hex),
+      },
+      {
+        type: "segmented",
+        label: "Cursor size",
+        options: [
+          { label: "1px", value: 1 },
+          { label: "2px", value: 2 },
+          { label: "3px", value: 3 },
+        ],
+        value: this.caretWidth,
+        onChange: (px) => this.setCaretWidth(px),
+      }
+    );
 
     this.settingsOverlay.open(
       settings,
@@ -3001,7 +3003,7 @@ export class Annotator {
     // Font settings back to defaults (#2487).
     this.proportional = false;
     this.fontSize = DEFAULT_FONT_SIZE;
-    // Default to the first host-supplied option (e.g. "Sans (app)") so the
+    // Default to the first host-supplied option (e.g. "Roboto (app sans)") so the
     // picker shows a valid value; fall back to the generic when none supplied.
     this.proportionalFontFamily =
       this.fontFamilyOptions.length > 0 ? this.fontFamilyOptions[0].value : PROPORTIONAL_FONT;

--- a/packages/annotator/src/lib/Annotator.ts
+++ b/packages/annotator/src/lib/Annotator.ts
@@ -3284,10 +3284,33 @@ export class Annotator {
   }
 
   /**
+   * Nearest-following closing tag pairing with `openTag`: the first same-name
+   * closing tag after the opening tag's position, scanning forward across
+   * segments (the same rule as removeAnchorFromSelection). Returns undefined
+   * when the anchor is asymmetrical (no pairing close).
+   */
+  private findPairingCloseTag(openTag: Tag, tagName: string): Tag | undefined {
+    const segments = this.text.segments;
+    for (let i = openTag.segmentIndex; i < segments.length; i++) {
+      const candidates =
+        i === openTag.segmentIndex
+          ? segments[i].closingTags.filter((t) => t.position > openTag.position)
+          : segments[i].closingTags;
+      const closeTag = candidates.find((t) => t.getTagName() === tagName);
+      if (closeTag) {
+        return closeTag;
+      }
+    }
+    return undefined;
+  }
+
+  /**
    * Resolves an anchor to its opening + pairing closing {@link Tag} against the
-   * current segments, using the same exact-then-nearest matching and
-   * nearest-following-close pairing as {@link moveAnchorBoundary}. Returns null
-   * when the anchor cannot be resolved (unknown name, or asymmetrical).
+   * current segments: the opening tag by exact (segmentIndex, position) ref
+   * match, else the nearest same-name opening tag by absolute raw distance (the
+   * ref goes stale when an earlier edit shifted raw positions); the closing tag
+   * by nearest-following-close pairing ({@link findPairingCloseTag}). Returns
+   * null when the anchor cannot be resolved (unknown name, or asymmetrical).
    */
   private resolveAnchorTags(
     tagName: string,
@@ -3325,22 +3348,11 @@ export class Annotator {
       return null;
     }
 
-    const resolvedOpenTag = openTag;
-    let closeTag: Tag | undefined;
-    for (let i = resolvedOpenTag.segmentIndex; i < segments.length; i++) {
-      const candidates =
-        i === resolvedOpenTag.segmentIndex
-          ? segments[i].closingTags.filter((t) => t.position > resolvedOpenTag.position)
-          : segments[i].closingTags;
-      closeTag = candidates.find((t) => t.getTagName() === tagName);
-      if (closeTag) {
-        break;
-      }
-    }
+    const closeTag = this.findPairingCloseTag(openTag, tagName);
     if (!closeTag) {
       return null;
     }
-    return { openTag: resolvedOpenTag, closeTag };
+    return { openTag, closeTag };
   }
 
   /**
@@ -3489,56 +3501,13 @@ export class Annotator {
   ): MoveAnchorBoundaryResult {
     const segments = this.text.segments;
 
-    // Resolve the opening tag: exact ref match, else nearest same-name opening
-    // tag by absolute raw distance (the ref goes stale when an earlier edit
-    // shifted raw positions).
-    let openTag: Tag | undefined;
-    const refSegment = segments[openTagRef.segmentIndex];
-    if (refSegment) {
-      openTag = refSegment.openingTags.find(
-        (t) => t.getTagName() === tagName && t.position === openTagRef.position
-      );
-    }
-    if (!openTag) {
-      let refAbs = openTagRef.position;
-      for (let i = 0; i < Math.min(openTagRef.segmentIndex, segments.length); i++) {
-        refAbs += segments[i].raw.length + 1;
-      }
-      let bestDistance = Infinity;
-      for (const segment of segments) {
-        for (const candidate of segment.openingTags) {
-          if (candidate.getTagName() !== tagName) {
-            continue;
-          }
-          const distance = Math.abs(candidate.getAbsoluteTagPosition(segments) - refAbs);
-          if (distance < bestDistance) {
-            bestDistance = distance;
-            openTag = candidate;
-          }
-        }
-      }
-    }
-    if (!openTag) {
+    // Resolve the anchor's opening + pairing closing tag (exact-then-nearest
+    // opening match, nearest-following-close pairing - see resolveAnchorTags).
+    const resolved = this.resolveAnchorTags(tagName, openTagRef);
+    if (!resolved) {
       return { status: "not-found" };
     }
-
-    // Pairing closing tag: nearest following same-name closing tag (same rule
-    // as removeAnchorFromSelection).
-    const resolvedOpenTag = openTag;
-    let closeTag: Tag | undefined;
-    for (let i = resolvedOpenTag.segmentIndex; i < segments.length; i++) {
-      const candidates =
-        i === resolvedOpenTag.segmentIndex
-          ? segments[i].closingTags.filter((t) => t.position > resolvedOpenTag.position)
-          : segments[i].closingTags;
-      closeTag = candidates.find((t) => t.getTagName() === tagName);
-      if (closeTag) {
-        break;
-      }
-    }
-    if (!closeTag) {
-      return { status: "not-found" };
-    }
+    const { openTag: resolvedOpenTag, closeTag } = resolved;
 
     const raw = this.text.value;
     const openAbs = resolvedOpenTag.getAbsoluteTagPosition(segments);
@@ -3612,23 +3581,10 @@ export class Annotator {
         (t) => t.getTagName() === tagName && t.position === position
       );
       if (movedOpenTag) {
-        let movedCloseTag: Tag | undefined;
-        let movedCloseSegmentIndex = -1;
-        for (let i = segmentIndex; i < newSegments.length; i++) {
-          const candidates =
-            i === segmentIndex
-              ? newSegments[i].closingTags.filter((t) => t.position > movedOpenTag.position)
-              : newSegments[i].closingTags;
-          const found = candidates.find((t) => t.getTagName() === tagName);
-          if (found) {
-            movedCloseTag = found;
-            movedCloseSegmentIndex = i;
-            break;
-          }
-        }
+        const movedCloseTag = this.findPairingCloseTag(movedOpenTag, tagName);
         if (movedCloseTag) {
           const start = movedOpenSegment.findTagParsedPosition(movedOpenTag);
-          const end = newSegments[movedCloseSegmentIndex].findTagParsedPosition(movedCloseTag);
+          const end = newSegments[movedCloseTag.segmentIndex].findTagParsedPosition(movedCloseTag);
           this.cursor.selectStart = { xLine: start.x, yLine: start.y };
           this.cursor.selectEnd = { xLine: end.x, yLine: end.y };
           this.cursor.setTrueSelectionDirection();

--- a/packages/annotator/src/lib/Annotator.ts
+++ b/packages/annotator/src/lib/Annotator.ts
@@ -3941,6 +3941,24 @@ export class Annotator {
       };
 
       const collectLiteral = () => {
+        if (!isCaseSensitive) {
+          // Match on the original-case text via a case-insensitive regex so
+          // occurrence offsets stay aligned with `lineLengths`. Searching a
+          // lowercased haystack would desync offsets whenever toLowerCase()
+          // changes the UTF-16 length (e.g. İ→i̇, ẞ→ss), producing wrong
+          // highlights and corrupting the replace-all slice range.
+          const escaped = toFind.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+          const regex = new RegExp(escaped, "giu");
+          let match;
+          while ((match = regex.exec(fullText)) !== null) {
+            pushMatch(match.index, match.index + match[0].length);
+            // Avoid an infinite loop on a zero-width match.
+            if (match[0].length === 0) {
+              regex.lastIndex++;
+            }
+          }
+          return;
+        }
         let startIndex = 0;
         while (startIndex <= haystack.length) {
           const index = haystack.indexOf(normalizedTerm, startIndex);
@@ -4114,6 +4132,10 @@ export class Annotator {
   }
 
   onPasteText() {
+    // Editing is disabled in HIGHLIGHT mode; paste must not mutate the document.
+    if (this.text.mode === EditMode.HIGHLIGHT) {
+      return;
+    }
     window.navigator.clipboard
       .readText()
       .then((clipText: string) => {
@@ -4135,6 +4157,11 @@ export class Annotator {
         this.cursor.moveToOffset(this.text, pasteAt + clipText.length);
         if (this.text.value !== before.value) {
           this.recordHistory(before, false);
+          // Notify the host app so paste marks the document dirty (enables the
+          // save button), same as a typing edit.
+          if (this.onTextChangeCb) {
+            this.onTextChangeCb(this.text.value);
+          }
         }
         this.keys.scrollCursorIntoView();
 

--- a/packages/annotator/src/lib/Annotator.ts
+++ b/packages/annotator/src/lib/Annotator.ts
@@ -96,8 +96,17 @@ const linesHosts = new WeakMap<HTMLCanvasElement, Annotator>();
 // Occurrence holds exact position of a point in text
 export interface Occurrence {
   segmentIndex: number;
+  /** Visual line index (within the segment) where the match starts. */
   lineIndex: number;
+  /**
+   * Visual line index (within the segment) where the match ends. Equals
+   * {@link lineIndex} for a match that fits on one line, but differs when the
+   * match straddles a soft-wrap boundary.
+   */
+  endLineIndex: number;
+  /** Column of the match start on {@link lineIndex}. */
   start: number;
+  /** Exclusive column of the match end on {@link endLineIndex}. */
   end: number;
 }
 
@@ -3883,54 +3892,83 @@ export class Annotator {
    * @returns
    */
   search(toFind: string, isRegex: boolean = false, isCaseSensitive: boolean = true): Occurrence[] {
-    const occurrences = [];
+    const occurrences: Occurrence[] = [];
+    if (!toFind) {
+      return occurrences;
+    }
     const normalizedTerm = isCaseSensitive ? toFind : toFind.toLowerCase();
 
-    const collectLiteralOccurrences = (line: string, segmentIndex: number, lineIndex: number) => {
-      const normalizedLine = isCaseSensitive ? line : line.toLowerCase();
-      let startIndex = 0;
-
-      while (startIndex < normalizedLine.length) {
-        const index = normalizedLine.indexOf(normalizedTerm, startIndex);
-        if (index === -1) {
+    // Map a flat offset within a segment's joined display text back to a
+    // (visual line index, column) pair. Soft-wrap line breaks are not real
+    // characters, so a term straddling a wrap boundary is searched against the
+    // joined text and mapped back here — otherwise it would be split across two
+    // `lines[]` entries and never match (issue: search vs. line break).
+    const locate = (lineLengths: number[], offset: number, isEnd: boolean) => {
+      let lineIndex = 0;
+      let acc = 0;
+      while (lineIndex < lineLengths.length - 1) {
+        const lineLen = lineLengths[lineIndex];
+        // Start (inclusive) belongs to a line while offset >= its end boundary;
+        // exclusive end stays on the line while offset == the end boundary.
+        const pastLine = isEnd ? offset > acc + lineLen : offset >= acc + lineLen;
+        if (!pastLine) {
           break;
         }
-
-        occurrences.push({
-          segmentIndex,
-          lineIndex,
-          start: index,
-          end: index + toFind.length,
-        });
-
-        startIndex = index + 1;
+        acc += lineLen;
+        lineIndex++;
       }
+      return { lineIndex, col: offset - acc };
     };
 
-    for (const segmentI in this.text.segments) {
-      for (const lineI in this.text.segments[segmentI].lines) {
-        const line = this.text.segments[segmentI].lines[lineI];
+    for (let segmentIndex = 0; segmentIndex < this.text.segments.length; segmentIndex++) {
+      const lines = this.text.segments[segmentIndex].lines;
+      // Reconstruct the segment's display text: wrapping keeps the overflowing
+      // space as trailing whitespace on the previous line, so join("") is exact.
+      const fullText = lines.join("");
+      const lineLengths = lines.map((line) => line.length);
+      const haystack = isCaseSensitive ? fullText : fullText.toLowerCase();
 
-        if (isRegex) {
-          try {
-            const regexFlags = isCaseSensitive ? "gu" : "giu";
-            const regex = new RegExp(toFind, regexFlags);
-            let match;
-            while ((match = regex.exec(line)) !== null) {
-              occurrences.push({
-                segmentIndex: parseInt(segmentI),
-                lineIndex: parseInt(lineI),
-                start: match.index,
-                end: match.index + match[0].length,
-              });
-            }
-          } catch (error) {
-            // If regex is invalid, treat as literal string
-            collectLiteralOccurrences(line, parseInt(segmentI, 10), parseInt(lineI, 10));
+      const pushMatch = (matchStart: number, matchEnd: number) => {
+        const startPos = locate(lineLengths, matchStart, false);
+        const endPos = locate(lineLengths, matchEnd, true);
+        occurrences.push({
+          segmentIndex,
+          lineIndex: startPos.lineIndex,
+          endLineIndex: endPos.lineIndex,
+          start: startPos.col,
+          end: endPos.col,
+        });
+      };
+
+      const collectLiteral = () => {
+        let startIndex = 0;
+        while (startIndex <= haystack.length) {
+          const index = haystack.indexOf(normalizedTerm, startIndex);
+          if (index === -1) {
+            break;
           }
-        } else {
-          collectLiteralOccurrences(line, parseInt(segmentI, 10), parseInt(lineI, 10));
+          pushMatch(index, index + toFind.length);
+          startIndex = index + 1;
         }
+      };
+
+      if (isRegex) {
+        try {
+          const regex = new RegExp(toFind, isCaseSensitive ? "gu" : "giu");
+          let match;
+          while ((match = regex.exec(fullText)) !== null) {
+            pushMatch(match.index, match.index + match[0].length);
+            // Avoid an infinite loop on a zero-width match.
+            if (match[0].length === 0) {
+              regex.lastIndex++;
+            }
+          }
+        } catch (error) {
+          // If regex is invalid, treat as literal string
+          collectLiteral();
+        }
+      } else {
+        collectLiteral();
       }
     }
 
@@ -3942,17 +3980,19 @@ export class Annotator {
    * @param occurence
    */
   selectSearchOccurrence(occurence: Occurrence) {
-    const absY = this.text.segments[occurence.segmentIndex].lineStart + occurence.lineIndex;
+    const segment = this.text.segments[occurence.segmentIndex];
+    const absStartY = segment.lineStart + occurence.lineIndex;
+    const absEndY = segment.lineStart + occurence.endLineIndex;
     this.cursor.xLine = occurence.end;
-    this.cursor.yLine = absY;
+    this.cursor.yLine = absEndY;
 
     this.cursor.selectStart = {
       xLine: occurence.start,
-      yLine: absY,
+      yLine: absStartY,
     };
     this.cursor.selectEnd = {
       xLine: occurence.end,
-      yLine: absY,
+      yLine: absEndY,
     };
 
     this.scrollToLine(this.cursor.selectStart.yLine);

--- a/packages/annotator/src/lib/Annotator.ts
+++ b/packages/annotator/src/lib/Annotator.ts
@@ -114,6 +114,7 @@ const SETTINGS_STORAGE_KEY = "inkvisitor.annotator.settings";
 
 interface PersistedSettings {
   caretWidth?: number;
+  caretBlock?: boolean;
   highlightColor?: string;
   showFps?: boolean;
   proportional?: boolean;
@@ -288,6 +289,14 @@ export class Annotator {
 
   /** Collapsed-caret width in CSS px (scaled by ratio at draw time). */
   private caretWidth = 1;
+
+  /**
+   * Block (full char-cell) caret intent. Monospace-only: the caret spans the
+   * whole `charWidth` cell so it scales with font size. Kept as latent intent
+   * while proportional is active (the effective block gates on `!proportional`),
+   * so returning to monospace restores it. Cleared when the user picks a fixed
+   * px width. */
+  private caretBlock = false;
 
   /**
    * User-chosen selection highlight color (`#rrggbb`), or undefined to defer to
@@ -2042,13 +2051,18 @@ export class Annotator {
       {
         type: "segmented",
         label: "Cursor size",
+        // "Full" (value 0) is the block caret filling the whole char cell —
+        // monospace-only, so it's disabled while proportional font is active.
         options: [
           { label: "1px", value: 1 },
           { label: "2px", value: 2 },
           { label: "3px", value: 3 },
+          { label: "Full", value: 0, disabled: this.proportional },
         ],
-        value: this.caretWidth,
-        onChange: (px) => this.setCaretWidth(px),
+        // Block only takes effect in monospace; while proportional show the
+        // fixed px selection instead.
+        value: this.caretBlock && !this.proportional ? 0 : this.caretWidth,
+        onChange: (v) => (v === 0 ? this.setCaretBlock(true) : this.setCaretWidth(v)),
       }
     );
 
@@ -2649,7 +2663,7 @@ export class Annotator {
         lineHeight: this.lineHeight,
         charWidth: this.charWidth,
         charsAtLine: this.text.charsAtLine,
-        caretWidth: this.caretWidth * this.ratio,
+        caretWidth: this.caretWidthDevicePx(),
         caretVisible: this.canvasFocused && this.caretBlink.isVisible(),
         columnToPixelX: this.drawColumnToPixelX(),
       });
@@ -2934,9 +2948,29 @@ export class Annotator {
     return this.caretWidth;
   }
 
-  /** Set the collapsed-caret width in CSS px (e.g. 1, 2, 3) and redraw. */
+  /**
+   * Effective collapsed-caret width in device px. A block caret (monospace only)
+   * fills the whole `charWidth` cell — already device-px so it tracks font size;
+   * otherwise the fixed px width scaled by `ratio`. */
+  private caretWidthDevicePx(): number {
+    return this.caretBlock && !this.proportional
+      ? this.charWidth
+      : this.caretWidth * this.ratio;
+  }
+
+  /** Set the collapsed-caret width in CSS px (e.g. 1, 2, 3) and redraw. A fixed
+   *  px pick is a new intent, so it clears any block-caret mode. */
   setCaretWidth(px: number): void {
     this.caretWidth = Math.max(1, px);
+    this.caretBlock = false;
+    this.saveSettings();
+    this.draw();
+  }
+
+  /** Enable the block (full char-cell) caret and redraw. Monospace-only; while
+   *  proportional it stays latent until monospace is restored. */
+  setCaretBlock(on: boolean): void {
+    this.caretBlock = on;
     this.saveSettings();
     this.draw();
   }
@@ -2962,6 +2996,9 @@ export class Annotator {
 
     if (typeof parsed.caretWidth === "number") {
       this.caretWidth = Math.max(1, parsed.caretWidth);
+    }
+    if (typeof parsed.caretBlock === "boolean") {
+      this.caretBlock = parsed.caretBlock;
     }
     if (typeof parsed.highlightColor === "string") {
       this.highlightColor = parsed.highlightColor;
@@ -2994,6 +3031,7 @@ export class Annotator {
   /** Reset all persisted settings to their defaults, clear storage, and redraw. */
   resetSettings(): void {
     this.caretWidth = 1;
+    this.caretBlock = false;
     this.highlightColor = undefined;
     // Revert the highlight color to the host theme color (last setSelectStyle).
     this.cursor.style = { ...this.cursor.style, color: this.selectColor };
@@ -3028,6 +3066,7 @@ export class Annotator {
       }
       const data: PersistedSettings = {
         caretWidth: this.caretWidth,
+        caretBlock: this.caretBlock,
         highlightColor: this.highlightColor,
         showFps: this.showFps,
         proportional: this.proportional,

--- a/packages/annotator/src/lib/Highlighter.ts
+++ b/packages/annotator/src/lib/Highlighter.ts
@@ -151,12 +151,14 @@ export default class Highlighter {
       // minFillWidth keeps a thin sliver visible, like the SELECT caret (#2885).
       ctx.fillRect(xStartPx, y, width || options.minFillWidth || width, height);
     } else if (this.hlMode === "select") {
-      // A collapsed caret (width === 0) is painted solid so it stays visible on
-      // top of anchor markers / highlights; the "color" blend only tints them
-      // and the caret vanishes (#2887). Selection spans keep the blend.
+      // A collapsed caret (width === 0) is painted source-over so it stays
+      // visible on top of anchor markers / highlights; the "color" blend only
+      // tints them and the caret vanishes (#2887). Its alpha comes from
+      // caretOpacity — the block (full-width) caret paints half transparent so
+      // the letter under it stays readable. Selection spans keep the blend.
       if (width === 0) {
         ctx.globalCompositeOperation = "source-over";
-        ctx.globalAlpha = 1;
+        ctx.globalAlpha = options.caretOpacity ?? 1;
       } else {
         ctx.globalCompositeOperation = "color";
       }

--- a/packages/annotator/src/lib/SettingsOverlay.ts
+++ b/packages/annotator/src/lib/SettingsOverlay.ts
@@ -15,7 +15,9 @@ import { MenuColors, LIGHT_MENU_COLORS } from "./constants";
 export interface SegmentedSetting {
   type: "segmented";
   label: string;
-  options: { label: string; value: number }[];
+  /** A `disabled` option renders greyed and is not selectable (e.g. the block
+   *  caret "Full" segment while proportional font is active). */
+  options: { label: string; value: number; disabled?: boolean }[];
   /** Currently-selected value (must match one of `options[].value`). */
   value: number;
   onChange: (value: number) => void;
@@ -404,14 +406,18 @@ export class SettingsOverlay {
     } as Partial<CSSStyleDeclaration>);
 
     let selected = setting.value;
-    const segments: { value: number; el: HTMLElement }[] = [];
+    const segments: { value: number; el: HTMLElement; disabled: boolean }[] = [];
 
     const restyle = () => {
       for (const seg of segments) {
         const active = seg.value === selected;
         Object.assign(seg.el.style, {
           background: active ? this.colors.accent : "transparent",
-          color: active ? this.colors.accentText : this.colors.text,
+          color: seg.disabled
+            ? this.colors.disabled
+            : active
+            ? this.colors.accentText
+            : this.colors.text,
         } as Partial<CSSStyleDeclaration>);
       }
     };
@@ -421,18 +427,20 @@ export class SettingsOverlay {
       seg.textContent = opt.label;
       Object.assign(seg.style, {
         padding: "0.4rem 1rem",
-        cursor: "pointer",
+        cursor: opt.disabled ? "default" : "pointer",
         borderRadius: "3px",
         transition: "background-color 0.12s ease",
       } as Partial<CSSStyleDeclaration>);
-      seg.addEventListener("mousedown", (e) => {
-        e.preventDefault();
-        e.stopPropagation();
-        selected = opt.value;
-        restyle();
-        setting.onChange(opt.value);
-      });
-      segments.push({ value: opt.value, el: seg });
+      if (!opt.disabled) {
+        seg.addEventListener("mousedown", (e) => {
+          e.preventDefault();
+          e.stopPropagation();
+          selected = opt.value;
+          restyle();
+          setting.onChange(opt.value);
+        });
+      }
+      segments.push({ value: opt.value, el: seg, disabled: !!opt.disabled });
       group.appendChild(seg);
     }
 

--- a/packages/client/src/Theme/theme-dark.ts
+++ b/packages/client/src/Theme/theme-dark.ts
@@ -53,7 +53,7 @@ const darkTheme = {
     primaryRGBA0: "rgba(246,246,255,0)",
     success: "#9eaad7",
     explorerHeader: "#091034",
-    warning: "#e5d088",
+    warning: "#f0c862",
     danger: "#ee8fa4",
     info: "#cbbdff",
     plain: "#b5b5b5", // inverted gray 300

--- a/packages/client/src/Theme/theme.ts
+++ b/packages/client/src/Theme/theme.ts
@@ -116,7 +116,8 @@ const theme = {
 
     tooltipColor: "#fff",
     tooltipBackground: "#000",
-    tooltipNodeBackground: "#324185",
+    tooltipNodeInfoBackground: "#324185",
+    tooltipNodeWarningBackground: "#B78928",
     tooltipBoxShadow: "rgba(0, 0, 0, 0.3)",
     tooltipArrowBoxShadow: "rgba(0, 0, 0, 0.1)",
 

--- a/packages/client/src/api.tsx
+++ b/packages/client/src/api.tsx
@@ -1061,6 +1061,9 @@ class Api {
    * Returns unique entity IDs referenced by all statements
    * on the given territory (actants, actions, props, tags, etc.).
    */
+  // REMOVE: Unused endpoint, could be removed
+  // it was used to get territory actants for EntitySuggester in StatementEditor (home icon)
+  // but the identical list of entities exists in StatementEditor's territoryData
   async entityIdsInTerritory(
     territoryId: string,
     options?: IApiOptions,

--- a/packages/client/src/components/advanced/Annotator/Annotator.tsx
+++ b/packages/client/src/components/advanced/Annotator/Annotator.tsx
@@ -23,6 +23,7 @@ import {
   EditMode,
   editModeDisplayLabel,
   MoveAnchorBoundaryResult,
+  Occurrence,
   Tag,
   WarningType,
 } from "@inkvisitor/annotator/src/lib";
@@ -1392,9 +1393,9 @@ export const TextAnnotator = ({
   }, [isMenuDisplayed]);
 
   const [searchTerm, setSearchTerm] = useState<string>("");
-  const [searchOccurences, setSearchOccurences] = useState<
-    { segmentIndex: number; lineIndex: number; start: number; end: number }[] | null
-  >(null);
+  const [searchOccurences, setSearchOccurences] = useState<Occurrence[] | null>(
+    null
+  );
   const [isRegexMode, setIsRegexMode] = useState<boolean>(false);
   const [isCaseSensitiveMode, setIsCaseSensitiveMode] = useState<boolean>(false);
   const [isExtendToWholeWordMode, setIsExtendToWholeWordMode] = useState<boolean>(false);

--- a/packages/client/src/components/advanced/Annotator/Annotator.tsx
+++ b/packages/client/src/components/advanced/Annotator/Annotator.tsx
@@ -862,10 +862,10 @@ export const TextAnnotator = ({
       // proportional-font picker). The annotator owns the choice + persistence;
       // the app just supplies the candidates, defaulting to the application font.
       a.setFontFamilyOptions([
-        { label: "Sans (app)", value: '"Roboto", sans-serif' },
+        { label: "Roboto (app sans)", value: '"Roboto", sans-serif' },
         // System option hidden for now because of inconsistent anchor highlight
-        // { label: "System", value: "system-ui, sans-serif" },
-        { label: "Serif", value: "Georgia, serif" },
+        // { label: "System UI (system sans)", value: "system-ui, sans-serif" },
+        { label: "Georgia (serif)", value: "Georgia, serif" },
       ]);
     };
 

--- a/packages/client/src/components/advanced/Annotator/Annotator.tsx
+++ b/packages/client/src/components/advanced/Annotator/Annotator.tsx
@@ -1393,9 +1393,7 @@ export const TextAnnotator = ({
   }, [isMenuDisplayed]);
 
   const [searchTerm, setSearchTerm] = useState<string>("");
-  const [searchOccurences, setSearchOccurences] = useState<Occurrence[] | null>(
-    null
-  );
+  const [searchOccurences, setSearchOccurences] = useState<Occurrence[] | null>(null);
   const [isRegexMode, setIsRegexMode] = useState<boolean>(false);
   const [isCaseSensitiveMode, setIsCaseSensitiveMode] = useState<boolean>(false);
   const [isExtendToWholeWordMode, setIsExtendToWholeWordMode] = useState<boolean>(false);
@@ -1666,7 +1664,7 @@ export const TextAnnotator = ({
                   entityId={xmlMarkupAnchorHover.entityId}
                   disableTooltip={false}
                   disableDoubleClick={false}
-                  tagMaxWidth={theme.space[60]}
+                  tagMaxWidth={150}
                 />
               </div>
             </FloatingPortal>

--- a/packages/client/src/components/advanced/Annotator/AnnotatorSearchLine/AnnotatorSearchLine.tsx
+++ b/packages/client/src/components/advanced/Annotator/AnnotatorSearchLine/AnnotatorSearchLine.tsx
@@ -1,4 +1,4 @@
-import { Annotator, EditMode } from "@inkvisitor/annotator/src/lib";
+import { Annotator, EditMode, Occurrence } from "@inkvisitor/annotator/src/lib";
 import { IDocument, IResponseEntity } from "@inkvisitor/shared/types";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import api from "api";
@@ -24,14 +24,7 @@ import { StyledCheckboxWrapper } from "./AnnotatorSearchLineStyles";
 interface AnnotatorSearchLine {
   searchTerm: string;
   setSearchTerm: (searchTerm: string) => void;
-  searchOccurences:
-    | {
-        segmentIndex: number;
-        lineIndex: number;
-        start: number;
-        end: number;
-      }[]
-    | null;
+  searchOccurences: Occurrence[] | null;
   searchActiveOccurence: number;
   setSearchActiveOccurence: (searchActiveOccurence: number) => void;
   isSearchAllowed: boolean;
@@ -47,15 +40,7 @@ interface AnnotatorSearchLine {
   annotatorMode: EditMode;
   selectedText: string;
   setSearchOccurences: React.Dispatch<
-    React.SetStateAction<
-      | {
-          segmentIndex: number;
-          lineIndex: number;
-          start: number;
-          end: number;
-        }[]
-      | null
-    >
+    React.SetStateAction<Occurrence[] | null>
   >;
   isRegexMode: boolean;
   setIsRegexMode: React.Dispatch<React.SetStateAction<boolean>>;
@@ -259,7 +244,7 @@ export const AnnotatorSearchLine: React.FC<AnnotatorSearchLine> = ({
 
           // Convert occurrence to absolute coordinates
           const absLineStart = segment.lineStart + occurrence.lineIndex;
-          const absLineEnd = absLineStart;
+          const absLineEnd = segment.lineStart + occurrence.endLineIndex;
 
           // Get segment positions for start and end
           const startSegment = annotator.text.getSegmentPosition(absLineStart, occurrence.start);

--- a/packages/client/src/components/advanced/EntitySuggester/EntitySuggester.tsx
+++ b/packages/client/src/components/advanced/EntitySuggester/EntitySuggester.tsx
@@ -61,6 +61,8 @@ interface EntitySuggesterProps {
   entityCreateStatementOrder?: number;
 
   button?: React.ReactNode;
+  // rendered inside the suggester input's trailing slot (only when disableCreate)
+  rightContent?: React.ReactNode;
   preSuggestions?: IEntity[];
 
   disableCreate?: boolean;
@@ -123,6 +125,7 @@ const EntitySuggesterFull: React.FC<
   entityCreateStatementOrder,
 
   button,
+  rightContent,
   preSuggestions,
 
   disableCreate = false,
@@ -512,6 +515,7 @@ const EntitySuggesterFull: React.FC<
         alwaysShowCreateModal={alwaysShowCreateModal}
         disableWildCard={disableWildCard || allCategories.length < 2}
         button={button}
+        rightContent={rightContent}
         disableTemplateInstantiation={disableTemplateInstantiation}
         isHidden={isHidden}
         externalDroppedItem={externalDroppedItem}

--- a/packages/client/src/components/advanced/EntitySuggester/EntitySuggester.tsx
+++ b/packages/client/src/components/advanced/EntitySuggester/EntitySuggester.tsx
@@ -35,6 +35,9 @@ interface EntitySuggesterProps {
   onTyped?: (newType: string) => void;
   placeholder?: string;
   inputWidth?: number | "full";
+  // Explicit width for the suggestions dropdown, independent of the input width.
+  // Set to intentionally show a wider results list.
+  suggestionListWidth?: number;
   openDetailOnCreate?: boolean;
   // territoryId keys the cached set of entity ids already used in the territory,
   // used to render the home icon next to suggestion list items. The cache is
@@ -111,6 +114,7 @@ const EntitySuggesterFull: React.FC<
   onTyped,
   placeholder = "",
   inputWidth,
+  suggestionListWidth,
   openDetailOnCreate = false,
   territoryId,
   excludedEntityClasses = [],
@@ -504,6 +508,7 @@ const EntitySuggesterFull: React.FC<
         disableButtons={disableButtons}
         disableEnter={disableEnter}
         inputWidth={inputWidth}
+        suggestionListWidth={suggestionListWidth}
         isInsideTemplate={isInsideTemplate}
         territoryParentId={territoryParentId}
         userOptions={user.options}

--- a/packages/client/src/components/advanced/EntityTag/EntityTag.tsx
+++ b/packages/client/src/components/advanced/EntityTag/EntityTag.tsx
@@ -41,8 +41,7 @@ const EXPANSION_MARK = {
   },
   subordinate: {
     label: "sub",
-    tooltip:
-      "Surfaced via 'include subordinates' (subclass / subordinate / meronym / child T)",
+    tooltip: "Surfaced via 'include subordinates' (subclass / subordinate / meronym / child T)",
   },
 } as const;
 
@@ -58,7 +57,7 @@ interface EntityTag {
   showOnly?: "tag" | "label";
   fullWidth?: boolean;
   /** Override the label's max-width (e.g. theme.space value). */
-  tagMaxWidth?: string;
+  tagMaxWidth?: number;
   button?: ReactNode;
   /**
    * Render `button` before the elvl group (left of it), away from the unlink
@@ -196,11 +195,7 @@ const EntityTagComponent: React.FC<EntityTag> = ({
         >
           {entity.class}
         </StyledEntityTag>
-        {mark && (
-          <StyledExpansionBadge title={mark.tooltip}>
-            {mark.label}
-          </StyledExpansionBadge>
-        )}
+        {mark && <StyledExpansionBadge title={mark.tooltip}>{mark.label}</StyledExpansionBadge>}
       </StyledTagComponentWrap>
     );
   }, [entity, isEquivalent, isSubordinate]);
@@ -294,10 +289,7 @@ const EntityTagComponent: React.FC<EntityTag> = ({
       )}
       {elvlButtonGroup && (
         <StyledElvlWrapper>
-          <div
-            onMouseOver={() => setElvlHovered(true)}
-            onMouseOut={() => setElvlHovered(false)}
-          >
+          <div onMouseOver={() => setElvlHovered(true)} onMouseOut={() => setElvlHovered(false)}>
             {elvlButtonGroup}
           </div>
         </StyledElvlWrapper>

--- a/packages/client/src/components/advanced/EntityTag/EntityTagById.tsx
+++ b/packages/client/src/components/advanced/EntityTag/EntityTagById.tsx
@@ -10,7 +10,7 @@ interface EntityTagByIdProps {
   entityId: string;
   entity?: IEntity;
   fullWidth?: boolean;
-  tagMaxWidth?: string;
+  tagMaxWidth?: number;
   disableTooltip?: boolean;
   unlinkButton?: UnlinkButton | false;
   disableToast?: boolean;

--- a/packages/client/src/components/advanced/EntityTag/EntityTagStyles.tsx
+++ b/packages/client/src/components/advanced/EntityTag/EntityTagStyles.tsx
@@ -105,7 +105,7 @@ export const StyledFaStar = styled(FaStar)<StyledFaStar>`
 const getColor = (
   $invertedLabel: boolean,
   $isFavorited: boolean,
-  $isItalic: boolean
+  $isItalic: boolean,
 ): keyof ThemeColor => {
   if ($invertedLabel) {
     if ($isFavorited) {
@@ -124,7 +124,7 @@ interface StyledLabel {
   $isFavorited: boolean;
   $labelOnly?: boolean;
   $isItalic: boolean;
-  $maxWidth?: string;
+  $maxWidth?: number;
 }
 export const StyledLabel = styled.div<StyledLabel>`
   display: inline-block;
@@ -142,7 +142,7 @@ export const StyledLabel = styled.div<StyledLabel>`
     theme.color.tagBorderColor[$tagBorderColorKey]};
   border-left-style: solid;
   max-width: ${({ theme, $fullWidth, $maxWidth }) =>
-    $maxWidth ? $maxWidth : $fullWidth ? "100%" : theme.space[30]};
+    $maxWidth ? `${$maxWidth}px` : $fullWidth ? "100%" : theme.space[30]};
   font-weight: ${({ theme, $invertedLabel }) =>
     $invertedLabel ? theme.fontWeight["bold"] : theme.fontWeight["normal"]};
 `;

--- a/packages/client/src/components/basic/ButtonGroup/ButtonGroup.tsx
+++ b/packages/client/src/components/basic/ButtonGroup/ButtonGroup.tsx
@@ -21,8 +21,10 @@ export const ButtonGroup = styled.div.attrs({
   border-radius: ${({ $borderRadius, theme }) =>
     $borderRadius ? theme.borderRadius[$borderRadius] : "none"};
   overflow: hidden;
+  flex-shrink: 0;
   > button:not(:last-child),
   > span:not(:last-child) {
+    flex-shrink: 0;
     margin-right: ${({ $noGap, $smallGap }) => ($noGap ? 0 : $smallGap ? "0.25rem" : "0.5rem")};
   }
 `;

--- a/packages/client/src/components/basic/Checkbox/Checkbox.tsx
+++ b/packages/client/src/components/basic/Checkbox/Checkbox.tsx
@@ -22,8 +22,6 @@ interface Checkbox {
   // paint the checked box as a plain (white) box with an accent-coloured border
   // and check instead of the default filled "info" look (see CheckboxStyles)
   accentColor?: keyof ThemeColor;
-  // render the label bold while the checkbox is checked (e.g. the negated "NOT" edge)
-  boldLabelWhenChecked?: boolean;
   tooltipLabel?: string;
   tooltipContent?: React.ReactNode;
   tooltipPosition?: AutoPlacement | BasePlacement | VariationPlacement;
@@ -39,7 +37,6 @@ export const Checkbox: React.FC<Checkbox> = ({
   icon,
   size = 15,
   accentColor,
-  boldLabelWhenChecked = false,
   tooltipLabel,
   tooltipContent,
   iconOnly = false,
@@ -89,7 +86,7 @@ export const Checkbox: React.FC<Checkbox> = ({
             </StyledCheckboxIndicator>
           </StyledCheckboxWrapper>
           {(label || icon) && (
-            <StyledLabel onClick={handleToggle} $bold={boldLabelWhenChecked && value}>
+            <StyledLabel onClick={handleToggle}>
               {label}
               {icon}
             </StyledLabel>

--- a/packages/client/src/components/basic/Checkbox/Checkbox.tsx
+++ b/packages/client/src/components/basic/Checkbox/Checkbox.tsx
@@ -22,6 +22,8 @@ interface Checkbox {
   // paint the checked box as a plain (white) box with an accent-coloured border
   // and check instead of the default filled "info" look (see CheckboxStyles)
   accentColor?: keyof ThemeColor;
+  // render the label bold while the checkbox is checked (e.g. the negated "NOT" edge)
+  boldLabelWhenChecked?: boolean;
   tooltipLabel?: string;
   tooltipContent?: React.ReactNode;
   tooltipPosition?: AutoPlacement | BasePlacement | VariationPlacement;
@@ -37,6 +39,7 @@ export const Checkbox: React.FC<Checkbox> = ({
   icon,
   size = 15,
   accentColor,
+  boldLabelWhenChecked = false,
   tooltipLabel,
   tooltipContent,
   iconOnly = false,
@@ -86,7 +89,7 @@ export const Checkbox: React.FC<Checkbox> = ({
             </StyledCheckboxIndicator>
           </StyledCheckboxWrapper>
           {(label || icon) && (
-            <StyledLabel onClick={handleToggle}>
+            <StyledLabel onClick={handleToggle} $bold={boldLabelWhenChecked && value}>
               {label}
               {icon}
             </StyledLabel>

--- a/packages/client/src/components/basic/Checkbox/Checkbox.tsx
+++ b/packages/client/src/components/basic/Checkbox/Checkbox.tsx
@@ -9,6 +9,7 @@ import {
   StyledLabel,
 } from "./CheckboxStyles";
 import { AutoPlacement, BasePlacement, VariationPlacement } from "@popperjs/core";
+import { ThemeColor } from "Theme/theme";
 
 interface Checkbox {
   value: boolean;
@@ -18,6 +19,9 @@ interface Checkbox {
   label?: string;
   icon?: React.ReactNode;
   size?: number;
+  // paint the checked box as a plain (white) box with an accent-coloured border
+  // and check instead of the default filled "info" look (see CheckboxStyles)
+  accentColor?: keyof ThemeColor;
   tooltipLabel?: string;
   tooltipContent?: React.ReactNode;
   tooltipPosition?: AutoPlacement | BasePlacement | VariationPlacement;
@@ -32,6 +36,7 @@ export const Checkbox: React.FC<Checkbox> = ({
   label,
   icon,
   size = 15,
+  accentColor,
   tooltipLabel,
   tooltipContent,
   iconOnly = false,
@@ -70,6 +75,7 @@ export const Checkbox: React.FC<Checkbox> = ({
             <StyledCheckboxIndicator
               $checked={value || indeterminate}
               $size={size}
+              $accentColor={accentColor}
               onClick={handleToggle}
             >
               {indeterminate ? (

--- a/packages/client/src/components/basic/Checkbox/Checkbox.tsx
+++ b/packages/client/src/components/basic/Checkbox/Checkbox.tsx
@@ -9,7 +9,7 @@ import {
   StyledLabel,
 } from "./CheckboxStyles";
 import { AutoPlacement, BasePlacement, VariationPlacement } from "@popperjs/core";
-import { ThemeColor } from "Theme/theme";
+import { FlatThemeColor } from "Theme/theme";
 
 interface Checkbox {
   value: boolean;
@@ -21,7 +21,7 @@ interface Checkbox {
   size?: number;
   // paint the checked box as a plain (white) box with an accent-coloured border
   // and check instead of the default filled "info" look (see CheckboxStyles)
-  accentColor?: keyof ThemeColor;
+  accentColor?: FlatThemeColor;
   tooltipLabel?: string;
   tooltipContent?: React.ReactNode;
   tooltipPosition?: AutoPlacement | BasePlacement | VariationPlacement;

--- a/packages/client/src/components/basic/Checkbox/CheckboxStyles.tsx
+++ b/packages/client/src/components/basic/Checkbox/CheckboxStyles.tsx
@@ -28,13 +28,9 @@ export const StyledCheckboxIndicator = styled.span<StyledCheckboxIndicator>`
   flex-shrink: 0;
   width: ${({ $size }) => $size}px;
   height: ${({ $size }) => $size}px;
-  border-style: solid;
-  // the accent variant sits on a coloured bg where its white fill already
-  // defines the box, so a thin border is enough (the default filled look needs
-  // the full 2px to read)
-  border-width: ${({ $accentColor }) => ($accentColor ? "1px" : "2px")};
-  border-color: ${({ theme, $checked, $accentColor }) =>
-    $checked ? theme.color[$accentColor ?? "info"] : theme.color["gray"][400]};
+  border: 2px solid
+    ${({ theme, $checked, $accentColor }) =>
+      $checked ? theme.color[$accentColor ?? "info"] : theme.color["gray"][400]};
   border-radius: ${({ theme }) => theme.borderRadius["sm"]};
   background-color: ${({ theme, $checked, $accentColor }) =>
     $checked && !$accentColor ? theme.color["info"] : theme.color["white"]};
@@ -62,8 +58,9 @@ export const StyledCheckboxWrapper = styled.span<{ $hasLabel?: boolean }>`
   cursor: pointer;
   margin-right: ${({ $hasLabel }) => ($hasLabel ? "0.2rem" : "0")};
 `;
-export const StyledLabel = styled.label`
+export const StyledLabel = styled.label<{ $bold?: boolean }>`
   font-size: ${({ theme }) => theme.fontSize["xs"]};
+  font-weight: ${({ theme, $bold }) => ($bold ? theme.fontWeight["bold"] : "inherit")};
   margin-left: 0.2rem;
   user-select: none;
   cursor: pointer;

--- a/packages/client/src/components/basic/Checkbox/CheckboxStyles.tsx
+++ b/packages/client/src/components/basic/Checkbox/CheckboxStyles.tsx
@@ -1,4 +1,5 @@
 import styled, { css, keyframes } from "styled-components";
+import { ThemeColor } from "Theme/theme";
 
 const checkmarkPop = keyframes`
   0% { transform: scale(0); }
@@ -15,6 +16,10 @@ export const StyledCheckbox = styled.div`
 interface StyledCheckboxIndicator {
   $checked: boolean;
   $size: number;
+  // when set, the checked box keeps a plain (white) fill and paints the border
+  // and checkmark in this accent colour instead of the default filled "info" look.
+  // Used e.g. by the negated query edge so the check echoes the red edge colour.
+  $accentColor?: keyof ThemeColor;
 }
 export const StyledCheckboxIndicator = styled.span<StyledCheckboxIndicator>`
   display: inline-flex;
@@ -23,22 +28,27 @@ export const StyledCheckboxIndicator = styled.span<StyledCheckboxIndicator>`
   flex-shrink: 0;
   width: ${({ $size }) => $size}px;
   height: ${({ $size }) => $size}px;
-  border: 2px solid
-    ${({ theme, $checked }) => ($checked ? theme.color["info"] : theme.color["gray"][400])};
+  border-style: solid;
+  // the accent variant sits on a coloured bg where its white fill already
+  // defines the box, so a thin border is enough (the default filled look needs
+  // the full 2px to read)
+  border-width: ${({ $accentColor }) => ($accentColor ? "1px" : "2px")};
+  border-color: ${({ theme, $checked, $accentColor }) =>
+    $checked ? theme.color[$accentColor ?? "info"] : theme.color["gray"][400]};
   border-radius: ${({ theme }) => theme.borderRadius["sm"]};
-  background-color: ${({ theme, $checked }) =>
-    $checked ? theme.color["info"] : theme.color["white"]};
+  background-color: ${({ theme, $checked, $accentColor }) =>
+    $checked && !$accentColor ? theme.color["info"] : theme.color["white"]};
   cursor: pointer;
   /* transition:
     background-color 0.15s ease,
     border-color 0.15s ease; */
 
   &:hover {
-    border-color: ${({ theme }) => theme.color["info"]};
+    border-color: ${({ theme, $accentColor }) => theme.color[$accentColor ?? "info"]};
   }
 
   svg {
-    color: ${({ theme }) => theme.color["white"]};
+    color: ${({ theme, $accentColor }) => theme.color[$accentColor ?? "white"]};
     ${({ $checked }) =>
       $checked &&
       css`

--- a/packages/client/src/components/basic/Checkbox/CheckboxStyles.tsx
+++ b/packages/client/src/components/basic/Checkbox/CheckboxStyles.tsx
@@ -58,9 +58,8 @@ export const StyledCheckboxWrapper = styled.span<{ $hasLabel?: boolean }>`
   cursor: pointer;
   margin-right: ${({ $hasLabel }) => ($hasLabel ? "0.2rem" : "0")};
 `;
-export const StyledLabel = styled.label<{ $bold?: boolean }>`
+export const StyledLabel = styled.label`
   font-size: ${({ theme }) => theme.fontSize["xs"]};
-  font-weight: ${({ theme, $bold }) => ($bold ? theme.fontWeight["bold"] : "inherit")};
   margin-left: 0.2rem;
   user-select: none;
   cursor: pointer;

--- a/packages/client/src/components/basic/Checkbox/CheckboxStyles.tsx
+++ b/packages/client/src/components/basic/Checkbox/CheckboxStyles.tsx
@@ -1,5 +1,5 @@
 import styled, { css, keyframes } from "styled-components";
-import { ThemeColor } from "Theme/theme";
+import { FlatThemeColor } from "Theme/theme";
 
 const checkmarkPop = keyframes`
   0% { transform: scale(0); }
@@ -19,7 +19,7 @@ interface StyledCheckboxIndicator {
   // when set, the checked box keeps a plain (white) fill and paints the border
   // and checkmark in this accent colour instead of the default filled "info" look.
   // Used e.g. by the negated query edge so the check echoes the red edge colour.
-  $accentColor?: keyof ThemeColor;
+  $accentColor?: FlatThemeColor;
 }
 export const StyledCheckboxIndicator = styled.span<StyledCheckboxIndicator>`
   display: inline-flex;

--- a/packages/client/src/components/basic/IconWithTooltip/IconWithTooltip.tsx
+++ b/packages/client/src/components/basic/IconWithTooltip/IconWithTooltip.tsx
@@ -5,16 +5,20 @@ import {
 } from "@popperjs/core";
 import { Tooltip } from "components";
 import { useTheme } from "hooks";
-import React, { useState } from "react";
+import React, { ReactElement, useState } from "react";
 import { ThemeColor } from "Theme/theme";
 
 interface IconWithTooltip {
   icon: React.ReactNode;
-  tooltipLabel: string;
+  tooltipLabel?: string;
   tooltipPosition?: AutoPlacement | BasePlacement | VariationPlacement;
   color?: keyof ThemeColor;
   fullWidth?: boolean;
   tooltipText?: string;
+  // rich tooltip body, overrides tooltipText when provided
+  tooltipContent?: ReactElement[] | ReactElement;
+  // tooltip background color (defaults to Tooltip's own default)
+  tooltipColor?: keyof ThemeColor;
 }
 export const IconWithTooltip: React.FC<IconWithTooltip> = ({
   icon,
@@ -23,6 +27,8 @@ export const IconWithTooltip: React.FC<IconWithTooltip> = ({
   color = "black",
   fullWidth = false,
   tooltipText,
+  tooltipContent,
+  tooltipColor,
 }) => {
   const [referenceElement, setReferenceElement] =
     useState<HTMLDivElement | null>(null);
@@ -45,13 +51,14 @@ export const IconWithTooltip: React.FC<IconWithTooltip> = ({
       >
         {icon}
       </div>
-      {tooltipLabel && (
+      {(tooltipLabel || tooltipText || tooltipContent) && (
         <Tooltip
           label={tooltipLabel}
           visible={showTooltip}
           referenceElement={referenceElement}
           position={tooltipPosition}
-          content={<p>{tooltipText}</p>}
+          content={tooltipContent ?? (tooltipText ? <p>{tooltipText}</p> : undefined)}
+          color={tooltipColor}
         />
       )}
     </>

--- a/packages/client/src/components/basic/Suggester/Suggester.tsx
+++ b/packages/client/src/components/basic/Suggester/Suggester.tsx
@@ -345,9 +345,17 @@ export const Suggester: React.FC<Suggester> = ({
   // separate trailing segment. Reserve its footprint in the input width so the
   // typing area stays as roomy as before and the suggester keeps its overall size.
   const CREATE_BUTTON_WIDTH = 25;
+  // The category dropdown is narrower when only one class is available (26 vs 33,
+  // see its width prop below), so single-class suggesters would end up narrower
+  // overall than multi-class ones for the same inputWidth. Add this back to the
+  // input width in the single-class case so the overall width stays consistent
+  // regardless of class count. Finetune this value.
+  const SINGLE_CLASS_WIDTH_COMPENSATION = 7;
   const effectiveInputWidth =
-    typeof inputWidth === "number" && !disableCreate
-      ? inputWidth + CREATE_BUTTON_WIDTH
+    typeof inputWidth === "number"
+      ? inputWidth +
+        (disableCreate ? 0 : CREATE_BUTTON_WIDTH) +
+        (categories.length > 1 ? 0 : SINGLE_CLASS_WIDTH_COMPENSATION)
       : inputWidth;
 
   return (

--- a/packages/client/src/components/basic/Suggester/Suggester.tsx
+++ b/packages/client/src/components/basic/Suggester/Suggester.tsx
@@ -76,6 +76,9 @@ interface Suggester {
   onConsumeExternalDrop?: () => void;
   onEmptyAddButtonClick?: () => void;
   clearableInput?: boolean;
+  // rendered inside the input's trailing slot (only when disableCreate is set,
+  // where the create button would otherwise sit)
+  rightContent?: React.ReactNode;
 }
 
 export const Suggester: React.FC<Suggester> = ({
@@ -121,6 +124,7 @@ export const Suggester: React.FC<Suggester> = ({
   onConsumeExternalDrop,
   onEmptyAddButtonClick,
   clearableInput = true,
+  rightContent,
 }) => {
   const [selected, setSelected] = useState(-1);
   const [isFocused, setIsFocused] = useState(false);
@@ -414,6 +418,8 @@ export const Suggester: React.FC<Suggester> = ({
                     }}
                     disabled={disabled}
                   />
+                ) : rightContent ? (
+                  rightContent
                 ) : (
                   button && button
                 )

--- a/packages/client/src/components/basic/Suggester/Suggester.tsx
+++ b/packages/client/src/components/basic/Suggester/Suggester.tsx
@@ -41,6 +41,9 @@ interface Suggester {
   categories: EntitySingleDropdownItem[]; // all possible categories
   disabled?: boolean; // todo not implemented yet
   inputWidth?: number | "full";
+  // Explicit width for the suggestions dropdown. When unset the list matches the
+  // measured input width; set it to intentionally show a wider results list.
+  suggestionListWidth?: number;
   disableCreate?: boolean;
   disableButtons?: boolean;
   isFetching?: boolean;
@@ -90,6 +93,7 @@ export const Suggester: React.FC<Suggester> = ({
   categories,
   disabled,
   inputWidth = 100,
+  suggestionListWidth,
   disableCreate = false,
   disableButtons = false,
 
@@ -151,6 +155,10 @@ export const Suggester: React.FC<Suggester> = ({
       setResultWidth(width);
     }
   }, [isFocused]);
+
+  // Explicit override wins over the measured input width so the results list can
+  // intentionally be wider than the input.
+  const effectiveResultWidth = suggestionListWidth ?? resultWidth;
 
   const onTypeFn = (newType: string) => {
     setSelected(-1);
@@ -450,7 +458,7 @@ export const Suggester: React.FC<Suggester> = ({
             >
               {suggestions.length || (isFetching && isFocused) ? (
                 <>
-                  <StyledRelativePosition $width={resultWidth}>
+                  <StyledRelativePosition $width={effectiveResultWidth}>
                     {renderEntitySuggestions(suggestions)}
                     <Loader size={30} show={isFetching} />
                   </StyledRelativePosition>
@@ -469,7 +477,7 @@ export const Suggester: React.FC<Suggester> = ({
               {/* PRE-SUGGESTIONS */}
               {preSuggestions && preSuggestions.length > 0 && typed.length === 0 ? (
                 <>
-                  <StyledRelativePosition $width={resultWidth}>
+                  <StyledRelativePosition $width={effectiveResultWidth}>
                     {renderEntitySuggestions(preSuggestions)}
                     <Loader size={30} show={isFetching} />
                   </StyledRelativePosition>

--- a/packages/client/src/hooks/useAnnotatorSearch.tsx
+++ b/packages/client/src/hooks/useAnnotatorSearch.tsx
@@ -78,15 +78,7 @@ interface UseAnnotatorSearchParams {
   isCaseSensitiveMode: boolean;
   annotatorMode: EditMode;
   setSearchOccurences: React.Dispatch<
-    React.SetStateAction<
-      | {
-          segmentIndex: number;
-          lineIndex: number;
-          start: number;
-          end: number;
-        }[]
-      | null
-    >
+    React.SetStateAction<Occurrence[] | null>
   >;
   setSearchActiveOccurence: React.Dispatch<React.SetStateAction<number>>;
   setSelectedText: React.Dispatch<React.SetStateAction<string>>;

--- a/packages/client/src/pages/Main/containers/EntityDetailBox/EntityDetail/EntityDetailFormSection/EntityDetailFormSection.tsx
+++ b/packages/client/src/pages/Main/containers/EntityDetailBox/EntityDetail/EntityDetailFormSection/EntityDetailFormSection.tsx
@@ -352,7 +352,12 @@ export const EntityDetailFormSection: React.FC<EntityDetailFormSection> = ({
             <StyledDetailContentRow>
               <StyledDetailContentRowLabel>Territory</StyledDetailContentRowLabel>
               <StyledDetailContentRowValue>
-                <EntityTag entity={entity.entities[entity.data.territory?.territoryId]} />
+                <div style={{ display: "grid" }}>
+                  <EntityTag
+                    fullWidth
+                    entity={entity.entities[entity.data.territory?.territoryId]}
+                  />
+                </div>
               </StyledDetailContentRowValue>
             </StyledDetailContentRow>
           )}

--- a/packages/client/src/pages/Main/containers/EntityDetailBox/EntityDetail/EntityDetailHeaderRow/EntityDetailHeaderRow.tsx
+++ b/packages/client/src/pages/Main/containers/EntityDetailBox/EntityDetail/EntityDetailHeaderRow/EntityDetailHeaderRow.tsx
@@ -76,7 +76,7 @@ export const EntityDetailHeaderRow: React.FC<EntityDetailHeaderRow> = ({
         newInstance = await InstTemplate(
           entity,
           getStoredUserRole() as UserEnums.Role,
-          territoryParentId
+          territoryParentId,
         );
         setShowAddParentModal(false);
       } else {
@@ -109,7 +109,7 @@ export const EntityDetailHeaderRow: React.FC<EntityDetailHeaderRow> = ({
         <StyledTagWrap>
           <EntityTag entity={entity} fullWidth />
         </StyledTagWrap>
-        <ButtonGroup style={{ height: "2.25rem" }}>
+        <ButtonGroup $height={22.5}>
           {userCanEdit && (
             <Button
               key="delete-entity"
@@ -240,7 +240,7 @@ export const EntityDetailHeaderRow: React.FC<EntityDetailHeaderRow> = ({
               inverted
               onClick={async () => {
                 await navigator.clipboard.writeText(
-                  `${window.location.protocol}//${window.location.host}${window.location.pathname}#selectedDetail=${entity.id}&detail=${entity.id}`
+                  `${window.location.protocol}//${window.location.host}${window.location.pathname}#selectedDetail=${entity.id}&detail=${entity.id}`,
                 );
                 toast.info("Link to detail copied to clipboard");
               }}

--- a/packages/client/src/pages/Query/Explorer/ExplorerBox.tsx
+++ b/packages/client/src/pages/Query/Explorer/ExplorerBox.tsx
@@ -122,6 +122,7 @@ export const ExplorerBox: React.FC<ExplorerBoxProps> = ({
               isQueryFetching={isQueryFetching}
               isRequestEmpty={isRequestEmpty}
               isSearchPending={isSearchPending}
+              stableSignature={stableSignature}
               queryError={queryError}
               height={contentHeight}
               getCachedEntity={getCachedEntity}

--- a/packages/client/src/pages/Query/Explorer/ExplorerTable/ExplorerTable.tsx
+++ b/packages/client/src/pages/Query/Explorer/ExplorerTable/ExplorerTable.tsx
@@ -112,14 +112,17 @@ export const ExplorerTable: React.FC<ExplorerTable> = ({
   // fetches and the render falls back to `lastData` — the old, now-irrelevant
   // rows would flash until the fetch resolves. Scroll pagination keeps the same
   // stableSignature, so it still reuses lastData to avoid flicker.
+  //
+  // Done during render (not in an effect) so the clear happens before paint:
+  // an effect fires after commit, letting the stale rows flash for one frame.
+  // Setting state during render makes React discard this render and re-render
+  // synchronously with the cleared state, so nothing stale is ever committed.
   const prevStableSignatureRef = useRef(stableSignature);
-  useEffect(() => {
-    if (prevStableSignatureRef.current !== stableSignature) {
-      prevStableSignatureRef.current = stableSignature;
-      setLastData(undefined);
-      setTotal(0);
-    }
-  }, [stableSignature]);
+  if (prevStableSignatureRef.current !== stableSignature) {
+    prevStableSignatureRef.current = stableSignature;
+    setLastData(undefined);
+    setTotal(0);
+  }
 
   const [rowFocused, setRowFocused] = useState<number>(-1);
   // Keep offset/limit for the data currently rendered to avoid flashing incorrect rows

--- a/packages/client/src/pages/Query/Explorer/ExplorerTable/ExplorerTable.tsx
+++ b/packages/client/src/pages/Query/Explorer/ExplorerTable/ExplorerTable.tsx
@@ -49,6 +49,12 @@ interface ExplorerTable {
   /** True when criteria are set but the search has not been run yet. */
   isSearchPending?: boolean;
   queryError: Error | null;
+  /**
+   * Identity of the current query (excludes offset/limit). Changes on a new
+   * search/filter/sort/view but not on scroll pagination — used to drop stale
+   * results instead of flashing them while the new query is fetching.
+   */
+  stableSignature?: string;
   height: number;
   getCachedEntity?: (rowIndex: number) => IResponseQueryEntity | undefined;
   onOpenEntityInDetail?: (entityId: string) => void;
@@ -69,6 +75,7 @@ export const ExplorerTable: React.FC<ExplorerTable> = ({
   isQueryFetching,
   isRequestEmpty,
   isSearchPending = false,
+  stableSignature,
   getCachedEntity,
   height: heightBox,
   onOpenEntityInDetail,
@@ -99,6 +106,20 @@ export const ExplorerTable: React.FC<ExplorerTable> = ({
   const columns = state.view.mode === Explore.EViewMode.Table ? state.view.columns : [];
 
   const [total, setTotal] = useState(0);
+
+  // Drop stale results the moment the query identity changes (new search /
+  // filter / sort / view). Without this, `data` is undefined while the new query
+  // fetches and the render falls back to `lastData` — the old, now-irrelevant
+  // rows would flash until the fetch resolves. Scroll pagination keeps the same
+  // stableSignature, so it still reuses lastData to avoid flicker.
+  const prevStableSignatureRef = useRef(stableSignature);
+  useEffect(() => {
+    if (prevStableSignatureRef.current !== stableSignature) {
+      prevStableSignatureRef.current = stableSignature;
+      setLastData(undefined);
+      setTotal(0);
+    }
+  }, [stableSignature]);
 
   const [rowFocused, setRowFocused] = useState<number>(-1);
   // Keep offset/limit for the data currently rendered to avoid flashing incorrect rows

--- a/packages/client/src/pages/Query/Query/components/QueryGridEdge.tsx
+++ b/packages/client/src/pages/Query/Query/components/QueryGridEdge.tsx
@@ -106,6 +106,9 @@ export const QueryGridEdge: React.FC<QueryGridEdgeProps> = ({
             key={`${edge.id}-not-${edge.logic}`}
             label="NOT"
             value={isNegative}
+            // neutral white box + dark check, reads as a control resting on the
+            // red negated edge rather than competing with it
+            accentColor="primary"
             tooltipLabel="negate this condition (find entities that do NOT match)"
             onChangeFn={(checked) => {
               const newLogic = checked ? Query.EdgeLogic.Negative : Query.EdgeLogic.Positive;

--- a/packages/client/src/pages/Query/Query/components/QueryGridEdge.tsx
+++ b/packages/client/src/pages/Query/Query/components/QueryGridEdge.tsx
@@ -109,8 +109,6 @@ export const QueryGridEdge: React.FC<QueryGridEdgeProps> = ({
             // neutral white box + dark check, reads as a control resting on the
             // red negated edge rather than competing with it
             accentColor="primary"
-            // bold the "NOT" label while the condition is negated
-            boldLabelWhenChecked
             tooltipLabel="negate this condition (find entities that do NOT match)"
             onChangeFn={(checked) => {
               const newLogic = checked ? Query.EdgeLogic.Negative : Query.EdgeLogic.Positive;

--- a/packages/client/src/pages/Query/Query/components/QueryGridEdge.tsx
+++ b/packages/client/src/pages/Query/Query/components/QueryGridEdge.tsx
@@ -109,6 +109,8 @@ export const QueryGridEdge: React.FC<QueryGridEdgeProps> = ({
             // neutral white box + dark check, reads as a control resting on the
             // red negated edge rather than competing with it
             accentColor="primary"
+            // bold the "NOT" label while the condition is negated
+            boldLabelWhenChecked
             tooltipLabel="negate this condition (find entities that do NOT match)"
             onChangeFn={(checked) => {
               const newLogic = checked ? Query.EdgeLogic.Negative : Query.EdgeLogic.Positive;

--- a/packages/client/src/pages/Query/Query/components/QueryGridNode.tsx
+++ b/packages/client/src/pages/Query/Query/components/QueryGridNode.tsx
@@ -1,14 +1,14 @@
 import { useQuery } from "@tanstack/react-query";
-import React, { useMemo, useRef, useState } from "react";
-import { FaPlus } from "react-icons/fa";
-import { IcoTrash } from "Theme/icons";
+import React, { useMemo } from "react";
+import { FaPlus, FaRegQuestionCircle } from "react-icons/fa";
+import { IcoQuestion, IcoTrash } from "Theme/icons";
 
 import { entitiesDict } from "@inkvisitor/shared/dictionaries";
 import { classesAll } from "@inkvisitor/shared/dictionaries/entity";
 import { EntityEnums } from "@inkvisitor/shared/enums";
 import { Query } from "@inkvisitor/shared/types/query";
 import api from "api";
-import { Button, Checkbox, SwitchGroup, Tooltip } from "components";
+import { Button, Checkbox, IconWithTooltip, SwitchGroup } from "components";
 import Dropdown, { EntitySuggester, EntityTag } from "components/advanced";
 
 import { getRelationConstrainedCategoryTypes } from "../../utils";
@@ -20,6 +20,8 @@ import {
   StyledNodeMainRow,
   StyledNodeTypeSelect,
   StyledParallelOperator,
+  StyledTooltipList,
+  StyledTooltipListItem,
 } from "./QueryStyles";
 import { useTheme } from "styled-components";
 
@@ -51,9 +53,6 @@ export const QueryGridNode: React.FC<QueryGridNodeProps> = ({
   const theme = useTheme();
   const isValid = problems.length === 0;
 
-  const [nodeHovered, setNodeHovered] = useState(false);
-  const nodeRef = useRef<HTMLDivElement>(null);
-
   const nodeTypeOptions = Object.values(Query.NodeType).map((type) => ({
     value: type,
     label: type.toString()[0],
@@ -61,6 +60,25 @@ export const QueryGridNode: React.FC<QueryGridNodeProps> = ({
   }));
 
   const edgeType = edge?.type;
+  const edgeLabel = edgeType ? Query.EdgeTypeLabels[edgeType] : "related";
+
+  // edges whose target entity is mandatory: with an empty picker the backend
+  // matches nothing (membership is only meaningful relative to a specific
+  // territory/statement), so the generic "empty = any" hint does not apply -
+  // these get a "requires a target entity" note instead. Mirrors the
+  // `if (!id) matches nothing` guards in server/src/service/query/edge.ts.
+  const edgeRequiresTarget =
+    !!edgeType &&
+    (
+      [
+        Query.EdgeType["IS:"],
+        Query.EdgeType["I_IS:"],
+        Query.EdgeType["SUT:"],
+        Query.EdgeType["SUT:C"],
+        Query.EdgeType["EUT:"],
+        Query.EdgeType["EUT:C"],
+      ] as Query.EdgeType[]
+    ).includes(edgeType);
 
   const nodeParams = edgeType ? Query.EdgeTypeTargetNodeParams[edgeType] : {};
 
@@ -80,6 +98,21 @@ export const QueryGridNode: React.FC<QueryGridNodeProps> = ({
     }
     return paramEntityId.allowedClasses.length === 0 ? classesAll : paramEntityId.allowedClasses;
   }, [paramEntityId, relationConstrainedCategoryTypes]);
+
+  // class label shown in the empty-suggester hint, e.g. "Concept". The class
+  // picked in the suggester is only written back to node.params.entityClasses
+  // when the edge also has an entityClass param; for pure entityId edges it
+  // stays empty, so fall back to the picker's allowed classes
+  // (entityIdCategoryTypes) - the same set the suggester offers. Only rendered
+  // when it narrows to a single class; multiple/all classes stay generic ("entity").
+  const selectedClassLabels =
+    node.params.entityClasses && node.params.entityClasses.length > 0
+      ? node.params.entityClasses
+          .map((c) => entitiesDict.find((e) => e.value === c)?.label ?? c)
+          .join(", ")
+      : entityIdCategoryTypes.length === 1
+        ? entitiesDict.find((e) => e.value === entityIdCategoryTypes[0])?.label ?? ""
+        : "";
 
   const isRelationEntityPickerDisabled =
     relationConstrainedCategoryTypes !== null && relationConstrainedCategoryTypes.length === 0;
@@ -166,44 +199,11 @@ export const QueryGridNode: React.FC<QueryGridNodeProps> = ({
       )}
       <StyledNodeMainRow>
         <StyledGraphNode
-          ref={nodeRef}
-          onMouseEnter={() => setNodeHovered(true)}
-          onMouseLeave={() => setNodeHovered(false)}
           style={{
             backgroundColor: nodeColor,
             border: `3px solid ${nodeBorder}`,
           }}
         >
-          {!isRoot && paramEntityId && (
-            <Tooltip
-              visible={nodeHovered}
-              referenceElement={nodeRef.current}
-              content={
-                paramEntityClass ? (
-                  <>
-                    <p>
-                      [edge type] with empty suggester entity = any entity of selected class (select
-                      * for all classes).
-                    </p>
-                    <p>
-                      NOT [edge type] with empty suggester entity = not has [edge type] entity
-                      empty.
-                    </p>
-                  </>
-                ) : (
-                  <>
-                    <p>[edge type] with empty suggester entity = any entity.</p>
-                    <p>
-                      NOT [edge type] with empty suggester entity = not has [edge type] entity
-                      empty.
-                    </p>
-                  </>
-                )
-              }
-              position="top"
-              color="tooltipNodeBackground"
-            />
-          )}
           {/* <StyledNodeTypeSelect>
           <Dropdown.Single.Basic
             options={nodeTypeOptions}
@@ -264,6 +264,7 @@ export const QueryGridNode: React.FC<QueryGridNodeProps> = ({
               {isRoot === false &&
                 (dataEntity !== undefined ? (
                   <EntityTag
+                    tagMaxWidth={200}
                     entity={dataEntity}
                     onDoubleClick={() => onOpenEntityInDetail?.(dataEntity.id)}
                     unlinkButton={{
@@ -280,7 +281,7 @@ export const QueryGridNode: React.FC<QueryGridNodeProps> = ({
                   />
                 ) : (
                   <EntitySuggester
-                    inputWidth={100}
+                    inputWidth={212}
                     categoryTypes={entityIdCategoryTypes}
                     placeholder="entity"
                     disableCreate
@@ -314,6 +315,32 @@ export const QueryGridNode: React.FC<QueryGridNodeProps> = ({
                         },
                       });
                     }}
+                    rightContent={
+                      <IconWithTooltip
+                        color="success"
+                        icon={<IcoQuestion size={11} />}
+                        tooltipPosition="top"
+                        tooltipColor="tooltipNodeBackground"
+                        tooltipLabel="Empty Entity Suggester"
+                        tooltipContent={
+                          edgeRequiresTarget ? (
+                            <p>This edge requires a target entity.</p>
+                          ) : (
+                            <StyledTooltipList>
+                              <StyledTooltipListItem>
+                                <b>Empty</b> → matches any {selectedClassLabels || "entity"} that
+                                has the "{edgeLabel}" relation
+                                {!selectedClassLabels && paramEntityClass && "; * = all classes"}
+                              </StyledTooltipListItem>
+                              <StyledTooltipListItem>
+                                <b>Empty + NOT</b> → matches nodes that have no "{edgeLabel}"
+                                relation
+                              </StyledTooltipListItem>
+                            </StyledTooltipList>
+                          )
+                        }
+                      />
+                    }
                   />
                 ))}
             </div>

--- a/packages/client/src/pages/Query/Query/components/QueryGridNode.tsx
+++ b/packages/client/src/pages/Query/Query/components/QueryGridNode.tsx
@@ -277,6 +277,10 @@ export const QueryGridNode: React.FC<QueryGridNodeProps> = ({
                   />
                 ) : (
                   <EntitySuggester
+                    // remount on edge type switch so the category re-inits to
+                    // entityClasses[0] instead of preserving the internal
+                    // selection from the previous edge
+                    key={edgeType}
                     inputWidth={212}
                     suggestionListWidth={320}
                     categoryTypes={entityIdCategoryTypes}

--- a/packages/client/src/pages/Query/Query/components/QueryGridNode.tsx
+++ b/packages/client/src/pages/Query/Query/components/QueryGridNode.tsx
@@ -335,9 +335,9 @@ export const QueryGridNode: React.FC<QueryGridNodeProps> = ({
                           ) : (
                             <StyledTooltipList>
                               <StyledTooltipListItem>
-                                <b>Empty</b> → matches any {selectedClassLabels || "entity"} that
-                                has the "{edgeLabel}" relation
-                                {!selectedClassLabels && paramEntityClass && "; * = all classes"}
+                                <b>Empty</b> → matches any entity that has the "{edgeLabel}"
+                                relation{" "}
+                                {(selectedClassLabels && `of class ${selectedClassLabels}`) || ""}
                               </StyledTooltipListItem>
                               <StyledTooltipListItem>
                                 <b>Empty + NOT</b> → matches nodes that have no "{edgeLabel}"

--- a/packages/client/src/pages/Query/Query/components/QueryGridNode.tsx
+++ b/packages/client/src/pages/Query/Query/components/QueryGridNode.tsx
@@ -99,20 +99,16 @@ export const QueryGridNode: React.FC<QueryGridNodeProps> = ({
     return paramEntityId.allowedClasses.length === 0 ? classesAll : paramEntityId.allowedClasses;
   }, [paramEntityId, relationConstrainedCategoryTypes]);
 
-  // class label shown in the empty-suggester hint, e.g. "Concept". The class
-  // picked in the suggester is only written back to node.params.entityClasses
-  // when the edge also has an entityClass param; for pure entityId edges it
-  // stays empty, so fall back to the picker's allowed classes
-  // (entityIdCategoryTypes) - the same set the suggester offers. Only rendered
-  // when it narrows to a single class; multiple/all classes stay generic ("entity").
+  // class label shown in the empty-suggester hint, e.g. "Concept". Only shown for
+  // classes the user actively picked in the suggester (written back to
+  // node.params.entityClasses on entityClass edges). When the suggester offers a
+  // single forced option the class is obvious from the picker itself, so no hint.
   const selectedClassLabels =
     node.params.entityClasses && node.params.entityClasses.length > 0
       ? node.params.entityClasses
           .map((c) => entitiesDict.find((e) => e.value === c)?.label ?? c)
           .join(", ")
-      : entityIdCategoryTypes.length === 1
-        ? (entitiesDict.find((e) => e.value === entityIdCategoryTypes[0])?.label ?? "")
-        : "";
+      : "";
 
   const isRelationEntityPickerDisabled =
     relationConstrainedCategoryTypes !== null && relationConstrainedCategoryTypes.length === 0;

--- a/packages/client/src/pages/Query/Query/components/QueryGridNode.tsx
+++ b/packages/client/src/pages/Query/Query/components/QueryGridNode.tsx
@@ -1,7 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 import React, { useMemo } from "react";
 import { FaPlus, FaRegQuestionCircle } from "react-icons/fa";
-import { IcoQuestion, IcoTrash } from "Theme/icons";
+import { IcoQuestion, IcoTrash, IcoWarning } from "Theme/icons";
 
 import { entitiesDict } from "@inkvisitor/shared/dictionaries";
 import { classesAll } from "@inkvisitor/shared/dictionaries/entity";
@@ -318,10 +318,16 @@ export const QueryGridNode: React.FC<QueryGridNodeProps> = ({
                     }}
                     rightContent={
                       <IconWithTooltip
-                        color="success"
-                        icon={<IcoQuestion size={11} />}
+                        color={edgeRequiresTarget ? "warning" : "success"}
+                        icon={
+                          edgeRequiresTarget ? <IcoWarning size={12} /> : <IcoQuestion size={11} />
+                        }
                         tooltipPosition="top"
-                        tooltipColor="tooltipNodeBackground"
+                        tooltipColor={
+                          edgeRequiresTarget
+                            ? "tooltipNodeWarningBackground"
+                            : "tooltipNodeInfoBackground"
+                        }
                         tooltipLabel="Empty Entity Suggester"
                         tooltipContent={
                           edgeRequiresTarget ? (

--- a/packages/client/src/pages/Query/Query/components/QueryGridNode.tsx
+++ b/packages/client/src/pages/Query/Query/components/QueryGridNode.tsx
@@ -111,7 +111,7 @@ export const QueryGridNode: React.FC<QueryGridNodeProps> = ({
           .map((c) => entitiesDict.find((e) => e.value === c)?.label ?? c)
           .join(", ")
       : entityIdCategoryTypes.length === 1
-        ? entitiesDict.find((e) => e.value === entityIdCategoryTypes[0])?.label ?? ""
+        ? (entitiesDict.find((e) => e.value === entityIdCategoryTypes[0])?.label ?? "")
         : "";
 
   const isRelationEntityPickerDisabled =

--- a/packages/client/src/pages/Query/Query/components/QueryGridNode.tsx
+++ b/packages/client/src/pages/Query/Query/components/QueryGridNode.tsx
@@ -282,6 +282,7 @@ export const QueryGridNode: React.FC<QueryGridNodeProps> = ({
                 ) : (
                   <EntitySuggester
                     inputWidth={212}
+                    suggestionListWidth={320}
                     categoryTypes={entityIdCategoryTypes}
                     placeholder="entity"
                     disableCreate

--- a/packages/client/src/pages/Query/Query/components/QueryStyles.tsx
+++ b/packages/client/src/pages/Query/Query/components/QueryStyles.tsx
@@ -87,3 +87,18 @@ export const StyledEdgeBox = styled.div<{ $color: string }>`
   padding-left: ${({ theme }) => theme.space[2]};
   margin-top: 10px;
 `;
+
+export const StyledTooltipList = styled.ul`
+  margin: 0;
+  padding-left: ${({ theme }) => theme.space[4]};
+  display: flex;
+  flex-direction: column;
+  gap: ${({ theme }) => theme.space[2]};
+  list-style-type: disc;
+`;
+
+export const StyledTooltipListItem = styled.li`
+  b {
+    font-weight: ${({ theme }) => theme.fontWeight["bold"]};
+  }
+`;

--- a/packages/client/src/pages/Query/Query/state.ts
+++ b/packages/client/src/pages/Query/Query/state.ts
@@ -122,11 +122,21 @@ const queryReducer = (state: Query.INode, action: QueryAction) => {
       }
       edgeToUpdate.type = newType;
 
-      // the child node's params are edge-type specific; drop the ones the new
-      // edge type does not accept so stale class/entity filters (and their
-      // tooltip hints) don't linger after a type switch
+      // the child node's params are edge-type specific. On a type switch, drop
+      // the params the new edge type does not accept so stale entity filters
+      // don't linger. For edges that respect an entityClass, seed the picker's
+      // default class (the first allowed, else the first of all classes) so the
+      // class filter and its tooltip hint are populated immediately on switch,
+      // matching what the suggester shows - instead of staying empty until the
+      // user picks a class different from the default.
       const newTargetParams = Query.EdgeTypeTargetNodeParams[newType] ?? {};
-      if (!newTargetParams.entityClass) {
+      if (newTargetParams.entityClass) {
+        if (!edgeToUpdate.node.params.entityClasses?.length) {
+          const allowed: EntityEnums.Class[] = newTargetParams.entityClass.allowedClasses ?? [];
+          const defaultClasses = allowed.length ? allowed : classesAll;
+          edgeToUpdate.node.params.entityClasses = [defaultClasses[0]];
+        }
+      } else {
         edgeToUpdate.node.params.entityClasses = undefined;
       }
       if (!newTargetParams.entityId) {

--- a/packages/client/src/pages/Query/Query/state.ts
+++ b/packages/client/src/pages/Query/Query/state.ts
@@ -124,18 +124,16 @@ const queryReducer = (state: Query.INode, action: QueryAction) => {
 
       // the child node's params are edge-type specific. On a type switch, drop
       // the params the new edge type does not accept so stale entity filters
-      // don't linger. For edges that respect an entityClass, seed the picker's
-      // default class (the first allowed, else the first of all classes) so the
-      // class filter and its tooltip hint are populated immediately on switch,
-      // matching what the suggester shows - instead of staying empty until the
-      // user picks a class different from the default.
+      // don't linger. For edges that respect an entityClass, always re-seed the
+      // picker's default class (the first allowed, else the first of all
+      // classes) - a class carried over from the previous edge type must never
+      // survive the switch - so the class filter and its tooltip hint match
+      // what the suggester shows immediately on switch.
       const newTargetParams = Query.EdgeTypeTargetNodeParams[newType] ?? {};
       if (newTargetParams.entityClass) {
-        if (!edgeToUpdate.node.params.entityClasses?.length) {
-          const allowed: EntityEnums.Class[] = newTargetParams.entityClass.allowedClasses ?? [];
-          const defaultClasses = allowed.length ? allowed : classesAll;
-          edgeToUpdate.node.params.entityClasses = [defaultClasses[0]];
-        }
+        const allowed: EntityEnums.Class[] = newTargetParams.entityClass.allowedClasses ?? [];
+        const defaultClasses = allowed.length ? allowed : classesAll;
+        edgeToUpdate.node.params.entityClasses = [defaultClasses[0]];
       } else {
         edgeToUpdate.node.params.entityClasses = undefined;
       }

--- a/packages/client/src/pages/Query/Query/state.ts
+++ b/packages/client/src/pages/Query/Query/state.ts
@@ -121,6 +121,17 @@ const queryReducer = (state: Query.INode, action: QueryAction) => {
         return updatedStateUpdate;
       }
       edgeToUpdate.type = newType;
+
+      // the child node's params are edge-type specific; drop the ones the new
+      // edge type does not accept so stale class/entity filters (and their
+      // tooltip hints) don't linger after a type switch
+      const newTargetParams = Query.EdgeTypeTargetNodeParams[newType] ?? {};
+      if (!newTargetParams.entityClass) {
+        edgeToUpdate.node.params.entityClasses = undefined;
+      }
+      if (!newTargetParams.entityId) {
+        edgeToUpdate.node.params.entityId = undefined;
+      }
       return updatedStateUpdate;
 
     case QueryActionType.updateEdgeLogic:

--- a/packages/server/src/service/query/edge.ts
+++ b/packages/server/src/service/query/edge.ts
@@ -37,6 +37,29 @@ export default class SearchEdge implements Query.IEdge {
   }
 }
 
+/**
+ * Intersects a precomputed candidate-id stream back into the incoming stream q:
+ * dedupes `idsStream`, coerces it to an array and emits only the ids already
+ * present in q - the subset invariant that positive matching and negation
+ * (base set minus matches) both rely on. Pass null when the edge has no usable
+ * target - the edge then matches nothing.
+ */
+function intersectIdsWithStream(q: RStream, idsStream: RStream | null): RStream {
+  const idsArray: RDatum = idsStream
+    ? (idsStream.distinct() as unknown as RDatum).coerceTo("array")
+    : r.expr([] as string[]);
+
+  return idsArray.do(function (ids: RDatum) {
+    return q
+      .filter(function (e: RDatum<IEntity>) {
+        return ids.contains(e("id"));
+      })
+      .map(function (e: RDatum<IEntity>) {
+        return e("id");
+      });
+  }) as unknown as RStream;
+}
+
 export class EdgeHasClassification extends SearchEdge {
   constructor(data: Partial<Query.IEdge>) {
     super(data);
@@ -127,28 +150,20 @@ export class EdgeSUnderChildrenT extends SearchEdge {
   run(q: RStream): RStream {
     const subtreeIds = this.subtreeTerritoryIds;
 
-    const statementIds: RDatum = subtreeIds.length
-      ? (r
-          .table(Entity.table)
-          .getAll(r.args(subtreeIds), {
-            index: DbEnums.Indexes.StatementTerritory,
-          })
-          .filter(function (e: RDatum<IEntity>) {
-            return e("class").eq(EntityEnums.Class.Statement);
-          })
-          .getField("id")
-          .distinct() as unknown as RDatum).coerceTo("array")
-      : r.expr([] as string[]);
-
-    return statementIds.do(function (ids: RDatum) {
-      return q
-        .filter(function (e: RDatum<IEntity>) {
-          return ids.contains(e("id"));
-        })
-        .map(function (e: RDatum<IEntity>) {
-          return e("id");
-        });
-    }) as unknown as RStream;
+    return intersectIdsWithStream(
+      q,
+      subtreeIds.length
+        ? (r
+            .table(Entity.table)
+            .getAll(r.args(subtreeIds), {
+              index: DbEnums.Indexes.StatementTerritory,
+            })
+            .filter(function (e: RDatum<IEntity>) {
+              return e("class").eq(EntityEnums.Class.Statement);
+            })
+            .getField("id") as unknown as RStream)
+        : null
+    );
   }
 }
 
@@ -468,7 +483,8 @@ function emitMatchingActants(
   statements: RStream,
   actantMatches: (actant: RDatum) => RValue<boolean>
 ): RStream {
-  const characterised = (
+  return intersectIdsWithStream(
+    q,
     statements
       .filter(function(e: RDatum<IEntity>) {
         return e("class").eq(EntityEnums.Class.Statement);
@@ -482,18 +498,7 @@ function emitMatchingActants(
             return a("entityId");
           });
       })
-      .distinct() as unknown as RDatum
-  ).coerceTo("array");
-
-  return characterised.do(function(ids: RDatum) {
-    return q
-      .filter(function(e: RDatum<IEntity>) {
-        return ids.contains(e("id"));
-      })
-      .map(function(e: RDatum<IEntity>) {
-        return e("id");
-      });
-  }) as unknown as RStream;
+  );
 }
 
 function runInverseStatementPropEdge(
@@ -702,35 +707,27 @@ function runStatementHasEntityEdge(
   q: RStream,
   targetId: string | undefined
 ): RStream {
-  const statementIds: RDatum = targetId
-    ? (r
-        .table(Entity.table)
-        .getAll(targetId, { index: DbEnums.Indexes.StatementEntities })
-        .union(
-          r
-            .table(Entity.table)
-            .getAll(targetId, {
-              index: DbEnums.Indexes.StatementDataProps,
-            }) as unknown as RStream
-        )
-        .filter(function (e: RDatum<IEntity>) {
-          return e("class").eq(EntityEnums.Class.Statement);
-        })
-        .map(function (e: RDatum<IEntity>) {
-          return e("id");
-        })
-        .distinct() as unknown as RDatum).coerceTo("array")
-    : r.expr([] as string[]);
-
-  return statementIds.do(function (ids: RDatum) {
-    return q
-      .filter(function (e: RDatum<IEntity>) {
-        return ids.contains(e("id"));
-      })
-      .map(function (e: RDatum<IEntity>) {
-        return e("id");
-      });
-  }) as unknown as RStream;
+  return intersectIdsWithStream(
+    q,
+    targetId
+      ? r
+          .table(Entity.table)
+          .getAll(targetId, { index: DbEnums.Indexes.StatementEntities })
+          .union(
+            r
+              .table(Entity.table)
+              .getAll(targetId, {
+                index: DbEnums.Indexes.StatementDataProps,
+              }) as unknown as RStream
+          )
+          .filter(function (e: RDatum<IEntity>) {
+            return e("class").eq(EntityEnums.Class.Statement);
+          })
+          .map(function (e: RDatum<IEntity>) {
+            return e("id");
+          })
+      : null
+  );
 }
 
 export class EdgeStatementHasEntity extends SearchEdge {
@@ -844,28 +841,20 @@ function runUsedUnderTerritoryEdge(
   q: RStream,
   territoryId: string | undefined
 ): RStream {
-  const usedIds: RDatum = territoryId
-    ? (r
-        .table(Entity.table)
-        .getAll(territoryId, { index: DbEnums.Indexes.StatementTerritory })
-        .filter(function (e: RDatum<IEntity>) {
-          return e("class").eq(EntityEnums.Class.Statement);
-        })
-        .concatMap(function (stmt: RDatum) {
-          return collectStatementEntityIds(stmt);
-        })
-        .distinct() as unknown as RDatum).coerceTo("array")
-    : r.expr([] as string[]);
-
-  return usedIds.do(function (ids: RDatum) {
-    return q
-      .filter(function (e: RDatum<IEntity>) {
-        return ids.contains(e("id"));
-      })
-      .map(function (e: RDatum<IEntity>) {
-        return e("id");
-      });
-  }) as unknown as RStream;
+  return intersectIdsWithStream(
+    q,
+    territoryId
+      ? r
+          .table(Entity.table)
+          .getAll(territoryId, { index: DbEnums.Indexes.StatementTerritory })
+          .filter(function (e: RDatum<IEntity>) {
+            return e("class").eq(EntityEnums.Class.Statement);
+          })
+          .concatMap(function (stmt: RDatum) {
+            return collectStatementEntityIds(stmt);
+          })
+      : null
+  );
 }
 
 export class EdgeUsedUnderTerritory extends SearchEdge {
@@ -917,30 +906,22 @@ export class EdgeUsedUnderChildrenTerritory extends SearchEdge {
   run(q: RStream): RStream {
     const subtreeIds = this.subtreeTerritoryIds;
 
-    const usedIds: RDatum = subtreeIds.length
-      ? (r
-          .table(Entity.table)
-          .getAll(r.args(subtreeIds), {
-            index: DbEnums.Indexes.StatementTerritory,
-          })
-          .filter(function (e: RDatum<IEntity>) {
-            return e("class").eq(EntityEnums.Class.Statement);
-          })
-          .concatMap(function (stmt: RDatum) {
-            return collectStatementEntityIds(stmt);
-          })
-          .distinct() as unknown as RDatum).coerceTo("array")
-      : r.expr([] as string[]);
-
-    return usedIds.do(function (ids: RDatum) {
-      return q
-        .filter(function (e: RDatum<IEntity>) {
-          return ids.contains(e("id"));
-        })
-        .map(function (e: RDatum<IEntity>) {
-          return e("id");
-        });
-    }) as unknown as RStream;
+    return intersectIdsWithStream(
+      q,
+      subtreeIds.length
+        ? r
+            .table(Entity.table)
+            .getAll(r.args(subtreeIds), {
+              index: DbEnums.Indexes.StatementTerritory,
+            })
+            .filter(function (e: RDatum<IEntity>) {
+              return e("class").eq(EntityEnums.Class.Statement);
+            })
+            .concatMap(function (stmt: RDatum) {
+              return collectStatementEntityIds(stmt);
+            })
+        : null
+    );
   }
 }
 
@@ -964,28 +945,20 @@ function runIsInStatementEdge(
   q: RStream,
   statementId: string | undefined
 ): RStream {
-  const usedIds: RDatum = statementId
-    ? (r
-        .table(Entity.table)
-        .getAll(statementId)
-        .filter(function (e: RDatum<IEntity>) {
-          return e("class").eq(EntityEnums.Class.Statement);
-        })
-        .concatMap(function (stmt: RDatum) {
-          return collectStatementEntityIds(stmt);
-        })
-        .distinct() as unknown as RDatum).coerceTo("array")
-    : r.expr([] as string[]);
-
-  return usedIds.do(function (ids: RDatum) {
-    return q
-      .filter(function (e: RDatum<IEntity>) {
-        return ids.contains(e("id"));
-      })
-      .map(function (e: RDatum<IEntity>) {
-        return e("id");
-      });
-  }) as unknown as RStream;
+  return intersectIdsWithStream(
+    q,
+    statementId
+      ? r
+          .table(Entity.table)
+          .getAll(statementId)
+          .filter(function (e: RDatum<IEntity>) {
+            return e("class").eq(EntityEnums.Class.Statement);
+          })
+          .concatMap(function (stmt: RDatum) {
+            return collectStatementEntityIds(stmt);
+          })
+      : null
+  );
 }
 
 export class EdgeIsInStatement extends SearchEdge {

--- a/packages/server/src/service/query/edge.ts
+++ b/packages/server/src/service/query/edge.ts
@@ -232,6 +232,7 @@ export class EdgeHasSuperordinate extends SearchEdge {
 
   run(q: RStream): RStream {
     const soeEntityId = this.node.params.entityId;
+    const soeEntityClasses = this.node.params.entityClasses ?? [];
     return q.concatMap(function(entity: RDatum<IEntity>) {
       return (
         r
@@ -246,10 +247,27 @@ export class EdgeHasSuperordinate extends SearchEdge {
           .filter(function(relation: RDatum<RelationTypes.IRelation>) {
             return relation("entityIds").nth(0).eq(entity("id"));
           })
-          // check if the target entity is the desired superordinate
+          // check if the target entity is the desired superordinate; with no
+          // target id but a class filter (empty suggester + class selected),
+          // keep only relations whose superordinate is of one of the classes.
+          // A dangling superordinate id (no such entity) is null-safe and
+          // simply fails the class condition.
           .filter(function(relation: RDatum<RelationTypes.IRelation>) {
             if (soeEntityId) {
               return relation("entityIds").nth(1).eq(soeEntityId);
+            }
+            if (soeEntityClasses.length) {
+              return r
+                .table(Entity.table)
+                .get(relation("entityIds").nth(1))
+                .default(null)
+                .do(function (ent: RDatum) {
+                  return r.branch(
+                    ent,
+                    r.expr(soeEntityClasses).contains(ent("class")),
+                    false
+                  );
+                });
             }
             return true;
           })

--- a/packages/server/src/service/query/edge.ts
+++ b/packages/server/src/service/query/edge.ts
@@ -189,6 +189,67 @@ export class EdgeHasRelation extends SearchEdge {
   }
 }
 
+/**
+ * Shared run for the forward relation edges that walk from the iterated entity
+ * (entityIds[0]) to its relation target (entityIds[1]): R:SCL (Superclass) and
+ * R:SOE (SuperordinateEntity). Matches relations of `relationType` where the
+ * target satisfies the edge target:
+ *  - a specific target entity id (`targetId`), or
+ *  - any entity whose class is in `targetClasses` (empty suggester + class
+ *    selected there), or
+ *  - with neither, any relation of the type.
+ * Emits the iterated entity itself (the entityIds[0] side), keeping the subset
+ * invariant positive matching and negation rely on. A dangling target entity id
+ * (no such entity) is null-safe and simply fails the class condition.
+ */
+function runHasRelationTargetEdge(
+  q: RStream,
+  relationType: RelationEnums.Type,
+  targetId: string | undefined,
+  targetClasses: EntityEnums.Class[]
+): RStream {
+  return q.concatMap(function(entity: RDatum<IEntity>) {
+    return (
+      r
+        .table(Relation.table)
+        .getAll(entity("id"), { index: DbEnums.Indexes.RelationsEntityIds })
+        .filter({
+          type: relationType,
+        })
+        // get all relations where the first entity is the source entity
+        // (for R:SOE this is the subordinate side; its superordinate is
+        // entityIds[1], mirroring SuperordinateEntity.getSuperordinate...
+        // ForwardConnections, which recurses on entityIds[1])
+        .filter(function(relation: RDatum<RelationTypes.IRelation>) {
+          return relation("entityIds").nth(0).eq(entity("id"));
+        })
+        // check if the target entity is the desired one
+        .filter(function(relation: RDatum<RelationTypes.IRelation>) {
+          if (targetId) {
+            return relation("entityIds").nth(1).eq(targetId);
+          }
+          if (targetClasses.length) {
+            return r
+              .table(Entity.table)
+              .get(relation("entityIds").nth(1))
+              .default(null)
+              .do(function (ent: RDatum) {
+                return r.branch(
+                  ent,
+                  r.expr(targetClasses).contains(ent("class")),
+                  false
+                );
+              });
+          }
+          return true;
+        })
+        .map(function(relation) {
+          return relation("entityIds").nth(0);
+        })
+    );
+  });
+}
+
 export class EdgeCHasSuperclass extends SearchEdge {
   constructor(data: Partial<Query.IEdge>) {
     super(data);
@@ -196,31 +257,12 @@ export class EdgeCHasSuperclass extends SearchEdge {
   }
 
   run(q: RStream): RStream {
-    const sclEntityId = this.node.params.entityId;
-    return q.concatMap(function(entity: RDatum<IEntity>) {
-      return (
-        r
-          .table(Relation.table)
-          .getAll(entity("id"), { index: DbEnums.Indexes.RelationsEntityIds })
-          .filter({
-            type: RelationEnums.Type.Superclass,
-          })
-          // get all relations where the first entity is the source entity
-          .filter(function(relation: RDatum<RelationTypes.IRelation>) {
-            return relation("entityIds").nth(0).eq(entity("id"));
-          })
-          // check if the target entity is the desired superclass
-          .filter(function(relation: RDatum<RelationTypes.IRelation>) {
-            if (sclEntityId) {
-              return relation("entityIds").nth(1).eq(sclEntityId);
-            }
-            return true;
-          })
-          .map(function(relation) {
-            return relation("entityIds").nth(0);
-          })
-      );
-    });
+    return runHasRelationTargetEdge(
+      q,
+      RelationEnums.Type.Superclass,
+      this.node.params.entityId,
+      this.node.params.entityClasses ?? []
+    );
   }
 }
 
@@ -231,53 +273,12 @@ export class EdgeHasSuperordinate extends SearchEdge {
   }
 
   run(q: RStream): RStream {
-    const soeEntityId = this.node.params.entityId;
-    const soeEntityClasses = this.node.params.entityClasses ?? [];
-    return q.concatMap(function(entity: RDatum<IEntity>) {
-      return (
-        r
-          .table(Relation.table)
-          .getAll(entity("id"), { index: DbEnums.Indexes.RelationsEntityIds })
-          .filter({
-            type: RelationEnums.Type.SuperordinateEntity,
-          })
-          // the entity is the subordinate side (entityIds[0]); its superordinate
-          // is entityIds[1] (mirrors SuperordinateEntity.getSuperordinate...
-          // ForwardConnections, which recurses on entityIds[1])
-          .filter(function(relation: RDatum<RelationTypes.IRelation>) {
-            return relation("entityIds").nth(0).eq(entity("id"));
-          })
-          // check if the target entity is the desired superordinate; with no
-          // target id but a class filter (empty suggester + class selected),
-          // keep only relations whose superordinate is of one of the classes.
-          // A dangling superordinate id (no such entity) is null-safe and
-          // simply fails the class condition.
-          .filter(function(relation: RDatum<RelationTypes.IRelation>) {
-            if (soeEntityId) {
-              return relation("entityIds").nth(1).eq(soeEntityId);
-            }
-            if (soeEntityClasses.length) {
-              return r
-                .table(Entity.table)
-                .get(relation("entityIds").nth(1))
-                .default(null)
-                .do(function (ent: RDatum) {
-                  return r.branch(
-                    ent,
-                    r.expr(soeEntityClasses).contains(ent("class")),
-                    false
-                  );
-                });
-            }
-            return true;
-          })
-          // emit the iterated entity itself (the subordinate), keeping the
-          // subset invariant positive matching and negation rely on
-          .map(function(relation) {
-            return relation("entityIds").nth(0);
-          })
-      );
-    });
+    return runHasRelationTargetEdge(
+      q,
+      RelationEnums.Type.SuperordinateEntity,
+      this.node.params.entityId,
+      this.node.params.entityClasses ?? []
+    );
   }
 }
 

--- a/packages/server/src/service/query/superclass-edge-reql.test.ts
+++ b/packages/server/src/service/query/superclass-edge-reql.test.ts
@@ -1,0 +1,161 @@
+import "ts-jest";
+import { r, Connection } from "rethinkdb-ts";
+import { DbEnums, EntityEnums, RelationEnums } from "@inkvisitor/shared/enums";
+import { Query } from "@inkvisitor/shared/types/query";
+import { getEdgeInstance } from "./edge";
+
+// Verifies the ACTUAL ReQL of the R:SCL (Superclass) edge against a real
+// RethinkDB. Like superordinate-edge-reql.test.ts it creates/drops its OWN
+// throwaway db, so it can never touch real data, and it self-skips when no
+// RethinkDB is reachable on DB_HOST/DB_PORT (defaults localhost:28015).
+const HOST = process.env.DB_HOST || "localhost";
+const PORT = Number(process.env.DB_PORT) || 28015;
+const TMP_DB = "iv_test_superclass_edge";
+const ENTITIES = "entities";
+const RELATIONS = "relations";
+
+// --- concept / action ids ---
+const ANIMAL = "con-animal"; // the Concept superclass we search by
+const VEHICLE = "con-vehicle"; // a different Concept superclass
+const DOG = "con-dog"; // subclass of Animal
+const CAT = "con-cat"; // subclass of Animal
+const CAR = "con-car"; // subclass of Vehicle
+const MOVE = "act-move"; // an ACTION superclass (class-filter fixture)
+const RUN = "act-run"; // subclass of the Move action
+const GHOST = "con-ghost"; // subclass of a MISSING (dangling) superclass
+const PLANT = "con-plant"; // related to Animal by a NON-superclass relation
+
+const entity = (id: string, cls = EntityEnums.Class.Concept) => ({
+  id,
+  class: cls,
+});
+const ENTITY_FIXTURES = [
+  ...[ANIMAL, VEHICLE, DOG, CAT, CAR, GHOST, PLANT].map((id) => entity(id)),
+  entity(MOVE, EntityEnums.Class.Action),
+  entity(RUN, EntityEnums.Class.Action),
+];
+
+// Superclass relation: entityIds = [subclass, superclass]
+const scl = (subclass: string, superclass: string) => ({
+  id: `scl-${subclass}-${superclass}`,
+  type: RelationEnums.Type.Superclass,
+  entityIds: [subclass, superclass],
+});
+const RELATION_FIXTURES = [
+  scl(DOG, ANIMAL),
+  scl(CAT, ANIMAL),
+  scl(CAR, VEHICLE),
+  scl(RUN, MOVE),
+  // dangling superclass: entity row does not exist
+  scl(GHOST, "missing-superclass"),
+  // a non-superclass relation between PLANT and ANIMAL - must be ignored
+  {
+    id: "rel-plant-animal",
+    type: RelationEnums.Type.Related,
+    entityIds: [PLANT, ANIMAL],
+  },
+];
+
+const runEdge = (
+  nodeParams: Query.INodeParams,
+  conn: Connection
+): Promise<string[]> => {
+  const edge = getEdgeInstance({
+    type: Query.EdgeType["R:SCL"],
+    params: {},
+    logic: Query.EdgeLogic.Positive,
+    id: "e1",
+    node: {
+      id: "n1",
+      type: Query.NodeType.E,
+      operator: Query.NodeOperator.And,
+      params: nodeParams,
+      edges: [],
+    },
+  });
+  return edge.run(r.table(ENTITIES)).distinct().run(conn) as Promise<string[]>;
+};
+
+const sorted = (a: string[]) => [...a].sort();
+
+describe("R:SCL (Superclass) edge (real ReQL)", () => {
+  let conn: Connection | null = null;
+
+  beforeAll(async () => {
+    try {
+      conn = await r.connect({ host: HOST, port: PORT, timeout: 2 });
+    } catch {
+      // eslint-disable-next-line no-console
+      console.warn(
+        `[superclass-edge-reql] no RethinkDB on ${HOST}:${PORT} - skipping real-ReQL suite`
+      );
+      conn = null;
+      return;
+    }
+    await r.dbDrop(TMP_DB).run(conn).catch(() => undefined);
+    await r.dbCreate(TMP_DB).run(conn);
+    conn.use(TMP_DB);
+    await r.tableCreate(ENTITIES).run(conn);
+    await r.tableCreate(RELATIONS).run(conn);
+    await r
+      .table(RELATIONS)
+      .indexCreate(DbEnums.Indexes.RelationsEntityIds, { multi: true })
+      .run(conn);
+    await r.table(RELATIONS).indexWait().run(conn);
+    await r.table(ENTITIES).insert(ENTITY_FIXTURES).run(conn);
+    await r.table(RELATIONS).insert(RELATION_FIXTURES).run(conn);
+  }, 30000);
+
+  afterAll(async () => {
+    if (conn) {
+      await r.dbDrop(TMP_DB).run(conn).catch(() => undefined);
+      await conn.close();
+    }
+  });
+
+  test("by entity: returns the subclasses of Animal, not Animal itself", async () => {
+    if (!conn) return;
+    const ids = await runEdge({ entityId: ANIMAL }, conn);
+    expect(sorted(ids)).toEqual(sorted([DOG, CAT]));
+    expect(ids).not.toContain(ANIMAL);
+    expect(ids).not.toContain(CAR);
+  });
+
+  test("only the Superclass relation type matches (Related is ignored)", async () => {
+    if (!conn) return;
+    const ids = await runEdge({ entityId: ANIMAL }, conn);
+    expect(ids).not.toContain(PLANT);
+  });
+
+  test("no target: returns every entity that has any superclass", async () => {
+    if (!conn) return;
+    const ids = await runEdge({}, conn);
+    expect(sorted(ids)).toEqual(sorted([DOG, CAT, CAR, RUN, GHOST]));
+  });
+
+  test("by class: Concept superclasses only (Action-superclassed and dangling excluded)", async () => {
+    if (!conn) return;
+    const ids = await runEdge(
+      { entityClasses: [EntityEnums.Class.Concept] },
+      conn
+    );
+    expect(sorted(ids)).toEqual(sorted([DOG, CAT, CAR]));
+    expect(ids).not.toContain(RUN); // superclass is an Action
+    expect(ids).not.toContain(GHOST); // dangling superclass fails the class check
+  });
+
+  test("by class: Action superclasses only", async () => {
+    if (!conn) return;
+    const ids = await runEdge({ entityClasses: [EntityEnums.Class.Action] }, conn);
+    expect(sorted(ids)).toEqual(sorted([RUN]));
+  });
+
+  test("entityId wins over entityClasses when both are set", async () => {
+    if (!conn) return;
+    const ids = await runEdge(
+      { entityId: ANIMAL, entityClasses: [EntityEnums.Class.Action] },
+      conn
+    );
+    expect(sorted(ids)).toEqual(sorted([DOG, CAT]));
+  });
+});

--- a/packages/server/src/service/query/superordinate-edge-reql.test.ts
+++ b/packages/server/src/service/query/superordinate-edge-reql.test.ts
@@ -21,14 +21,20 @@ const MILAN = "loc-milan"; // subordinate to Lombardy
 const BERGAMO = "loc-bergamo"; // subordinate to Lombardy
 const ROME = "loc-rome"; // subordinate to Lazio
 const PARIS = "loc-paris"; // related to Lombardy by a NON-superordinate relation
+const FOUNDING = "evt-founding"; // an EVENT superordinate (class-filter fixture)
+const TURIN = "loc-turin"; // subordinate to the FOUNDING event
+const NAPLES = "loc-naples"; // subordinate to a MISSING (dangling) superordinate
 
 const entity = (id: string, cls = EntityEnums.Class.Location) => ({
   id,
   class: cls,
 });
-const ENTITY_FIXTURES = [LOMBARDY, LAZIO, MILAN, BERGAMO, ROME, PARIS].map((id) =>
-  entity(id)
-);
+const ENTITY_FIXTURES = [
+  ...[LOMBARDY, LAZIO, MILAN, BERGAMO, ROME, PARIS, TURIN, NAPLES].map((id) =>
+    entity(id)
+  ),
+  entity(FOUNDING, EntityEnums.Class.Event),
+];
 
 // SuperordinateEntity relation: entityIds = [subordinate, superordinate]
 const soe = (subordinate: string, superordinate: string) => ({
@@ -40,6 +46,9 @@ const RELATION_FIXTURES = [
   soe(MILAN, LOMBARDY),
   soe(BERGAMO, LOMBARDY),
   soe(ROME, LAZIO),
+  soe(TURIN, FOUNDING),
+  // dangling superordinate: entity row does not exist
+  soe(NAPLES, "missing-superordinate"),
   // a non-superordinate relation between PARIS and LOMBARDY - must be ignored
   {
     id: "rel-paris-lombardy",
@@ -49,7 +58,7 @@ const RELATION_FIXTURES = [
 ];
 
 const runEdge = (
-  targetEntityId: string | undefined,
+  nodeParams: Query.INodeParams,
   conn: Connection
 ): Promise<string[]> => {
   const edge = getEdgeInstance({
@@ -61,7 +70,7 @@ const runEdge = (
       id: "n1",
       type: Query.NodeType.E,
       operator: Query.NodeOperator.And,
-      params: targetEntityId ? { entityId: targetEntityId } : {},
+      params: nodeParams,
       edges: [],
     },
   });
@@ -107,7 +116,7 @@ describe("R:SOE (SuperordinateEntity) edge (real ReQL)", () => {
 
   test("by entity: returns the subordinates of Lombardy, not Lombardy itself", async () => {
     if (!conn) return;
-    const ids = await runEdge(LOMBARDY, conn);
+    const ids = await runEdge({ entityId: LOMBARDY }, conn);
     expect(sorted(ids)).toEqual(sorted([MILAN, BERGAMO]));
     expect(ids).not.toContain(LOMBARDY);
     expect(ids).not.toContain(ROME);
@@ -115,13 +124,39 @@ describe("R:SOE (SuperordinateEntity) edge (real ReQL)", () => {
 
   test("only the SuperordinateEntity relation type matches (Related is ignored)", async () => {
     if (!conn) return;
-    const ids = await runEdge(LOMBARDY, conn);
+    const ids = await runEdge({ entityId: LOMBARDY }, conn);
     expect(ids).not.toContain(PARIS);
   });
 
   test("no target: returns every entity that has any superordinate", async () => {
     if (!conn) return;
-    const ids = await runEdge(undefined, conn);
+    const ids = await runEdge({}, conn);
+    expect(sorted(ids)).toEqual(sorted([MILAN, BERGAMO, ROME, TURIN, NAPLES]));
+  });
+
+  test("by class: Location superordinates only (Event-superordinated and dangling excluded)", async () => {
+    if (!conn) return;
+    const ids = await runEdge(
+      { entityClasses: [EntityEnums.Class.Location] },
+      conn
+    );
     expect(sorted(ids)).toEqual(sorted([MILAN, BERGAMO, ROME]));
+    expect(ids).not.toContain(TURIN); // superordinate is an Event
+    expect(ids).not.toContain(NAPLES); // dangling superordinate fails the class check
+  });
+
+  test("by class: Event superordinates only", async () => {
+    if (!conn) return;
+    const ids = await runEdge({ entityClasses: [EntityEnums.Class.Event] }, conn);
+    expect(sorted(ids)).toEqual(sorted([TURIN]));
+  });
+
+  test("entityId wins over entityClasses when both are set", async () => {
+    if (!conn) return;
+    const ids = await runEdge(
+      { entityId: LOMBARDY, entityClasses: [EntityEnums.Class.Event] },
+      conn
+    );
+    expect(sorted(ids)).toEqual(sorted([MILAN, BERGAMO]));
   });
 });

--- a/packages/shared/types/query.ts
+++ b/packages/shared/types/query.ts
@@ -226,6 +226,21 @@ export namespace Query {
     "R:IMP": {},
     "I_R:IMP": {},
     "R:SOE": {
+      // entityClass: with an empty suggester, the category picked there narrows
+      // the superordinate to entities of that class (server: EdgeHasSuperordinate)
+      entityClass: {
+        allowedClasses: [
+          EntityEnums.Class.Location,
+          EntityEnums.Class.Object,
+          EntityEnums.Class.Event,
+          EntityEnums.Class.Group,
+          EntityEnums.Class.Statement,
+          EntityEnums.Class.Value,
+          EntityEnums.Class.Resource,
+          EntityEnums.Class.Person,
+          EntityEnums.Class.Being,
+        ],
+      },
       entityId: {
         allowedClasses: [
           EntityEnums.Class.Location,

--- a/packages/shared/types/query.ts
+++ b/packages/shared/types/query.ts
@@ -201,6 +201,11 @@ export namespace Query {
       entityId: { allowedClasses: [] },
     },
     "R:SCL": {
+      // entityClass: with an empty suggester, the category picked there narrows
+      // the superclass to entities of that class (server: EdgeCHasSuperclass)
+      entityClass: {
+        allowedClasses: [EntityEnums.Class.Action, EntityEnums.Class.Concept],
+      },
       entityId: {
         allowedClasses: [EntityEnums.Class.Action, EntityEnums.Class.Concept],
       },


### PR DESCRIPTION
## 1.5.4 — client improvements & fixes

### Annotator
- Fix search across soft-wrapped lines
- Overlay settings: reordered, font-family name in dropdown, auto-Roboto on mono switch
- Block caret for monospace fonts

### Query grid & Explorer
- Friendlier empty-suggester tooltip (migrated to `IconWithTooltip` inside the Suggester input)
- Warning indicator on empty required entity suggester
- Restyled negated ("NOT") edge checkbox as a neutral box on the red edge
- Drop stale Explorer results when the query changes

### Suggester
- New `suggestionListWidth` override for a wider results list
- Consistent overall width across single/multi class count

### Shared
- `Checkbox`: new `accentColor` prop (plain box + accent border/check for colored backgrounds)
- Comment to mark unused API endpoint