### PR TITLE
3060 how to add entity reference value as column in explorer

### DIFF
--- a/packages/client/src/pages/Query/Explorer/ExplorerTable/ExplorerTable.tsx
+++ b/packages/client/src/pages/Query/Explorer/ExplorerTable/ExplorerTable.tsx
@@ -228,6 +228,25 @@ export const ExplorerTable: React.FC<ExplorerTable> = ({
             break;
           }
 
+          case Explore.EExploreColumnType.ERV: {
+            const params =
+              column.params as Explore.IExploreColumnParams<Explore.EExploreColumnType.ERV>;
+
+            const newRef: IReference = {
+              id: uuidv4(),
+              resource: params.resource,
+              value: newEntity.id,
+            };
+
+            updateEntityMutation.mutate({
+              entityId: rowEntity.id,
+              changes: {
+                references: [...rowEntity.references, newRef],
+              },
+            });
+            break;
+          }
+
           case Explore.EExploreColumnType.ER: {
             const params =
               column.params as Explore.IExploreColumnParams<Explore.EExploreColumnType.ER>;
@@ -433,10 +452,6 @@ export const ExplorerTable: React.FC<ExplorerTable> = ({
         });
       }, SCROLL_WINDOW_UPDATE_DEBOUNCE_MS);
     }
-  };
-
-  const handleCloseDetailsModal = () => {
-    clearAllDetailIds();
   };
 
   return (

--- a/packages/client/src/pages/Query/Explorer/ExplorerTable/ExplorerTable.tsx
+++ b/packages/client/src/pages/Query/Explorer/ExplorerTable/ExplorerTable.tsx
@@ -22,10 +22,14 @@ import ExplorerTableNewColumnPanel from "./ExplorerTableNewColumnPanel/ExplorerT
 import { StyledBody, StyledEmptyMessage, StyledTableWrapper } from "./ExplorerTableStyles";
 
 import ExploreTableHeader from "./Header/ExploreTableHeader";
+import { CELL_DISPLAY_LIMIT } from "./Cell/ExplorerCellOverflow";
 import { HEIGHT_ROW_DEFAULT, WIDTH_COLUMN_FIRST } from "./constants";
-import { getColumnWidth } from "./utils";
+import { contentSizedColumnTypes } from "./types";
+import { estimateColumnWidth, getColumnWidth } from "./utils";
 
 const OVERSCAN_ROWS = 10;
+
+const EMPTY_COLUMNS: Explore.IExploreColumn[] = [];
 
 /**
  * Debounce delay before dispatching offset/limit changes during scroll.
@@ -89,21 +93,46 @@ export const ExplorerTable: React.FC<ExplorerTable> = ({
   const themeContext = useTheme();
   const { detailIdArray, clearAllDetailIds, selectedDetailId } = useSearchParams();
   const [lastData, setLastData] = useState<IResponseQuery | undefined>(undefined);
+
+  const { limit, offset } = state;
+  // Stable identity for the non-table branch: `columns` is an effect dependency,
+  // and a fresh [] every render would re-fire it unconditionally.
+  const columns = state.view.mode === Explore.EViewMode.Table ? state.view.columns : EMPTY_COLUMNS;
+
+  // Content-estimated widths per column id, ratcheted: a column only ever
+  // grows within one query (see estimateColumnWidth). Estimated from each
+  // loaded data window, never DOM-measured — rows are virtualized, so the
+  // viewport content varies with scroll position and measuring would jitter.
+  // Only ever shrinks by resetting on a new query (stableSignature change).
+  const [columnWidths, setColumnWidths] = useState<Record<string, number>>({});
+
   useEffect(() => {
     if (data && typeof data.total === "number") {
       setLastData(data);
       setRenderWindow({ offset: state.offset, limit: state.limit });
+
+      // Ratchet content-sized column widths from the arrived window.
+      setColumnWidths((prev) => {
+        let changed = false;
+        const next = { ...prev };
+        for (const col of columns) {
+          if (!contentSizedColumnTypes.has(col.type)) continue;
+          const estimated = estimateColumnWidth(col, data.entities, CELL_DISPLAY_LIMIT);
+          if (estimated > (next[col.id] ?? 0)) {
+            next[col.id] = estimated;
+            changed = true;
+          }
+        }
+        return changed ? next : prev;
+      });
     }
-  }, [data, state.offset, state.limit]);
+  }, [data, state.offset, state.limit, columns]);
 
   const {
     entities,
     total: incomingTotal,
     entityIds,
   } = data ?? lastData ?? { entities: [], total: 0, entityIds: [] as string[] };
-
-  const { limit, offset } = state;
-  const columns = state.view.mode === Explore.EViewMode.Table ? state.view.columns : [];
 
   const [total, setTotal] = useState(0);
 
@@ -122,6 +151,8 @@ export const ExplorerTable: React.FC<ExplorerTable> = ({
     prevStableSignatureRef.current = stableSignature;
     setLastData(undefined);
     setTotal(0);
+    // New query: restart the width ratchet so columns can size down again.
+    setColumnWidths({});
   }
 
   const [rowFocused, setRowFocused] = useState<number>(-1);
@@ -310,8 +341,11 @@ export const ExplorerTable: React.FC<ExplorerTable> = ({
   );
 
   const widthTable = useMemo(() => {
-    return WIDTH_COLUMN_FIRST + columns.reduce((sum, col) => sum + getColumnWidth(col.type), 0);
-  }, [columns]);
+    return (
+      WIDTH_COLUMN_FIRST +
+      columns.reduce((sum, col) => sum + (columnWidths[col.id] ?? getColumnWidth(col.type)), 0)
+    );
+  }, [columns, columnWidths]);
 
   const windowUpdateTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -399,6 +433,7 @@ export const ExplorerTable: React.FC<ExplorerTable> = ({
               rowId={index}
               rowItem={rowItem!}
               columns={columns}
+              columnWidths={columnWidths}
               handleEditColumn={handleEditColumn}
               onRowSelect={onRowSelect}
               onRowClick={handleRowClick}
@@ -425,6 +460,7 @@ export const ExplorerTable: React.FC<ExplorerTable> = ({
       getCachedEntity,
       onOpenEntityInDetail,
       total,
+      columnWidths,
     ],
   );
 
@@ -492,6 +528,7 @@ export const ExplorerTable: React.FC<ExplorerTable> = ({
           {/* Alternatively, use the memoized header component below to minimize re-renders */}
           <ExploreTableHeader
             columns={columns}
+            columnWidths={columnWidths}
             onRemoveColumn={handleRemoveColumn}
             onMoveColumn={handleMoveColumn}
           />

--- a/packages/client/src/pages/Query/Explorer/ExplorerTable/ExplorerTable.tsx
+++ b/packages/client/src/pages/Query/Explorer/ExplorerTable/ExplorerTable.tsx
@@ -349,6 +349,7 @@ export const ExplorerTable: React.FC<ExplorerTable> = ({
       const rowEntityId = rowItem?.entity?.id ?? getEntityIdAtRow(index);
       const isSelected = rowEntityId ? selectedEntityIdsSet.has(rowEntityId) : false;
       const placeholderLabel = rowItem?.entity?.labels?.[0] ?? index;
+      const isLastRow = index === total - 1;
 
       return (
         <div
@@ -357,6 +358,12 @@ export const ExplorerTable: React.FC<ExplorerTable> = ({
             width: widthTable,
             minWidth: "100%",
             height: HEIGHT_ROW_DEFAULT,
+            ...(isLastRow
+              ? {
+                  borderBottomLeftRadius: themeContext.borderRadius.default,
+                  borderBottomRightRadius: themeContext.borderRadius.default,
+                }
+              : {}),
           }}
           className={`qt-row ${isOdd ? " qt-row-odd" : ""}${isSelected ? " qt-row-selected" : ""}${
             rowFocused === index ? " qt-row-focused" : ""
@@ -417,6 +424,7 @@ export const ExplorerTable: React.FC<ExplorerTable> = ({
       rowFocused,
       getCachedEntity,
       onOpenEntityInDetail,
+      total,
     ],
   );
 
@@ -473,6 +481,9 @@ export const ExplorerTable: React.FC<ExplorerTable> = ({
             height: heightBox - 20,
             overflowX: "auto",
             overflowY: "hidden",
+            boxSizing: "border-box",
+            paddingLeft: themeContext.space[4],
+            paddingRight: themeContext.space[4],
           } as React.CSSProperties
         }
       >

--- a/packages/client/src/pages/Query/Explorer/ExplorerTable/ExplorerTableNewColumnPanel/ExplorerTableNewColumnPanel.tsx
+++ b/packages/client/src/pages/Query/Explorer/ExplorerTable/ExplorerTableNewColumnPanel/ExplorerTableNewColumnPanel.tsx
@@ -135,7 +135,7 @@ const ExplorerTableNewColumnPanel: React.FC<Props> = ({
           />
         ) : (
           <EntitySuggester
-            categoryTypes={[EntityEnums.Class.Concept]}
+            categoryTypes={def.entityClasses ?? [EntityEnums.Class.Concept]}
             onPicked={(e) => setParamValue(def.id, e)}
             inputWidth="full"
           />

--- a/packages/client/src/pages/Query/Explorer/ExplorerTable/ExplorerTableRow.tsx
+++ b/packages/client/src/pages/Query/Explorer/ExplorerTable/ExplorerTableRow.tsx
@@ -266,6 +266,19 @@ const ExplorerTableRow: React.FC<ExplorerTableRowProps> = ({
         });
       }
 
+      if (column?.type === Explore.EExploreColumnType.ERV) {
+        const newEntity = deleteRef(sourceEntity, {
+          valueId: entityToRemove.id,
+        });
+
+        updateEntityMutation.mutate({
+          entityId: sourceEntity.id,
+          changes: {
+            references: newEntity.references,
+          },
+        });
+      }
+
       if (column?.type === Explore.EExploreColumnType.ERR) {
         const newEntity = deleteRef(sourceEntity, {
           resourceId: entityToRemove.id,
@@ -476,6 +489,18 @@ const ExplorerTableRow: React.FC<ExplorerTableRowProps> = ({
     (rowEntity: IEntity, column: Explore.IExploreColumn): React.ReactElement | null => {
       if (column.editable) {
         if (column.type === Explore.EExploreColumnType.EPV) {
+          return (
+            <EntitySuggester
+              inputWidth={74}
+              categoryTypes={classesAll}
+              onPicked={(newEntity) => {
+                handleEditColumn(rowEntity, column.id, newEntity);
+              }}
+              compactUntilHover
+            />
+          );
+        }
+        if (column.type === Explore.EExploreColumnType.ERV) {
           return (
             <EntitySuggester
               inputWidth={74}

--- a/packages/client/src/pages/Query/Explorer/ExplorerTable/ExplorerTableRow.tsx
+++ b/packages/client/src/pages/Query/Explorer/ExplorerTable/ExplorerTableRow.tsx
@@ -131,6 +131,8 @@ interface ExplorerTableRowProps {
   rowId: number;
   rowItem: IResponseQueryEntity;
   columns: Explore.IExploreColumn[];
+  /** Content-estimated widths per column id; static fallback when absent. */
+  columnWidths: Record<string, number>;
   handleEditColumn: (
     entity: IEntity,
     columnId: string,
@@ -149,6 +151,7 @@ const ExplorerTableRow: React.FC<ExplorerTableRowProps> = ({
   rowId,
   rowItem,
   columns,
+  columnWidths,
   handleEditColumn,
 
   onRowSelect,
@@ -583,14 +586,15 @@ const ExplorerTableRow: React.FC<ExplorerTableRowProps> = ({
       </div>
 
       {columns.map((column, key) => {
+        const width = columnWidths[column.id] ?? getColumnWidth(column.type);
         return (
           <div
             key={key}
             className="qt-col"
             style={{
-              width: getColumnWidth(column.type),
-              minWidth: getColumnWidth(column.type),
-              maxWidth: getColumnWidth(column.type),
+              width,
+              minWidth: width,
+              maxWidth: width,
             }}
           >
             <StyledCellContent>
@@ -618,6 +622,8 @@ function areRowsEqual(
   if (prev.onRowClick !== next.onRowClick) return false;
   // Re-render when columns array identity changes (e.g., add/remove)
   if (prev.columns !== next.columns) return false;
+  // Re-render when the width map identity changes (ratchet grew / query reset)
+  if (prev.columnWidths !== next.columnWidths) return false;
   if (prev.rowItem !== next.rowItem) return false;
   return true;
 }

--- a/packages/client/src/pages/Query/Explorer/ExplorerTable/ExplorerTableStyles.tsx
+++ b/packages/client/src/pages/Query/Explorer/ExplorerTable/ExplorerTableStyles.tsx
@@ -6,7 +6,7 @@ interface StyledTableWrapper {
 }
 export const StyledTableWrapper = styled.div<StyledTableWrapper>`
   position: relative;
-  margin: 0.5rem 1rem 0 1rem;
+  margin-top: 0.5rem;
   overflow: hidden;
 `;
 export const StyledRowWrapper = styled.div`
@@ -73,7 +73,10 @@ export const StyledHeaderColumnControls = styled.span`
   padding-left: 0;
   opacity: 0;
   overflow: hidden;
-  transition: max-width 0.15s ease, opacity 0.12s ease, padding-left 0.15s ease;
+  transition:
+    max-width 0.15s ease,
+    opacity 0.12s ease,
+    padding-left 0.15s ease;
 `;
 
 export const StyledHeaderColumnContent = styled.div<{ $isDragging?: boolean }>`
@@ -172,7 +175,6 @@ export const StyledTableControl = styled(StyledSpaceBetween)`
   position: relative;
   padding: ${({ theme }) => theme.space[2]};
   padding-top: 0.2rem;
-  margin-right: 2rem;
   z-index: 20;
 `;
 

--- a/packages/client/src/pages/Query/Explorer/ExplorerTable/Header/ExploreTableHeader.tsx
+++ b/packages/client/src/pages/Query/Explorer/ExplorerTable/Header/ExploreTableHeader.tsx
@@ -6,9 +6,11 @@ import { WIDTH_COLUMN_FIRST } from "../constants";
 
 const ExploreTableHeader: React.FC<{
   columns: Explore.IExploreColumn[];
+  /** Content-estimated widths per column id; static fallback when absent. */
+  columnWidths: Record<string, number>;
   onRemoveColumn: (id: string) => void;
   onMoveColumn: (fromIndex: number, toIndex: number) => void;
-}> = React.memo(({ columns, onRemoveColumn, onMoveColumn }) => {
+}> = React.memo(({ columns, columnWidths, onRemoveColumn, onMoveColumn }) => {
   return (
     <StyledHeader>
       <StyledHeaderEntityCell
@@ -26,6 +28,7 @@ const ExploreTableHeader: React.FC<{
           <ExploreTableHeaderColumn
             key={column.id}
             column={column}
+            width={columnWidths[column.id]}
             index={key}
             isFirst={key === 0}
             isLast={key === columns.length - 1}

--- a/packages/client/src/pages/Query/Explorer/ExplorerTable/Header/ExploreTableHeaderColumn.tsx
+++ b/packages/client/src/pages/Query/Explorer/ExplorerTable/Header/ExploreTableHeaderColumn.tsx
@@ -19,6 +19,8 @@ import { ExploreTableHeaderTooltip } from "./ExploreTableHeaderTooltip";
 
 interface ExploreTableHeaderColumn {
   column: Explore.IExploreColumn;
+  /** Content-estimated width; falls back to the static width per type. */
+  width?: number;
   index: number;
   isFirst: boolean;
   isLast: boolean;
@@ -28,6 +30,7 @@ interface ExploreTableHeaderColumn {
 
 const ExploreTableHeaderColumn: React.FC<ExploreTableHeaderColumn> = ({
   column,
+  width: dynamicWidth,
   index,
   isFirst,
   isLast,
@@ -37,7 +40,7 @@ const ExploreTableHeaderColumn: React.FC<ExploreTableHeaderColumn> = ({
   const theme = useTheme();
   const dropRef = useRef<HTMLDivElement>(null);
   const dragRef = useRef<HTMLSpanElement>(null);
-  const width = getColumnWidth(column.type);
+  const width = dynamicWidth ?? getColumnWidth(column.type);
 
   const [{ handlerId }, drop] = useDrop<DragItem, void, { handlerId: Identifier | null }>({
     accept: ItemTypes.EXPLORER_COLUMN,

--- a/packages/client/src/pages/Query/Explorer/ExplorerTable/constants.ts
+++ b/packages/client/src/pages/Query/Explorer/ExplorerTable/constants.ts
@@ -2,4 +2,7 @@ export const WIDTH_COLUMN_FIRST = 280;
 export const WIDTH_COLUMN_DEFAULT = 400;
 export const WIDTH_COLUMN_EUC = 210;
 export const WIDTH_COLUMN_NARROW = 160;
+/** Bounds for content-estimated (dynamic) column widths. */
+export const WIDTH_COLUMN_MIN = 160;
+export const WIDTH_COLUMN_MAX = 640;
 export const HEIGHT_ROW_DEFAULT = 38;

--- a/packages/client/src/pages/Query/Explorer/ExplorerTable/types.ts
+++ b/packages/client/src/pages/Query/Explorer/ExplorerTable/types.ts
@@ -42,3 +42,16 @@ export const smallColumnTypes = new Set([
   Explore.EExploreColumnType.ELI,
 ]);
 
+/**
+ * Column types whose width is estimated from cell content (entity tags +
+ * optional suggester). Fixed-control columns (status/language/POS dropdowns,
+ * user tag, plain text) keep their static widths.
+ */
+export const contentSizedColumnTypes = new Set([
+  Explore.EExploreColumnType.ER,
+  Explore.EExploreColumnType.EPV,
+  Explore.EExploreColumnType.EPT,
+  Explore.EExploreColumnType.ERR,
+  Explore.EExploreColumnType.ERV,
+]);
+

--- a/packages/client/src/pages/Query/Explorer/ExplorerTable/utils.ts
+++ b/packages/client/src/pages/Query/Explorer/ExplorerTable/utils.ts
@@ -1,9 +1,104 @@
+import { IEntity, IResponseQueryEntity, IUser } from "@inkvisitor/shared/types";
 import { Explore } from "@inkvisitor/shared/types/query";
-import { WIDTH_COLUMN_DEFAULT, WIDTH_COLUMN_EUC, WIDTH_COLUMN_NARROW } from "./constants";
+import {
+  WIDTH_COLUMN_DEFAULT,
+  WIDTH_COLUMN_EUC,
+  WIDTH_COLUMN_MAX,
+  WIDTH_COLUMN_MIN,
+  WIDTH_COLUMN_NARROW,
+} from "./constants";
 import { narrowColumnTypes, smallColumnTypes } from "./types";
 
 export const getColumnWidth = (type: Explore.EExploreColumnType): number => {
   if (narrowColumnTypes.has(type)) return WIDTH_COLUMN_NARROW;
   if (smallColumnTypes.has(type)) return WIDTH_COLUMN_EUC;
   return WIDTH_COLUMN_DEFAULT;
+};
+
+// --- Content-based column width estimation -------------------------------
+// Widths are estimated from the loaded data window (never DOM-measured: rows
+// are virtualized, so measuring would loop and jitter with scroll position).
+// The estimates are consumed through a ratchet in ExplorerTable - a column
+// only ever grows within one query, so scrolling into sparser rows never
+// shrinks columns and jumps the layout.
+
+// NOTE: the app root font-size is 62.5%, so 1rem = 10px - all px below are
+// calibrated against that.
+/** Average glyph width (px) at the cell font size (xs at 10px root). */
+const CELL_CHAR_PX = 6;
+/** EntityTag label cap: theme.space[30] = 7.5rem = 75px. */
+const TAG_LABEL_MAX_PX = 75;
+/** EntityTag class-marker square + borders. */
+const TAG_MARKER_PX = 24;
+/** EntityTag unlink button, shown in editable columns. */
+const TAG_BUTTON_PX = 22;
+/** Cap for primitive (plain text) cell values. */
+const TEXT_MAX_PX = 150;
+/** Gap between items inside a cell (0.25rem). */
+const CELL_GAP_PX = 4;
+/** qt-col horizontal padding (1rem left + 0.3rem right) plus slack. */
+const CELL_PADDING_PX = 26;
+/** "..." overflow indicator (StyledDots: three glyphs + 0.25rem margin). */
+const OVERFLOW_CHIP_PX = 18;
+/** Compact EntitySuggester (74px input + button chrome). */
+const SUGGESTER_PX = 110;
+
+const getItemLabel = (item: unknown): string => {
+  if (item && typeof item === "object") {
+    const it = item as Partial<IEntity> & Partial<IUser>;
+    return it.labels?.[0] ?? it.name ?? "";
+  }
+  return String(item ?? "");
+};
+
+const estimateItemWidth = (item: unknown, hasUnlink: boolean): number => {
+  const labelPx = getItemLabel(item).length * CELL_CHAR_PX;
+  // Objects render as tags (EntityTag/UserTag): class marker + label capped at
+  // the tag's own max-width + unlink button on editable columns. Primitives
+  // render as plain truncated text.
+  if (item && typeof item === "object") {
+    return TAG_MARKER_PX + Math.min(labelPx, TAG_LABEL_MAX_PX) + (hasUnlink ? TAG_BUTTON_PX : 0);
+  }
+  return Math.min(labelPx, TEXT_MAX_PX);
+};
+
+/**
+ * Estimate the width (px) a column needs to show the widest cell in the given
+ * data window without truncating item count. `displayLimit` caps how many
+ * items a cell renders before collapsing the rest into the overflow chip
+ * (CELL_DISPLAY_LIMIT), which also bounds the estimate.
+ */
+export const estimateColumnWidth = (
+  column: Explore.IExploreColumn,
+  rows: IResponseQueryEntity[],
+  displayLimit: number,
+): number => {
+  let maxContent = 0;
+  for (const row of rows) {
+    const cell = row.columnData[column.id];
+    const items = Array.isArray(cell)
+      ? cell
+      : cell !== undefined && cell !== null && cell !== ""
+        ? [cell]
+        : [];
+
+    let w = 0;
+    for (const item of items.slice(0, displayLimit)) {
+      w += estimateItemWidth(item, column.editable) + CELL_GAP_PX;
+    }
+    if (items.length > displayLimit) {
+      w += OVERFLOW_CHIP_PX;
+    }
+    maxContent = Math.max(maxContent, w);
+  }
+
+  let width = CELL_PADDING_PX + maxContent;
+  if (column.editable) {
+    // Editable cells always render the compact suggester next to the content.
+    width += SUGGESTER_PX + CELL_GAP_PX;
+  }
+
+  // Floor keeps the header (drag handle + label + controls) usable on sparse
+  // columns; cap stops a single long row from blowing up the table.
+  return Math.min(Math.max(width, WIDTH_COLUMN_MIN), WIDTH_COLUMN_MAX);
 };

--- a/packages/server/src/service/query/results.ts
+++ b/packages/server/src/service/query/results.ts
@@ -213,6 +213,25 @@ export default class Results<T extends { id: string }> {
           out[column.id] = resources;
           break;
         }
+        // Entity Reference Values
+        case Explore.EExploreColumnType.ERV: {
+          const params =
+            column.params as Explore.IExploreColumnParams<Explore.EExploreColumnType.ERV>;
+
+          const resourceId = params.resource;
+          const entityIds: Record<string, null> = {};
+
+          entity.references
+            .filter((ref) => ref.resource === resourceId)
+            .forEach((ref) => {
+              if (ref.value) {
+                entityIds[ref.value] = null;
+              }
+            });
+
+          out[column.id] = await Entity.findEntitiesByIds(db, Object.keys(entityIds));
+          break;
+        }
         // Entity Property types
         case Explore.EExploreColumnType.EPT: {
           const entities = await Entity.findEntitiesByIds(

--- a/packages/shared/types/query.ts
+++ b/packages/shared/types/query.ts
@@ -1114,6 +1114,8 @@ export namespace Explore {
     type: ExploreColumnParamValueType;
     label: string;
     isRequired: boolean;
+    /** For "entity" params: restrict the suggester to these classes. Defaults to Concept. */
+    entityClasses?: EntityEnums.Class[];
   }
 
   /** Params for column types that require configuration */
@@ -1122,6 +1124,9 @@ export namespace Explore {
   }
   export interface IExploreColumnParamsEPV {
     propertyType: string;
+  }
+  export interface IExploreColumnParamsERV {
+    resource: string;
   }
   /** Empty params for column types with no configuration */
   export type IExploreColumnParamsEmpty = Record<string, never>;
@@ -1139,7 +1144,7 @@ export namespace Explore {
     [EExploreColumnType.EPV]: IEExploreColumnTypeConfigEntry<IExploreColumnParamsEPV>;
     [EExploreColumnType.EPT]: IEExploreColumnTypeConfigEntry<IExploreColumnParamsEmpty>;
     [EExploreColumnType.ERR]: IEExploreColumnTypeConfigEntry<IExploreColumnParamsEmpty>;
-    [EExploreColumnType.ERV]: IEExploreColumnTypeConfigEntry<IExploreColumnParamsEmpty>;
+    [EExploreColumnType.ERV]: IEExploreColumnTypeConfigEntry<IExploreColumnParamsERV>;
     [EExploreColumnType.ES]: IEExploreColumnTypeConfigEntry<IExploreColumnParamsEmpty>;
     [EExploreColumnType.CPV]: IEExploreColumnTypeConfigEntry<IExploreColumnParamsEmpty>;
     [EExploreColumnType.CPO]: IEExploreColumnTypeConfigEntry<IExploreColumnParamsEmpty>;
@@ -1202,9 +1207,19 @@ export namespace Explore {
     },
     [EExploreColumnType.ERV]: {
       label: "Entity Reference Values",
-      description: "Shows the value side of entity references.",
-      isDisabled: true,
-      params: {},
+      description:
+        "Shows the value side of entity references for a specific resource. The resource is a Resource entity that defines which reference values are displayed.",
+      isDisabled: false,
+      params: { resource: "" },
+      paramsDef: [
+        {
+          id: "resource",
+          type: "entity",
+          label: "Reference resource",
+          isRequired: true,
+          entityClasses: [EntityEnums.Class.Resource],
+        },
+      ],
     },
     [EExploreColumnType.ES]: {
       label: "Entity Statements",


### PR DESCRIPTION
## Changes:
1. feat(Explorer): add entity reference value column support
2. Use whole page width when table overflows horizontally
3. feat(ExplorerTable): content-estimated column widths — auto-sizes columns based on content

Close #3070