### PR TITLE
3047 Statement text in detail and anchorTexts for Statement EntityTag

### DIFF
--- a/packages/client/src/Theme/constants.ts
+++ b/packages/client/src/Theme/constants.ts
@@ -76,6 +76,7 @@ export const tooltipLabelSeparator = " • ";
 export const SAFE_PASSWORD_DESCRIPTION =
   "A safe password: at least 12 characters, a combination of uppercase letters, lowercase letters, numbers, and symbols.";
 export const MIN_LABEL_LENGTH_MESSAGE = "Fill in at least one character";
+export const STATEMENT_LABEL_NOT_RECOMMENDED = "label is not recommended for Statements";
 
 // animations
 export const springConfig: { [key: string]: {} } = {

--- a/packages/client/src/Theme/theme-dark.ts
+++ b/packages/client/src/Theme/theme-dark.ts
@@ -49,8 +49,8 @@ const darkTheme = {
     greyer: "#b5b5b5",
     text: "#c7c7c7",
     primary: "#f6f6ff",
-    primaryRGBA: "rgba(246,246,255,1)",
-    primaryRGBA0: "rgba(246,246,255,0)",
+    statementHighlight: "rgba(158,170,215,1)", // success accent, matches opened-row bar
+    statementHighlight0: "rgba(158,170,215,0)",
     success: "#9eaad7",
     explorerHeader: "#091034",
     warning: "#f0c862",

--- a/packages/client/src/Theme/theme.ts
+++ b/packages/client/src/Theme/theme.ts
@@ -46,8 +46,8 @@ const theme = {
     greyer: "#4a5568",
     text: "#383737",
     primary: "#091034",
-    primaryRGBA: "rgba(9,16,52,1)",
-    primaryRGBA0: "rgba(9,16,52,0)",
+    statementHighlight: "rgba(97,116,194,1)", // success accent, matches opened-row bar
+    statementHighlight0: "rgba(97,116,194,0)",
     success: "#6174C2",
     warning: "#D8AA37",
     danger: "#99103B",

--- a/packages/client/src/components/advanced/Annotator/Annotator.tsx
+++ b/packages/client/src/components/advanced/Annotator/Annotator.tsx
@@ -553,7 +553,9 @@ export const TextAnnotator = ({
           const newStatement: IStatement = CStatement(
             getStoredUserRole() as UserEnums.Role,
             userData.options,
-            text,
+            // Statements are not meant to carry a label — the New Statement
+            // button no longer fills it with the selected text.
+            "",
             "",
             effectiveTerritoryId,
             statementId,

--- a/packages/client/src/components/advanced/Annotator/Annotator.tsx
+++ b/packages/client/src/components/advanced/Annotator/Annotator.tsx
@@ -1910,6 +1910,10 @@ export const TextAnnotator = ({
           labelTyped={newTerritoryName}
           parentTerritory={territoryCreateParent}
           entityCreateTerritoryOrder={territoryCreateOrder}
+          // propagate the anchor elvl (from the Sibling/Child click) into the
+          // modal footer, same as the suggester → create-modal path
+          anchorElvl={territoryElvl}
+          onAnchorElvlChange={setTerritoryElvl}
           onMutationSuccess={async (entity) => {
             await handleAddAnchor(entity.id, territoryElvl);
             setTerritoryCreateModalType(false);

--- a/packages/client/src/components/advanced/Annotator/AnnotatorMenu.tsx
+++ b/packages/client/src/components/advanced/Annotator/AnnotatorMenu.tsx
@@ -786,7 +786,9 @@ export const TextAnnotatorMenu = ({
                       inverted={anchorsEditActive}
                       noBackground={anchorsEditActive}
                       tooltipLabel="view mode"
-                      tooltipContent={<p>(hold ctrl/cmd over the list for temporary edit mode)</p>}
+                      tooltipContent={
+                        <p>(hold ctrl or cmd over the list for temporary edit mode)</p>
+                      }
                       onClick={() => handleAnchorsEditModeChange(false)}
                     />
                     <Button

--- a/packages/client/src/components/advanced/Annotator/AnnotatorMenu.tsx
+++ b/packages/client/src/components/advanced/Annotator/AnnotatorMenu.tsx
@@ -241,9 +241,11 @@ export const TextAnnotatorMenu = ({
   );
   const [statementElvl, setStatementElvl] = useState<EntityEnums.Elvl>(EntityEnums.Elvl.Textual);
   const [suggesterElvl, setSuggesterElvl] = useState<EntityEnums.Elvl>(EntityEnums.Elvl.Textual);
-  // While the suggester input is focused, the elvl group shows a warning ring to
-  // remind the user to check the (pre-selected) epistemic level before acting.
+  // While the suggester input is focused or hovered, the elvl group shows a
+  // warning ring to remind the user to check the (pre-selected) epistemic level
+  // before acting.
   const [suggesterFocused, setSuggesterFocused] = useState(false);
+  const [suggesterHovered, setSuggesterHovered] = useState(false);
   const [territoryElvl, setTerritoryElvl] = useState<EntityEnums.Elvl>(EntityEnums.Elvl.Textual);
 
   // The deepest leaf subT at the cursor (smallest span = innermost) is the
@@ -653,7 +655,10 @@ export const TextAnnotatorMenu = ({
               </StyledAnnotatorItemContent>
               {/* Entity Suggester */}
               <StyledAnnotatorItemContent>
-                <StyledAnnotatorItemContentLine>
+                <StyledAnnotatorItemContentLine
+                  onMouseEnter={() => setSuggesterHovered(true)}
+                  onMouseLeave={() => setSuggesterHovered(false)}
+                >
                   <EntitySuggester
                     categoryTypes={classesAnnotator}
                     statementLabelHint
@@ -685,7 +690,7 @@ export const TextAnnotatorMenu = ({
                     rightContent={
                       <ElvlButtonGroup
                         value={suggesterElvl}
-                        warning={suggesterFocused}
+                        warning={suggesterFocused || suggesterHovered}
                         onChange={(suggesterElvl) => {
                           setSuggesterElvl(suggesterElvl);
                         }}

--- a/packages/client/src/components/advanced/Annotator/AnnotatorMenu.tsx
+++ b/packages/client/src/components/advanced/Annotator/AnnotatorMenu.tsx
@@ -55,6 +55,7 @@ import {
   StyledAnnotatorMenuDragHandle,
   StyledAnnotatorNoAnchors,
   StyledCaretButtonWrapper,
+  StyledElvlWarningTrigger,
   StyledMoveAnchorControls,
   StyledMoveAnchorFooter,
   StyledMoveAnchorGroup,
@@ -247,6 +248,10 @@ export const TextAnnotatorMenu = ({
   const [suggesterFocused, setSuggesterFocused] = useState(false);
   const [suggesterHovered, setSuggesterHovered] = useState(false);
   const [territoryElvl, setTerritoryElvl] = useState<EntityEnums.Elvl>(EntityEnums.Elvl.Textual);
+  // Hovering a create button rings its elvl group as a reminder to check the
+  // (pre-selected) epistemic level before acting — same cue as the suggester.
+  const [statementBtnHovered, setStatementBtnHovered] = useState(false);
+  const [territoryBtnHovered, setTerritoryBtnHovered] = useState(false);
 
   // The deepest leaf subT at the cursor (smallest span = innermost) is the
   // "relevant" T and the default Statement target. The active T (opened in the
@@ -615,19 +620,29 @@ export const TextAnnotatorMenu = ({
                 {onCreateStatement && (
                   <StyledStatementSubsection>
                     <StyledAnnotatorItemContentLine>
-                      <Button
-                        label="New Statement"
-                        tooltipLabel={`Create new Statement in ${
-                          selectedTargetTerritoryEntity
-                            ? selectedTargetTerritoryEntity.labels[0]
-                            : "the active T"
-                        }`}
-                        icon={<TbAnchor size={15} />}
-                        color="primary"
-                        onClick={() => {
-                          onCreateStatement(statementElvl, undefined, selectedTargetTerritoryId);
-                        }}
-                      />
+                      <StyledElvlWarningTrigger
+                        onMouseEnter={() => setStatementBtnHovered(true)}
+                        onMouseLeave={() => setStatementBtnHovered(false)}
+                      >
+                        <Button
+                          label="New Statement"
+                          tooltipContent={
+                            <p>
+                              Create new Statement in{" "}
+                              <strong>
+                                {selectedTargetTerritoryEntity
+                                  ? selectedTargetTerritoryEntity.labels[0]
+                                  : "the active T"}
+                              </strong>
+                            </p>
+                          }
+                          icon={<TbAnchor size={15} />}
+                          color="primary"
+                          onClick={() => {
+                            onCreateStatement(statementElvl, undefined, selectedTargetTerritoryId);
+                          }}
+                        />
+                      </StyledElvlWarningTrigger>
                       {renderTargetTrailer(
                         statementTargetPicker,
                         "Choose target territory for the new Statement",
@@ -635,6 +650,7 @@ export const TextAnnotatorMenu = ({
                       <ElvlButtonGroup
                         border
                         value={statementElvl}
+                        warning={statementBtnHovered}
                         onChange={(statementElvl) => {
                           setStatementElvl(statementElvl);
                         }}
@@ -706,7 +722,10 @@ export const TextAnnotatorMenu = ({
                     {onCreateTerritory && (
                       <StyledTerritorySubsection>
                         <StyledTerritorySubsectionTitle>territory</StyledTerritorySubsectionTitle>
-                        <StyledTerritoryButtonColumn>
+                        <StyledTerritoryButtonColumn
+                          onMouseEnter={() => setTerritoryBtnHovered(true)}
+                          onMouseLeave={() => setTerritoryBtnHovered(false)}
+                        >
                           {selectedTargetHasParentT && (
                             <Button
                               icon={<TerritorySiblingIcon />}
@@ -746,6 +765,7 @@ export const TextAnnotatorMenu = ({
                         <ElvlButtonGroup
                           border
                           value={territoryElvl}
+                          warning={territoryBtnHovered}
                           onChange={(territoryElvl) => {
                             setTerritoryElvl(territoryElvl);
                           }}

--- a/packages/client/src/components/advanced/Annotator/AnnotatorMenu.tsx
+++ b/packages/client/src/components/advanced/Annotator/AnnotatorMenu.tsx
@@ -381,13 +381,11 @@ export const TextAnnotatorMenu = ({
   }, [anchors, entities]);
 
   // Anchor controls mode: view (kebab menu + static elvl) or edit (inline
-  // resize / elvl / unlink). Persisted so the choice survives menu reopen.
-  const [anchorsEditMode, setAnchorsEditMode] = useState<boolean>(
-    () => localStorage.getItem("annotatorAnchorsEditMode") === "true",
-  );
+  // resize / elvl / unlink). Always starts in view mode and resets to view on
+  // menu close — not persisted across sessions.
+  const [anchorsEditMode, setAnchorsEditMode] = useState<boolean>(false);
   const handleAnchorsEditModeChange = (edit: boolean) => {
     setAnchorsEditMode(edit);
-    localStorage.setItem("annotatorAnchorsEditMode", String(edit));
   };
   // Holding Ctrl/Cmd while hovering the anchor list enables edit mode
   // temporarily.

--- a/packages/client/src/components/advanced/Annotator/AnnotatorMenu.tsx
+++ b/packages/client/src/components/advanced/Annotator/AnnotatorMenu.tsx
@@ -655,11 +655,12 @@ export const TextAnnotatorMenu = ({
                 <StyledAnnotatorItemContentLine>
                   <EntitySuggester
                     categoryTypes={classesAnnotator}
+                    statementLabelHint
                     initTyped={text.length > 30 ? text.substring(0, 30) : text}
                     onSelected={(newAnchorId) => {
                       onAnchorAdd(newAnchorId, suggesterElvl);
                     }}
-                    inputWidth={200}
+                    inputWidth="full"
                     openDetailOnCreate
                     parentTerritory={selectedTargetTerritoryEntity || territory}
                     onEntityCreateMutationSuccess={(entity) => {
@@ -679,13 +680,15 @@ export const TextAnnotatorMenu = ({
                       onCreateStatement && onCreateStatement(suggesterElvl, entityCreateModalProps)
                     }
                     disableCleanTypedAfterCreate
-                  />
-                  <ElvlButtonGroup
-                    border
-                    value={suggesterElvl}
-                    onChange={(suggesterElvl) => {
-                      setSuggesterElvl(suggesterElvl);
-                    }}
+                    rightContent={
+                      <ElvlButtonGroup
+                        border
+                        value={suggesterElvl}
+                        onChange={(suggesterElvl) => {
+                          setSuggesterElvl(suggesterElvl);
+                        }}
+                      />
+                    }
                   />
                 </StyledAnnotatorItemContentLine>
               </StyledAnnotatorItemContent>

--- a/packages/client/src/components/advanced/Annotator/AnnotatorMenu.tsx
+++ b/packages/client/src/components/advanced/Annotator/AnnotatorMenu.tsx
@@ -242,6 +242,9 @@ export const TextAnnotatorMenu = ({
   );
   const [statementElvl, setStatementElvl] = useState<EntityEnums.Elvl>(EntityEnums.Elvl.Textual);
   const [suggesterElvl, setSuggesterElvl] = useState<EntityEnums.Elvl>(EntityEnums.Elvl.Textual);
+  // While the suggester input is focused, the elvl group shows a warning ring to
+  // remind the user to check the (pre-selected) epistemic level before acting.
+  const [suggesterFocused, setSuggesterFocused] = useState(false);
   const [territoryElvl, setTerritoryElvl] = useState<EntityEnums.Elvl>(EntityEnums.Elvl.Textual);
 
   // The deepest leaf subT at the cursor (smallest span = innermost) is the
@@ -680,10 +683,11 @@ export const TextAnnotatorMenu = ({
                       onCreateStatement && onCreateStatement(suggesterElvl, entityCreateModalProps)
                     }
                     disableCleanTypedAfterCreate
+                    onFocusChange={setSuggesterFocused}
                     rightContent={
                       <ElvlButtonGroup
-                        border
                         value={suggesterElvl}
+                        warning={suggesterFocused}
                         onChange={(suggesterElvl) => {
                           setSuggesterElvl(suggesterElvl);
                         }}

--- a/packages/client/src/components/advanced/Annotator/AnnotatorMenu.tsx
+++ b/packages/client/src/components/advanced/Annotator/AnnotatorMenu.tsx
@@ -252,6 +252,9 @@ export const TextAnnotatorMenu = ({
   // (pre-selected) epistemic level before acting — same cue as the suggester.
   const [statementBtnHovered, setStatementBtnHovered] = useState(false);
   const [territoryBtnHovered, setTerritoryBtnHovered] = useState(false);
+  // A create-button hover owns the warning ring while it lasts, so the
+  // persistent suggester-focus ring steps aside — never two rings at once.
+  const createBtnHovered = statementBtnHovered || territoryBtnHovered;
 
   // The deepest leaf subT at the cursor (smallest span = innermost) is the
   // "relevant" T and the default Statement target. The active T (opened in the
@@ -706,7 +709,7 @@ export const TextAnnotatorMenu = ({
                     rightContent={
                       <ElvlButtonGroup
                         value={suggesterElvl}
-                        warning={suggesterFocused || suggesterHovered}
+                        warning={(suggesterFocused || suggesterHovered) && !createBtnHovered}
                         onChange={(suggesterElvl) => {
                           setSuggesterElvl(suggesterElvl);
                         }}

--- a/packages/client/src/components/advanced/Annotator/AnnotatorMenu.tsx
+++ b/packages/client/src/components/advanced/Annotator/AnnotatorMenu.tsx
@@ -687,6 +687,8 @@ export const TextAnnotatorMenu = ({
                     }
                     disableCleanTypedAfterCreate
                     onFocusChange={setSuggesterFocused}
+                    anchorElvl={suggesterElvl}
+                    onAnchorElvlChange={setSuggesterElvl}
                     rightContent={
                       <ElvlButtonGroup
                         value={suggesterElvl}

--- a/packages/client/src/components/advanced/Annotator/AnnotatorMenu.tsx
+++ b/packages/client/src/components/advanced/Annotator/AnnotatorMenu.tsx
@@ -33,6 +33,7 @@ import { IcoTrash } from "Theme/icons";
 import { ButtonSize, classesAnnotator } from "types";
 import { EntitySuggester } from "../EntitySuggester/EntitySuggester";
 import { EntityTag } from "../EntityTag/EntityTag";
+import { EntityTagById } from "../EntityTag/EntityTagById";
 import { ElvlButtonGroup } from "../IconButtonGroups/ElvlButtonGroup";
 import { TerritoryChildIcon, TerritorySiblingIcon } from "./AnnotatorIcons";
 import {
@@ -55,7 +56,6 @@ import {
   StyledAnnotatorNoAnchors,
   StyledCaretButtonWrapper,
   StyledMoveAnchorControls,
-  StyledMoveAnchorEntityTag,
   StyledMoveAnchorFooter,
   StyledMoveAnchorGroup,
   StyledMoveAnchorGroupLabel,
@@ -70,7 +70,6 @@ import {
 } from "./AnnotatorStyles";
 import { AnnotatorPositionTNode, TerritoryCreateModalType } from "./types";
 import { useAnnotatorTargetPicker } from "./useAnnotatorTargetPicker";
-import { EntityTagById } from "../EntityTag/EntityTagById";
 
 interface TextAnnotatorMenuProps {
   text: string;
@@ -332,6 +331,7 @@ export const TextAnnotatorMenu = ({
         </StyledStatementTargetArrow>
         <StyledStatementTargetCurrent>
           <EntityTag
+            fullWidth
             disableCopyToClipboard
             entity={selectedTargetTerritoryEntity}
             disableDoubleClick
@@ -460,9 +460,7 @@ export const TextAnnotatorMenu = ({
             Resize anchor span
           </StyledAnnotatorItemTitle>
           <StyledAnnotatorItemContent>
-            <StyledMoveAnchorEntityTag>
-              <EntityTag entity={movingEntity} fullWidth disableDrag disableDoubleClick />
-            </StyledMoveAnchorEntityTag>
+            <EntityTag entity={movingEntity} fullWidth disableDrag disableDoubleClick />
             <StyledMoveAnchorPanel>
               <StyledMoveAnchorControls>
                 <StyledMoveAnchorGroup>
@@ -601,7 +599,7 @@ export const TextAnnotatorMenu = ({
                       }}
                       tooltipLabel="Create anchor for active territory"
                     />
-                    {activeTerritoryId && <EntityTagById entityId={activeTerritoryId} />}
+                    {activeTerritoryId && <EntityTagById fullWidth entityId={activeTerritoryId} />}
                     <ElvlButtonGroup
                       border
                       value={activeTerritoryElvl}

--- a/packages/client/src/components/advanced/Annotator/AnnotatorMenuAnchorListRow.tsx
+++ b/packages/client/src/components/advanced/Annotator/AnnotatorMenuAnchorListRow.tsx
@@ -68,7 +68,10 @@ type AnnotatorAnchorGridCell = {
 type AnnotatorAnchorControlsCluster = Pick<
   AnnotatorAnchorGridCell,
   "item" | "onRemoveAnchor" | "onUpdateAnchor" | "onMoveAnchor" | "editControls"
->;
+> & {
+  /** Entity status → colors the elvl divider like the tag's other status borders. */
+  status: EntityEnums.Status;
+};
 
 /**
  * The anchor row's controls, rendered in the tag's button slot. Owns its own
@@ -86,6 +89,7 @@ const AnnotatorAnchorControlsCluster: React.FC<AnnotatorAnchorControlsCluster> =
   onUpdateAnchor,
   onMoveAnchor,
   editControls,
+  status,
 }) => {
   const [hovered, setHovered] = useState(false);
   const elvlValue = item.anchor.attributes.elvl as EntityEnums.Elvl;
@@ -118,7 +122,7 @@ const AnnotatorAnchorControlsCluster: React.FC<AnnotatorAnchorControlsCluster> =
                 shape="sharp-square"
               />
             )}
-            <StyledAnchorClusterElvl>
+            <StyledAnchorClusterElvl $tagBorderColorKey={status}>
               <ElvlButtonGroup
                 value={elvlValue}
                 onChange={(elvl) => {
@@ -179,6 +183,7 @@ const AnnotatorAnchorGridCell: React.FC<AnnotatorAnchorGridCell> = ({
           controlsAvailable ? (
             <AnnotatorAnchorControlsCluster
               item={item}
+              status={entity.status}
               onRemoveAnchor={onRemoveAnchor}
               onUpdateAnchor={onUpdateAnchor}
               onMoveAnchor={onMoveAnchor}

--- a/packages/client/src/components/advanced/Annotator/AnnotatorStyles.tsx
+++ b/packages/client/src/components/advanced/Annotator/AnnotatorStyles.tsx
@@ -1,3 +1,4 @@
+import { EntityEnums } from "@inkvisitor/shared/enums";
 import styled from "styled-components";
 
 /** Defined before viewport so the parent can target it on hover. */
@@ -424,9 +425,13 @@ export const StyledAnchorClusterMoveButton = styled.div`
  * group's own look: a single thin divider on its left (as in the tag's native
  * elvl slot) and no divider between the option buttons.
  */
-export const StyledAnchorClusterElvl = styled.div`
+interface StyledAnchorClusterElvl {
+  $tagBorderColorKey: EntityEnums.Status;
+}
+export const StyledAnchorClusterElvl = styled.div<StyledAnchorClusterElvl>`
   display: flex;
-  border-left: ${({ theme }) => `2px solid ${theme.color["black"]}`};
+  border-left: ${({ theme, $tagBorderColorKey }) =>
+    `2px solid ${theme.color.tagBorderColor[$tagBorderColorKey]}`};
   && button {
     border-left-width: 0;
   }

--- a/packages/client/src/components/advanced/Annotator/AnnotatorStyles.tsx
+++ b/packages/client/src/components/advanced/Annotator/AnnotatorStyles.tsx
@@ -344,6 +344,11 @@ export const StyledCaretButtonWrapper = styled.span`
   display: flex;
 `;
 
+/** Wraps a create button so hovering it can ring its related elvl group. */
+export const StyledElvlWarningTrigger = styled.span`
+  display: flex;
+`;
+
 // #2885 — move-anchor mode: compact panel that replaces the menu body while
 // an anchor span is being nudged with the arrow buttons.
 export const StyledMoveAnchorPanel = styled.div`

--- a/packages/client/src/components/advanced/Annotator/AnnotatorStyles.tsx
+++ b/packages/client/src/components/advanced/Annotator/AnnotatorStyles.tsx
@@ -374,13 +374,6 @@ export const StyledMoveAnchorGroupLabel = styled.div`
   margin-bottom: ${({ theme }) => theme.space[1]};
 `;
 
-export const StyledMoveAnchorEntityTag = styled.div`
-  display: grid;
-  align-items: center;
-  width: 100%;
-  padding-left: ${({ theme }) => theme.space[1]};
-`;
-
 export const StyledMoveAnchorFooter = styled.div`
   display: flex;
   justify-content: flex-end;

--- a/packages/client/src/components/advanced/EntityCreateModal/EntityCreateModal.tsx
+++ b/packages/client/src/components/advanced/EntityCreateModal/EntityCreateModal.tsx
@@ -76,7 +76,11 @@ export const EntityCreateModal: React.FC<EntityCreateModal> = ({
     setShowModal(true);
   }, []);
 
-  const [label, setLabel] = useState(labelTyped);
+  // Statements are not meant to carry a label — start empty so the hint
+  // placeholder shows instead of prefilling the selected text.
+  const [label, setLabel] = useState(
+    categorySelected === EntityEnums.Class.Statement ? "" : labelTyped
+  );
   const [detailTyped, setDetailTyped] = useState("");
   const [selectedCategory, setSelectedCategory] = useState<EntityEnums.Class>(
     categorySelected || entityClasses[0]
@@ -117,7 +121,11 @@ export const EntityCreateModal: React.FC<EntityCreateModal> = ({
     if (userRole === UserEnums.Role.Viewer) {
       toast.warning("You don't have permission to create entities");
       return false;
-    } else if (!skipLabelCheck && label.length < 1) {
+    } else if (
+      !skipLabelCheck &&
+      selectedCategory !== EntityEnums.Class.Statement &&
+      label.length < 1
+    ) {
       toast.info(MIN_LABEL_LENGTH_MESSAGE);
       return false;
     } else if (selectedCategory === EntityEnums.Class.Statement && !territoryEntity) {
@@ -340,6 +348,7 @@ export const EntityCreateModal: React.FC<EntityCreateModal> = ({
                   }
                 }}
                 onTyped={(newType: string) => setLabel(newType)}
+                statementLabelHint
                 disableCreate
                 disableTemplatesAccept
                 disableWildCard

--- a/packages/client/src/components/advanced/EntityCreateModal/EntityCreateModal.tsx
+++ b/packages/client/src/components/advanced/EntityCreateModal/EntityCreateModal.tsx
@@ -25,12 +25,16 @@ import {
   ModalInputLabel,
   ModalInputWrap,
 } from "components";
-import Dropdown, { EntitySuggester, EntityTag } from "components/advanced";
+import Dropdown, { ElvlButtonGroup, EntitySuggester, EntityTag } from "components/advanced";
 import { CAction, CConcept, CEntity, CStatement, CTerritory, InstTemplate } from "constructors";
 import React, { useEffect, useMemo, useState } from "react";
 import { toast } from "react-toastify";
 import { getEntityLabel, getShortLabelByLetterCount } from "utils/utils";
-import { StyledNote } from "./EntityCreateModalStyles";
+import {
+  StyledAnchorElvlLabel,
+  StyledAnchorElvlWrap,
+  StyledNote,
+} from "./EntityCreateModalStyles";
 import { useOrderedLanguageDict, useTemplatesQuery, useUserQuery } from "hooks/react-query";
 
 const defaultDropdownValue = "empty";
@@ -56,6 +60,12 @@ interface EntityCreateModal {
   entityCreateTerritoryOrder?: number;
 
   allowedEntityClasses?: EntityEnums.Class[];
+
+  // epistemic level of the anchor created for the new entity (annotator
+  // suggester); when provided, an ElvlButtonGroup is shown in the footer so the
+  // user can pick it without closing the modal
+  anchorElvl?: EntityEnums.Elvl;
+  onAnchorElvlChange?: (elvl: EntityEnums.Elvl) => void;
 }
 export const EntityCreateModal: React.FC<EntityCreateModal> = ({
   closeModal,
@@ -68,6 +78,8 @@ export const EntityCreateModal: React.FC<EntityCreateModal> = ({
   entityCreateStatementOrder,
   entityCreateTerritoryOrder,
   allowedEntityClasses,
+  anchorElvl,
+  onAnchorElvlChange,
 }) => {
   const entityClasses = allowedEntityClasses ? allowedEntityClasses : classesAll;
 
@@ -471,7 +483,17 @@ export const EntityCreateModal: React.FC<EntityCreateModal> = ({
             </>
           )}
         </ModalContent>
-        <ModalFooter>
+        <ModalFooter spaceBetween={anchorElvl !== undefined && !!onAnchorElvlChange}>
+          {anchorElvl !== undefined && onAnchorElvlChange && (
+            <StyledAnchorElvlWrap>
+              <StyledAnchorElvlLabel>{"anchor elvl:"}</StyledAnchorElvlLabel>
+              <ElvlButtonGroup
+                border
+                value={anchorElvl}
+                onChange={(elvl) => onAnchorElvlChange(elvl)}
+              />
+            </StyledAnchorElvlWrap>
+          )}
           <ButtonGroup>
             <Button key="cancel" label="Cancel" color="greyer" inverted onClick={closeModal} />
             <Button key="submit" label="Create" color="info" onClick={handleSubmit} />

--- a/packages/client/src/components/advanced/EntityCreateModal/EntityCreateModalStyles.tsx
+++ b/packages/client/src/components/advanced/EntityCreateModal/EntityCreateModalStyles.tsx
@@ -9,3 +9,12 @@ export const StyledNote = styled.i`
   font-size: ${({ theme }) => theme.fontSize["xs"]};
   text-align: right;
 `;
+export const StyledAnchorElvlWrap = styled.div`
+  display: flex;
+  align-items: center;
+  gap: ${({ theme }) => theme.space[2]};
+`;
+export const StyledAnchorElvlLabel = styled.span`
+  font-size: ${({ theme }) => theme.fontSize["xs"]};
+  color: ${({ theme }) => theme.color["greyer"]};
+`;

--- a/packages/client/src/components/advanced/EntitySuggester/EntitySuggester.tsx
+++ b/packages/client/src/components/advanced/EntitySuggester/EntitySuggester.tsx
@@ -66,6 +66,9 @@ interface EntitySuggesterProps {
   button?: React.ReactNode;
   // rendered inside the suggester input's trailing slot (only when disableCreate)
   rightContent?: React.ReactNode;
+  // notifies the parent when the input gains/loses focus (e.g. the annotator
+  // highlights the elvl group while the suggester is focused)
+  onFocusChange?: (isFocused: boolean) => void;
   preSuggestions?: IEntity[];
 
   disableCreate?: boolean;
@@ -135,6 +138,7 @@ const EntitySuggesterFull: React.FC<
 
   button,
   rightContent,
+  onFocusChange,
   preSuggestions,
 
   disableCreate = false,
@@ -553,6 +557,7 @@ const EntitySuggesterFull: React.FC<
         button={button}
         rightContent={rightContent}
         disableTemplateInstantiation={disableTemplateInstantiation}
+        onFocusChange={onFocusChange}
         isHidden={isHidden}
         externalDroppedItem={externalDroppedItem}
         onConsumeExternalDrop={onConsumeExternalDrop}

--- a/packages/client/src/components/advanced/EntitySuggester/EntitySuggester.tsx
+++ b/packages/client/src/components/advanced/EntitySuggester/EntitySuggester.tsx
@@ -63,6 +63,11 @@ interface EntitySuggesterProps {
   onEntityCreateMutationSuccess?: (entity: IEntity) => void;
   entityCreateStatementOrder?: number;
 
+  // epistemic level of the anchor created for the new entity; forwarded to the
+  // EntityCreateModal so the user can pick it there without closing the modal
+  anchorElvl?: EntityEnums.Elvl;
+  onAnchorElvlChange?: (elvl: EntityEnums.Elvl) => void;
+
   button?: React.ReactNode;
   // rendered inside the suggester input's trailing slot (only when disableCreate)
   rightContent?: React.ReactNode;
@@ -135,6 +140,8 @@ const EntitySuggesterFull: React.FC<
   onCreateStatement,
   onEntityCreateMutationSuccess,
   entityCreateStatementOrder,
+  anchorElvl,
+  onAnchorElvlChange,
 
   button,
   rightContent,
@@ -601,6 +608,8 @@ const EntitySuggesterFull: React.FC<
           parentTerritory={parentTerritory}
           entityCreateStatementOrder={entityCreateStatementOrder}
           onCreateStatement={onCreateStatement}
+          anchorElvl={anchorElvl}
+          onAnchorElvlChange={onAnchorElvlChange}
         />
       )}
     </>

--- a/packages/client/src/components/advanced/EntitySuggester/EntitySuggester.tsx
+++ b/packages/client/src/components/advanced/EntitySuggester/EntitySuggester.tsx
@@ -7,7 +7,7 @@ import {
 import { EntityEnums, UserEnums } from "@inkvisitor/shared/enums";
 import { IEntity, IResponseEntity, IStatement, ITerritory } from "@inkvisitor/shared/types";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { wildCardChar } from "Theme/constants";
+import { STATEMENT_LABEL_NOT_RECOMMENDED, wildCardChar } from "Theme/constants";
 import api from "api";
 import { Suggester, Button } from "components";
 import { CEntity, InstTemplate } from "constructors";
@@ -87,6 +87,11 @@ interface EntitySuggesterProps {
 
   disabled?: boolean;
   isHidden?: boolean;
+  // When the selected class is Statement, empties the input and shows a gray
+  // hint placeholder ("label is not recommended for Statements"); restores the
+  // previously typed text when switching back to another class. Statements are
+  // not meant to carry a label.
+  statementLabelHint?: boolean;
   disableCleanTypedAfterCreate?: boolean;
   clearableInput?: boolean;
   onEmptyAddButtonClick?: () => void;
@@ -149,6 +154,7 @@ const EntitySuggesterFull: React.FC<
 
   disabled = false,
   isHidden = false,
+  statementLabelHint = false,
   externalDroppedItem,
   onConsumeExternalDrop,
   disableCleanTypedAfterCreate = false,
@@ -158,6 +164,9 @@ const EntitySuggesterFull: React.FC<
   includeSubordinates = false,
 }) => {
   const [typed, setTyped] = useState<string>(initTyped ?? "");
+  // Remembers the input typed under a non-Statement class so it can be restored
+  // when the user switches away from Statement (statementLabelHint mode).
+  const preStatementTypedRef = useRef<string>(initTyped ?? "");
   const debouncedTyped = useDebounce(typed, 100);
   const [selectedCategory, setSelectedCategory] = useState<
     EntityEnums.Class | EntityEnums.Extension.Any
@@ -476,7 +485,11 @@ const EntitySuggesterFull: React.FC<
         preSuggestions={
           preSuggestions && filterSuggestions(getClassFilteredPreSuggestions(preSuggestions))
         }
-        placeholder={placeholder}
+        placeholder={
+          statementLabelHint && selectedCategory === EntityEnums.Class.Statement
+            ? STATEMENT_LABEL_NOT_RECOMMENDED
+            : placeholder
+        }
         typed={typed} // input value
         category={selectedCategory} // selected category
         categories={allCategories} // all possible categories
@@ -486,6 +499,24 @@ const EntitySuggesterFull: React.FC<
           onTyped && onTyped(newType);
         }}
         onChangeCategory={(option) => {
+          if (statementLabelHint) {
+            const toStatement =
+              option === EntityEnums.Class.Statement &&
+              selectedCategory !== EntityEnums.Class.Statement;
+            const fromStatement =
+              option !== EntityEnums.Class.Statement &&
+              selectedCategory === EntityEnums.Class.Statement;
+            if (toStatement) {
+              // remember the current text and clear so the hint placeholder shows
+              preStatementTypedRef.current = typed;
+              setTyped("");
+              onTyped && onTyped("");
+            } else if (fromStatement) {
+              // restore the text typed before switching to Statement
+              setTyped(preStatementTypedRef.current);
+              onTyped && onTyped(preStatementTypedRef.current);
+            }
+          }
           setSelectedCategory(option);
           onChangeCategory && onChangeCategory(option);
         }}

--- a/packages/client/src/components/advanced/EntityTag/EntityTag.tsx
+++ b/packages/client/src/components/advanced/EntityTag/EntityTag.tsx
@@ -86,6 +86,12 @@ interface EntityTag {
   isEquivalent?: boolean;
   /** Marks the tag as surfaced via "include subordinates" (inverse SCL/SOE/HOL + child T). */
   isSubordinate?: boolean;
+  /**
+   * Document anchor span(s) of a statement, used as the label when the
+   * statement has no user-defined label (see getEntityLabel). Only meaningful
+   * for statement tags whose anchor text is loaded by the caller.
+   */
+  anchorTexts?: string[];
 }
 
 const EntityTagComponent: React.FC<EntityTag> = ({
@@ -116,6 +122,7 @@ const EntityTagComponent: React.FC<EntityTag> = ({
   onDoubleClick: onDoubleClickOverride,
   isEquivalent = false,
   isSubordinate = false,
+  anchorTexts,
 }) => {
   const { appendDetailId } = useSearchParams();
   const dispatch = useAppDispatch();
@@ -127,7 +134,10 @@ const EntityTagComponent: React.FC<EntityTag> = ({
   const [tagHovered, setTagHovered] = useState(false);
   const [clickedOnce, setClickedOnce] = useState(false);
   const referenceEl = useRef<HTMLDivElement>(null!);
-  const entityLabel = useMemo(() => getEntityLabel(entity), [entity]);
+  const entityLabel = useMemo(
+    () => getEntityLabel(entity, anchorTexts),
+    [entity, anchorTexts]
+  );
 
   useEffect(() => {
     if (!clickedOnce) return;
@@ -388,8 +398,8 @@ function areEntityTagsEqual(
   if (prev.entity?.status !== next.entity.status) return false;
   if (prev.entity?.data?.logicalType !== next.entity?.data?.logicalType) return false;
   if (prev.entity.isTemplate !== next.entity.isTemplate) return false;
-  const prevLabel = getEntityLabel(prev.entity);
-  const nextLabel = getEntityLabel(next.entity);
+  const prevLabel = getEntityLabel(prev.entity, prev.anchorTexts);
+  const nextLabel = getEntityLabel(next.entity, next.anchorTexts);
   if (prevLabel !== nextLabel) return false;
   return true;
 }

--- a/packages/client/src/components/advanced/EntityTag/EntityTag.tsx
+++ b/packages/client/src/components/advanced/EntityTag/EntityTag.tsx
@@ -86,12 +86,6 @@ interface EntityTag {
   isEquivalent?: boolean;
   /** Marks the tag as surfaced via "include subordinates" (inverse SCL/SOE/HOL + child T). */
   isSubordinate?: boolean;
-  /**
-   * Document anchor span(s) of a statement, used as the label when the
-   * statement has no user-defined label (see getEntityLabel). Only meaningful
-   * for statement tags whose anchor text is loaded by the caller.
-   */
-  anchorTexts?: string[];
 }
 
 const EntityTagComponent: React.FC<EntityTag> = ({
@@ -122,7 +116,6 @@ const EntityTagComponent: React.FC<EntityTag> = ({
   onDoubleClick: onDoubleClickOverride,
   isEquivalent = false,
   isSubordinate = false,
-  anchorTexts,
 }) => {
   const { appendDetailId } = useSearchParams();
   const dispatch = useAppDispatch();
@@ -135,8 +128,9 @@ const EntityTagComponent: React.FC<EntityTag> = ({
   const [clickedOnce, setClickedOnce] = useState(false);
   const referenceEl = useRef<HTMLDivElement>(null!);
   const entityLabel = useMemo(
-    () => getEntityLabel(entity, anchorTexts),
-    [entity, anchorTexts]
+    // getEntityLabel reads entity.anchorTexts (stamped by server responses)
+    () => getEntityLabel(entity),
+    [entity],
   );
 
   useEffect(() => {
@@ -398,8 +392,8 @@ function areEntityTagsEqual(
   if (prev.entity?.status !== next.entity.status) return false;
   if (prev.entity?.data?.logicalType !== next.entity?.data?.logicalType) return false;
   if (prev.entity.isTemplate !== next.entity.isTemplate) return false;
-  const prevLabel = getEntityLabel(prev.entity, prev.anchorTexts);
-  const nextLabel = getEntityLabel(next.entity, next.anchorTexts);
+  const prevLabel = getEntityLabel(prev.entity);
+  const nextLabel = getEntityLabel(next.entity);
   if (prevLabel !== nextLabel) return false;
   return true;
 }

--- a/packages/client/src/components/advanced/EntityTag/EntityTag.tsx
+++ b/packages/client/src/components/advanced/EntityTag/EntityTag.tsx
@@ -292,7 +292,7 @@ const EntityTagComponent: React.FC<EntityTag> = ({
         <StyledButtonWrapper {...buttonWrapperProps}>{button}</StyledButtonWrapper>
       )}
       {elvlButtonGroup && (
-        <StyledElvlWrapper>
+        <StyledElvlWrapper $tagBorderColorKey={entity.status}>
           <div onMouseOver={() => setElvlHovered(true)} onMouseOut={() => setElvlHovered(false)}>
             {elvlButtonGroup}
           </div>

--- a/packages/client/src/components/advanced/EntityTag/EntityTagStyles.tsx
+++ b/packages/client/src/components/advanced/EntityTag/EntityTagStyles.tsx
@@ -83,7 +83,7 @@ interface StyledLabelWrap {
   $invertedLabel: boolean;
 }
 export const StyledLabelWrap = styled.div<StyledLabelWrap>`
-  display: inline-flex;
+  display: inline-grid;
   overflow: hidden;
   background-color: ${({ theme, $invertedLabel }) =>
     $invertedLabel ? theme.color.tagSelectedBackground : theme.color.tagBackground};
@@ -128,7 +128,6 @@ interface StyledLabel {
 }
 export const StyledLabel = styled.div<StyledLabel>`
   display: inline-block;
-  vertical-align: middle;
   white-space: nowrap;
   overflow: hidden !important;
   text-overflow: ellipsis;

--- a/packages/client/src/components/advanced/EntityTag/EntityTagStyles.tsx
+++ b/packages/client/src/components/advanced/EntityTag/EntityTagStyles.tsx
@@ -24,12 +24,16 @@ export const StyledButtonWrapper = styled.div<StyledButtonWrapper>`
   }
 `;
 
-export const StyledElvlWrapper = styled.div`
+interface StyledElvlWrapper {
+  $tagBorderColorKey: EntityEnums.Status;
+}
+export const StyledElvlWrapper = styled.div<StyledElvlWrapper>`
   display: flex;
   > div {
     border-width: 0;
     border-left-width: ${({ theme }) => theme.borderWidth[1]};
-    border-left-color: ${({ theme }) => theme.color["black"]};
+    border-left-color: ${({ theme, $tagBorderColorKey }) =>
+      theme.color.tagBorderColor[$tagBorderColorKey]};
     border-left-style: solid;
   }
 `;

--- a/packages/client/src/components/advanced/IconButtonGroups/ElvlButtonGroup.tsx
+++ b/packages/client/src/components/advanced/IconButtonGroups/ElvlButtonGroup.tsx
@@ -17,6 +17,8 @@ interface ElvlButtonGroup {
   value: EntityEnums.Elvl;
   onChange: (elvl: EntityEnums.Elvl) => void;
   disabled?: boolean;
+  // warning ring prompting the user to choose an elvl
+  warning?: boolean;
 }
 export const ElvlButtonGroup: React.FC<ElvlButtonGroup> = ({
   border = false,
@@ -24,6 +26,7 @@ export const ElvlButtonGroup: React.FC<ElvlButtonGroup> = ({
   value,
   onChange,
   disabled,
+  warning,
 }) => {
   return (
     <IconButtonGroup<EntityEnums.Elvl>
@@ -35,6 +38,7 @@ export const ElvlButtonGroup: React.FC<ElvlButtonGroup> = ({
       onChange={onChange}
       value={value}
       disabled={disabled}
+      warning={warning}
     />
   );
 };

--- a/packages/client/src/components/basic/IconButtonGroup/IconButtonGroup.tsx
+++ b/packages/client/src/components/basic/IconButtonGroup/IconButtonGroup.tsx
@@ -61,7 +61,7 @@ export const IconButtonGroup = <TValue extends ValueTypes>({
                 }
                 noBorder
                 inverted
-                shape={sharpCorners ? "sharp" : "rounded-sm"}
+                shape={sharpCorners ? "sharp" : option.value === value ? "rounded-sm" : "sharp"}
                 color={option.value === value ? "primary" : "grey"}
                 onClick={() => {
                   if (option.value !== value) {

--- a/packages/client/src/components/basic/IconButtonGroup/IconButtonGroup.tsx
+++ b/packages/client/src/components/basic/IconButtonGroup/IconButtonGroup.tsx
@@ -19,6 +19,8 @@ type IconButtonGroup<TValue extends ValueTypes> = {
   value: TValue;
   icons: { [key in TValue]: React.ReactNode };
   disabled?: boolean;
+  // draws a warning ring around the group to prompt the user to choose a value
+  warning?: boolean;
 };
 
 export const IconButtonGroup = <TValue extends ValueTypes>({
@@ -30,6 +32,7 @@ export const IconButtonGroup = <TValue extends ValueTypes>({
   value,
   icons,
   disabled = false,
+  warning = false,
 }: IconButtonGroup<TValue>) => {
   // Disabled mode shows only the selected option. If nothing is selected there
   // is nothing to show, so hide the component entirely (no empty wrapper box).
@@ -38,7 +41,7 @@ export const IconButtonGroup = <TValue extends ValueTypes>({
   }
 
   return (
-    <StyledWrapper $border={border} $sharpCorners={sharpCorners}>
+    <StyledWrapper $border={border} $sharpCorners={sharpCorners} $warning={warning}>
       {options.map((option, key) => {
         return (
           <React.Fragment key={key}>
@@ -58,7 +61,7 @@ export const IconButtonGroup = <TValue extends ValueTypes>({
                 }
                 noBorder
                 inverted
-                shape={sharpCorners ? "sharp" : undefined}
+                shape={sharpCorners ? "sharp" : "rounded-sm"}
                 color={option.value === value ? "primary" : "grey"}
                 onClick={() => {
                   if (option.value !== value) {

--- a/packages/client/src/components/basic/IconButtonGroup/IconButtonGroupStyles.tsx
+++ b/packages/client/src/components/basic/IconButtonGroup/IconButtonGroupStyles.tsx
@@ -3,16 +3,27 @@ import styled from "styled-components";
 interface StyledWrapper {
   $border?: boolean;
   $sharpCorners?: boolean;
+  $warning?: boolean;
 }
 export const StyledWrapper = styled.div<StyledWrapper>`
+  position: relative;
   display: inline-flex;
   height: ${({ theme, $border }) => ($border ? theme.space[8] : theme.space[8])};
   border: ${({ theme, $border }) =>
     $border ? `${theme.borderWidth[1]} solid ${theme.color["grey"]}` : ""};
   border-radius: ${({ theme, $sharpCorners }) =>
     $sharpCorners ? theme.borderRadius["none"] : theme.borderRadius["sm"]};
-  overflow: ${({ $border }) => ($border ? "hidden" : "")};
+  overflow: ${({ $border, $warning }) => ($border || $warning ? "hidden" : "")};
   background-color: ${({ theme }) => theme.color["white"]};
+
+  &::after {
+    content: ${({ $warning }) => ($warning ? '""' : "none")};
+    position: absolute;
+    inset: 0;
+    border: ${({ theme }) => `${theme.borderWidth[2]} solid ${theme.color["warningBorder"]}`};
+    border-radius: inherit;
+    pointer-events: none;
+  }
 `;
 
 export const StyledBold = styled.span`

--- a/packages/client/src/components/basic/IconButtonGroup/IconButtonGroupStyles.tsx
+++ b/packages/client/src/components/basic/IconButtonGroup/IconButtonGroupStyles.tsx
@@ -15,6 +15,7 @@ export const StyledWrapper = styled.div<StyledWrapper>`
     $sharpCorners ? theme.borderRadius["none"] : theme.borderRadius["sm"]};
   overflow: ${({ $border, $warning }) => ($border || $warning ? "hidden" : "")};
   background-color: ${({ theme }) => theme.color["white"]};
+  flex-shrink: 0;
 
   &::after {
     content: ${({ $warning }) => ($warning ? '""' : "none")};

--- a/packages/client/src/components/basic/IconButtonGroup/IconButtonGroupStyles.tsx
+++ b/packages/client/src/components/basic/IconButtonGroup/IconButtonGroupStyles.tsx
@@ -11,6 +11,8 @@ export const StyledWrapper = styled.div<StyledWrapper>`
   height: ${({ theme, $border }) => ($border ? theme.space[8] : theme.space[8])};
   border: ${({ theme, $border }) =>
     $border ? `${theme.borderWidth[1]} solid ${theme.color["grey"]}` : ""};
+  border-color: ${({ theme, $warning }) =>
+    $warning ? theme.color["warningBorder"] : theme.color["grey"]};
   border-radius: ${({ theme, $sharpCorners }) =>
     $sharpCorners ? theme.borderRadius["none"] : theme.borderRadius["sm"]};
   overflow: hidden;
@@ -22,7 +24,13 @@ export const StyledWrapper = styled.div<StyledWrapper>`
     position: absolute;
     inset: 0;
     border: ${({ theme }) => `${theme.borderWidth[2]} solid ${theme.color["warningBorder"]}`};
-    border-radius: inherit;
+    /* inset:0 sits at the padding box; when the group has its own border the
+       ring is that border-width inside the outer corner, so shrink its radius
+       to match (no border → inherit the wrapper radius, as in the suggester). */
+    border-radius: ${({ theme, $border, $sharpCorners }) => {
+      const base = $sharpCorners ? theme.borderRadius["none"] : theme.borderRadius["sm"];
+      return $border ? `calc(${base} - ${theme.borderWidth[1]})` : base;
+    }};
     pointer-events: none;
   }
 `;

--- a/packages/client/src/components/basic/IconButtonGroup/IconButtonGroupStyles.tsx
+++ b/packages/client/src/components/basic/IconButtonGroup/IconButtonGroupStyles.tsx
@@ -13,8 +13,8 @@ export const StyledWrapper = styled.div<StyledWrapper>`
     $border ? `${theme.borderWidth[1]} solid ${theme.color["grey"]}` : ""};
   border-radius: ${({ theme, $sharpCorners }) =>
     $sharpCorners ? theme.borderRadius["none"] : theme.borderRadius["sm"]};
-  overflow: ${({ $border, $warning }) => ($border || $warning ? "hidden" : "")};
-  background-color: ${({ theme }) => theme.color["white"]};
+  overflow: hidden;
+  background-color: ${({ theme }) => theme.color.invertedBg["grey"]};
   flex-shrink: 0;
 
   &::after {

--- a/packages/client/src/components/basic/Input/InputStyles.tsx
+++ b/packages/client/src/components/basic/Input/InputStyles.tsx
@@ -307,6 +307,7 @@ export const StyledRightContent = styled.div<{
   display: flex;
   align-items: center;
   gap: 0.15rem;
+  z-index: 2;
   padding-left: ${({ $showDivider }) => ($showDivider ? "0.4rem" : "0")};
 
   &::before {

--- a/packages/client/src/components/basic/Suggester/Suggester.tsx
+++ b/packages/client/src/components/basic/Suggester/Suggester.tsx
@@ -224,7 +224,9 @@ export const Suggester: React.FC<Suggester> = ({
   }, [externalDroppedItem]);
 
   const handleEnterPress = () => {
-    if (selected === -1 && typed.length > 0) {
+    // Statements are created without a label, so allow triggering create with an
+    // empty input; other classes still require at least one character.
+    if (selected === -1 && (typed.length > 0 || category === EntityEnums.Class.Statement)) {
       if (!disableCreate) {
         if (
           category === dropdownWildCard.value ||
@@ -263,7 +265,9 @@ export const Suggester: React.FC<Suggester> = ({
   };
 
   const handleAddBtnClick = () => {
-    if (typed.length > 0) {
+    // Statements are created without a label, so allow triggering create with an
+    // empty input; other classes still require at least one character.
+    if (typed.length > 0 || category === EntityEnums.Class.Statement) {
       if (
         category === dropdownWildCard.value ||
         category === EntityEnums.Class.Statement ||
@@ -422,23 +426,25 @@ export const Suggester: React.FC<Suggester> = ({
               fullHeight
               clearable={clearableInput}
               rightContent={
-                !disableCreate ? (
-                  <IconButton
-                    icon={<FaPlus />}
-                    tooltipLabel="create new entity"
-                    color={buttonColorKey}
-                    noBackground
-                    noBorder
-                    onClick={() => {
-                      handleAddBtnClick();
-                    }}
-                    disabled={disabled}
-                  />
-                ) : rightContent ? (
-                  rightContent
-                ) : (
-                  button && button
-                )
+                <>
+                  {/* rightContent renders alongside the create button (e.g. the
+                      annotator's elvl group); the button fallback only applies
+                      when create is disabled and no rightContent is provided. */}
+                  {rightContent ? rightContent : disableCreate ? button && button : null}
+                  {!disableCreate && (
+                    <IconButton
+                      icon={<FaPlus />}
+                      tooltipLabel="create new entity"
+                      color={buttonColorKey}
+                      noBackground
+                      noBorder
+                      onClick={() => {
+                        handleAddBtnClick();
+                      }}
+                      disabled={disabled}
+                    />
+                  )}
+                </>
               }
             />
           </div>

--- a/packages/client/src/components/basic/Suggester/Suggester.tsx
+++ b/packages/client/src/components/basic/Suggester/Suggester.tsx
@@ -26,6 +26,7 @@ import {
   StyledAiOutlineWarning,
   StyledInputWrapper,
   StyledRelativePosition,
+  StyledRightContentDivider,
   StyledSuggester,
   StyledSuggesterList,
   SuggesterHidden,
@@ -82,6 +83,9 @@ interface Suggester {
   // rendered inside the input's trailing slot (only when disableCreate is set,
   // where the create button would otherwise sit)
   rightContent?: React.ReactNode;
+  // notifies the parent when the input gains/loses focus (e.g. the annotator
+  // highlights the elvl group while the suggester is focused)
+  onFocusChange?: (isFocused: boolean) => void;
 }
 
 export const Suggester: React.FC<Suggester> = ({
@@ -129,6 +133,7 @@ export const Suggester: React.FC<Suggester> = ({
   onEmptyAddButtonClick,
   clearableInput = true,
   rightContent,
+  onFocusChange,
 }) => {
   const [selected, setSelected] = useState(-1);
   const [isFocused, setIsFocused] = useState(false);
@@ -414,10 +419,12 @@ export const Suggester: React.FC<Suggester> = ({
               roundCorners={false}
               onFocus={() => {
                 setIsFocused(true);
+                onFocusChange && onFocusChange(true);
               }}
               onBlur={() => {
                 // Comment this for debug
                 setIsFocused(false);
+                onFocusChange && onFocusChange(false);
                 setSelected(-1);
               }}
               onEnterPressFn={handleEnterPress}
@@ -432,17 +439,20 @@ export const Suggester: React.FC<Suggester> = ({
                       when create is disabled and no rightContent is provided. */}
                   {rightContent ? rightContent : disableCreate ? button && button : null}
                   {!disableCreate && (
-                    <IconButton
-                      icon={<FaPlus />}
-                      tooltipLabel="create new entity"
-                      color={buttonColorKey}
-                      noBackground
-                      noBorder
-                      onClick={() => {
-                        handleAddBtnClick();
-                      }}
-                      disabled={disabled}
-                    />
+                    <>
+                      {rightContent && <StyledRightContentDivider />}
+                      <IconButton
+                        icon={<FaPlus />}
+                        tooltipLabel="create new entity"
+                        color={buttonColorKey}
+                        noBackground
+                        noBorder
+                        onClick={() => {
+                          handleAddBtnClick();
+                        }}
+                        disabled={disabled}
+                      />
+                    </>
                   )}
                 </>
               }

--- a/packages/client/src/components/basic/Suggester/SuggesterStyles.tsx
+++ b/packages/client/src/components/basic/Suggester/SuggesterStyles.tsx
@@ -2,6 +2,7 @@ import { AiOutlineWarning } from "react-icons/ai";
 import styled from "styled-components";
 import { ThemeColor } from "Theme/theme";
 import { space2 } from "Theme/theme-space-shortcut";
+import { DEFAULT_DIVIDER_HEIGHT } from "components/basic/Input/InputStyles";
 
 interface StyledSuggester {
   $marginTop?: boolean;
@@ -131,4 +132,14 @@ export const StyledAiOutlineWarning = styled(AiOutlineWarning)`
 
 export const SuggesterHidden = styled.div`
   display: none;
+`;
+
+// vertical divider separating the injected rightContent (e.g. the annotator's
+// elvl group) from the create button inside the input's trailing slot
+export const StyledRightContentDivider = styled.div`
+  height: ${DEFAULT_DIVIDER_HEIGHT};
+  width: ${({ theme }) => theme.borderWidth[1]};
+  background-color: ${({ theme }) => theme.color["gray"][300]};
+  flex-shrink: 0;
+  margin: 0 0.1rem;
 `;

--- a/packages/client/src/pages/About/AboutPage.tsx
+++ b/packages/client/src/pages/About/AboutPage.tsx
@@ -20,15 +20,18 @@ import LogoGACR from "assets/logos/gacr-en_rgb.png";
 import LogoERC from "assets/logos/logo_erc-flag_eum.png";
 import LogoMUNI from "assets/logos/arts-muni.png";
 import LogoEUMSMT from "assets/logos/eu_msmt.png";
+import { InterfaceEnums } from "@inkvisitor/shared/enums";
+import { useAppSelector } from "redux/hooks";
 
 interface IAcknowledgementLogo {
   src: string;
   url: string;
+  isDark?: boolean;
 }
-const AcknowledgementLogo: React.FC<IAcknowledgementLogo> = ({ src, url }) => {
+const AcknowledgementLogo: React.FC<IAcknowledgementLogo> = ({ src, url, isDark }) => {
   return (
     <a href={url} target="_blank" rel="noopener noreferrer">
-      <StyledAcknowledgementLogo src={src} />
+      <StyledAcknowledgementLogo src={src} $isDark={isDark} />
     </a>
   );
 };
@@ -80,10 +83,13 @@ const PersonWithIcon: React.FC<IPersonWithIcon> = ({ label, url }) => {
 interface IAboutPage {}
 
 export const AboutPage: React.FC<IAboutPage> = ({}) => {
+  const selectedThemeId: InterfaceEnums.Theme = useAppSelector((state) => state.theme);
+  const isDark = selectedThemeId === InterfaceEnums.Theme.Dark;
+
   return (
     <StyledContentWrapper>
-      <StyledContent>
-        <StyledLogo>
+      <StyledContent $isDark={isDark}>
+        <StyledLogo $isDark={isDark}>
           <img width={"100%"} src={LogoInkvisitor} />
         </StyledLogo>
 
@@ -217,10 +223,10 @@ export const AboutPage: React.FC<IAboutPage> = ({}) => {
         </StyledContentSection>
 
         <StyledAcknowledgement>
-          <AcknowledgementLogo src={LogoERC.default} url="https://erc.europa.eu/homepage" />
-          <AcknowledgementLogo src={LogoGACR.default} url="https://gacr.cz/en/" />
-          <AcknowledgementLogo src={LogoMUNI.default} url="https://www.phil.muni.cz/en" />
-          <AcknowledgementLogo src={LogoEUMSMT.default} url="https://www.msmt.cz/?lang=2" />
+          <AcknowledgementLogo src={LogoERC} url="https://erc.europa.eu/homepage" isDark={isDark} />
+          <AcknowledgementLogo src={LogoGACR} url="https://gacr.cz/en/" isDark={isDark} />
+          <AcknowledgementLogo src={LogoMUNI} url="https://www.phil.muni.cz/en" isDark={isDark} />
+          <AcknowledgementLogo src={LogoEUMSMT} url="https://www.msmt.cz/?lang=2" isDark={isDark} />
         </StyledAcknowledgement>
       </StyledContent>
     </StyledContentWrapper>

--- a/packages/client/src/pages/About/AboutPageStyles.tsx
+++ b/packages/client/src/pages/About/AboutPageStyles.tsx
@@ -9,13 +9,13 @@ export const StyledContentWrapper = styled.div`
   background-color: ${({ theme }) => theme.color["gray"][150]};
 `;
 
-export const StyledContent = styled.div`
+export const StyledContent = styled.div<{ $isDark?: boolean }>`
   display: flex;
   flex-direction: column;
   width: 75%;
   max-width: 96rem;
   margin: ${({ theme }) => `${theme.space[8]} auto`};
-  background-color: ${({ theme }) => theme.color["white"]};
+  background-color: ${({ theme, $isDark }) => ($isDark ? theme.color.muni : theme.color["white"])};
   border-radius: ${({ theme }) => theme.borderRadius["lg"]};
   box-shadow: ${({ theme }) => theme.boxShadow["subtle"]};
   font-size: ${({ theme }) => theme.fontSize["sm"]};
@@ -26,7 +26,7 @@ export const StyledContent = styled.div`
   }
 `;
 
-export const StyledLogo = styled.div`
+export const StyledLogo = styled.div<{ $isDark?: boolean }>`
   display: flex;
   justify-content: center;
   background-color: ${({ theme }) => theme.color.muni};
@@ -34,6 +34,8 @@ export const StyledLogo = styled.div`
   border-radius: ${({ theme }) => theme.borderRadius["md"]};
   border-bottom-left-radius: 0;
   border-bottom-right-radius: 0;
+  border-bottom: ${({ theme, $isDark }) =>
+    $isDark ? `1px solid ${theme.color["gray"][300]}` : "none"};
   overflow: hidden;
   margin-bottom: ${({ theme }) => theme.space[4]};
 
@@ -116,18 +118,20 @@ export const StyledAcknowledgement = styled.div`
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  justify-content: center;
-  gap: ${({ theme }) => theme.space[6]};
-  margin-top: ${({ theme }) => theme.space[10]};
-  padding-top: ${({ theme }) => theme.space[8]};
+  justify-content: space-around;
+  padding: ${({ theme }) => theme.space[8]} 0;
   border-top: ${({ theme }) => `1px solid ${theme.color["gray"][300]}`};
 `;
 
-export const StyledAcknowledgementLogo = styled.img`
+export const StyledAcknowledgementLogo = styled.img<{ $isDark?: boolean }>`
   height: 5rem;
   width: auto;
+  box-sizing: content-box;
   filter: grayscale(1);
-  opacity: 0.65;
+  opacity: ${({ $isDark }) => ($isDark ? 0.55 : 0.65)};
+  background-color: ${({ theme, $isDark }) => ($isDark ? theme.color["gray"][800] : "transparent")};
+  padding: ${({ theme, $isDark }) => ($isDark ? theme.space[3] : 0)};
+  border-radius: ${({ theme }) => theme.borderRadius["md"]};
   transition:
     filter 0.2s ease,
     opacity 0.2s ease;

--- a/packages/client/src/pages/Main/containers/EntityBookmarkBox/EntityBookmarkTable/EntityBookmarkTable.tsx
+++ b/packages/client/src/pages/Main/containers/EntityBookmarkBox/EntityBookmarkTable/EntityBookmarkTable.tsx
@@ -3,9 +3,9 @@ import { EntityTag } from "components/advanced";
 import update from "immutability-helper";
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { CellProps, Column, Row, useTable } from "react-table";
-import { EntityBookmarkTableRow } from "./EntityBookmarkTableRow";
-import { StyledTable, StyledTagWrap } from "./EntityBookmarkTableStyles";
 import { IcoTrash } from "Theme/icons";
+import { EntityBookmarkTableRow } from "./EntityBookmarkTableRow";
+import { StyledTable } from "./EntityBookmarkTableStyles";
 
 type CellType = CellProps<IEntity>;
 
@@ -34,48 +34,40 @@ export const EntityBookmarkTable: React.FC<EntityBookmarkTable> = ({
           const entity = row.original;
 
           return (
-            <StyledTagWrap>
-              <EntityTag
-                entity={entity}
-                tooltipPosition="left"
-                fullWidth
-                unlinkButton={{
-                  onClick: () => {
-                    removeBookmark(folder.id, entity.id);
-                  },
-                  tooltipLabel: "delete bookmark",
-                  icon: <IcoTrash />,
-                }}
-              />
-            </StyledTagWrap>
+            <EntityTag
+              entity={entity}
+              tooltipPosition="left"
+              fullWidth
+              unlinkButton={{
+                onClick: () => {
+                  removeBookmark(folder.id, entity.id);
+                },
+                tooltipLabel: "delete bookmark",
+                icon: <IcoTrash />,
+              }}
+            />
           );
         },
       },
     ],
-    [folder]
+    [folder],
   );
 
   const getRowId = useCallback((row: IEntity) => {
     return row.id;
   }, []);
 
-  const {
-    getTableProps,
-    getTableBodyProps,
-    headerGroups,
-    rows,
-    prepareRow,
-    visibleColumns,
-  } = useTable({
-    columns,
-    data: useMemo(() => folderEntities || [], [folderEntities]),
-    getRowId,
-  });
+  const { getTableProps, getTableBodyProps, headerGroups, rows, prepareRow, visibleColumns } =
+    useTable({
+      columns,
+      data: useMemo(() => folderEntities || [], [folderEntities]),
+      getRowId,
+    });
 
   const updateFolderItemOrder = () => {
     updateFolderEntitys(
       folderEntities.map((a) => a.id),
-      folder.id
+      folder.id,
     );
   };
 
@@ -86,7 +78,7 @@ export const EntityBookmarkTable: React.FC<EntityBookmarkTable> = ({
           [dragIndex, 1],
           [hoverIndex, 0, prevFolderEntities[dragIndex]],
         ],
-      })
+      }),
     );
   }, []);
 

--- a/packages/client/src/pages/Main/containers/EntityBookmarkBox/EntityBookmarkTable/EntityBookmarkTableStyles.tsx
+++ b/packages/client/src/pages/Main/containers/EntityBookmarkBox/EntityBookmarkTable/EntityBookmarkTableStyles.tsx
@@ -41,9 +41,6 @@ export const StyledTd = styled.td`
   padding-left: 0;
   font-size: ${({ theme }) => theme.fontSize["sm"]};
 `;
-export const StyledTagWrap = styled.div`
-  display: grid;
-`;
 export const StyledDragHandleTd = styled.td`
   cursor: move;
 `;

--- a/packages/client/src/pages/Main/containers/EntityDetailBox/EntityDetail/EntityDetailFormSection/EntityDetailFormSection.tsx
+++ b/packages/client/src/pages/Main/containers/EntityDetailBox/EntityDetail/EntityDetailFormSection/EntityDetailFormSection.tsx
@@ -42,7 +42,6 @@ import {
   StyledDetailForm,
   StyledFormWrapper,
   StyledRelativePosition,
-  StyledTagWrap,
 } from "../EntityDetailStyles";
 import { EntityDetailFormSectionAlternativeLabels } from "./EntityDetailFormSectionAlternativeLabels/EntityDetailFormSectionAlternativeLabels";
 
@@ -228,9 +227,7 @@ export const EntityDetailFormSection: React.FC<EntityDetailFormSection> = ({
             <StyledDetailContentRow>
               <StyledDetailContentRowLabel>Applied Template</StyledDetailContentRowLabel>
               <StyledDetailContentRowValue>
-                <StyledTagWrap>
-                  <EntityTag entity={templateApplied} fullWidth />
-                </StyledTagWrap>
+                <EntityTag entity={templateApplied} fullWidth />
               </StyledDetailContentRowValue>
             </StyledDetailContentRow>
           )}
@@ -305,15 +302,13 @@ export const EntityDetailFormSection: React.FC<EntityDetailFormSection> = ({
             <StyledDetailContentRow>
               <StyledDetailContentRowLabel>Parent Territory</StyledDetailContentRowLabel>
               <StyledDetailContentRowValue>
-                <StyledTagWrap>
-                  <EntityTag
-                    fullWidth
-                    entity={entity.entities[entity.data.parent?.territoryId]}
-                    disableDoubleClick={entity.data.parent?.territoryId === rootTerritoryId}
-                    disableDrag={entity.data.parent?.territoryId === rootTerritoryId}
-                    disableTooltip={entity.data.parent?.territoryId === rootTerritoryId}
-                  />
-                </StyledTagWrap>
+                <EntityTag
+                  fullWidth
+                  entity={entity.entities[entity.data.parent?.territoryId]}
+                  disableDoubleClick={entity.data.parent?.territoryId === rootTerritoryId}
+                  disableDrag={entity.data.parent?.territoryId === rootTerritoryId}
+                  disableTooltip={entity.data.parent?.territoryId === rootTerritoryId}
+                />
                 {/* move to different parent territory */}
                 {entity.class === EntityEnums.Class.Territory &&
                   entity.data.parent.territoryId !== rootTerritoryId && (

--- a/packages/client/src/pages/Main/containers/EntityDetailBox/EntityDetail/EntityDetailStyles.tsx
+++ b/packages/client/src/pages/Main/containers/EntityDetailBox/EntityDetail/EntityDetailStyles.tsx
@@ -180,12 +180,6 @@ export const StyledDetailForm = styled.div`
   }
 `;
 
-export const StyledTagWrap = styled.div`
-  display: inline-grid;
-  overflow: hidden;
-  max-width: 100%;
-`;
-
 export const StyledPropGroupWrap = styled.div`
   overflow: auto;
   margin-bottom: ${({ theme }) => theme.space[5]};

--- a/packages/client/src/pages/Main/containers/EntityDetailBox/EntityDetail/EntityDetailUsedInTable/EntityDetailStatementsTable/EntityDetailStatementsTable.tsx
+++ b/packages/client/src/pages/Main/containers/EntityDetailBox/EntityDetail/EntityDetailUsedInTable/EntityDetailStatementsTable/EntityDetailStatementsTable.tsx
@@ -100,21 +100,35 @@ export const EntityDetailStatementsTable: React.FC<EntityDetailStatementsTable> 
       {
         Header: "Text",
         Cell: ({ row }: CellType) => {
-          const useCase = row.original;
-          const entityId = useCase.statement?.id;
-          const entity = entityId ? entities[entityId] : false;
+          const { statement, anchorTexts } = row.original;
 
-          return (
-            <>
-              {entity && entity.class === EntityEnums.Class.Statement ? (
-                <StyledTableTextGridCell>
-                  <StyledShortenedText>{entity.data.text}</StyledShortenedText>
-                </StyledTableTextGridCell>
-              ) : (
-                ""
-              )}
-            </>
-          );
+          if (!statement) {
+            return "";
+          }
+
+          // Fallback order (each used only when the one above is empty):
+          //   1) document anchor span(s) - multiple anchors joined with " ... "
+          //   2) statement text (deprecated but still in use sometimes)
+          //   3) statement label - rendered italic to mark it as a label
+          const anchorText = anchorTexts
+            ?.map((t) => t.trim())
+            .filter((t) => t)
+            .join(" ... ");
+          const statementText = statement.data.text?.trim();
+          const label = statement.labels?.[0]?.trim();
+
+          let content: React.ReactNode = "";
+          if (anchorText) {
+            content = <StyledShortenedText>{anchorText}</StyledShortenedText>;
+          } else if (statementText) {
+            content = (
+              <StyledShortenedText>{statement.data.text}</StyledShortenedText>
+            );
+          } else if (label) {
+            content = <StyledShortenedText $italic>{label}</StyledShortenedText>;
+          }
+
+          return <StyledTableTextGridCell>{content}</StyledTableTextGridCell>;
         },
       },
       {

--- a/packages/client/src/pages/Main/containers/EntityDetailBox/EntityDetail/EntityDetailUsedInTable/EntityDetailStatementsTable/EntityDetailStatementsTable.tsx
+++ b/packages/client/src/pages/Main/containers/EntityDetailBox/EntityDetail/EntityDetailUsedInTable/EntityDetailStatementsTable/EntityDetailStatementsTable.tsx
@@ -132,7 +132,7 @@ export const EntityDetailStatementsTable: React.FC<EntityDetailStatementsTable> 
             );
           } else if (statementText) {
             content = (
-              <StyledShortenedText>{statement.data.text}</StyledShortenedText>
+              <StyledShortenedText>{statementText}</StyledShortenedText>
             );
           } else if (label) {
             content = <StyledShortenedText $italic>{label}</StyledShortenedText>;

--- a/packages/client/src/pages/Main/containers/EntityDetailBox/EntityDetail/EntityDetailUsedInTable/EntityDetailStatementsTable/EntityDetailStatementsTable.tsx
+++ b/packages/client/src/pages/Main/containers/EntityDetailBox/EntityDetail/EntityDetailUsedInTable/EntityDetailStatementsTable/EntityDetailStatementsTable.tsx
@@ -101,7 +101,7 @@ export const EntityDetailStatementsTable: React.FC<EntityDetailStatementsTable> 
       {
         Header: "Text",
         Cell: ({ row }: CellType) => {
-          const { statement, anchorTexts } = row.original;
+          const { statement } = row.original;
 
           if (!statement) {
             return "";
@@ -111,7 +111,9 @@ export const EntityDetailStatementsTable: React.FC<EntityDetailStatementsTable> 
           //   1) document anchor span(s) - multiple anchors joined with " ... "
           //   2) statement text (deprecated but still in use sometimes)
           //   3) statement label - rendered italic to mark it as a label
-          const anchorText = anchorTexts
+          // anchorTexts is stamped onto the entities map by the server
+          // (Entity.applyAnchorTexts)
+          const anchorText = entities[statement.id]?.anchorTexts
             ?.map((t) => t.trim())
             .filter((t) => t)
             .join(" ... ");

--- a/packages/client/src/pages/Main/containers/EntityDetailBox/EntityDetail/EntityDetailUsedInTable/EntityDetailStatementsTable/EntityDetailStatementsTable.tsx
+++ b/packages/client/src/pages/Main/containers/EntityDetailBox/EntityDetail/EntityDetailUsedInTable/EntityDetailStatementsTable/EntityDetailStatementsTable.tsx
@@ -11,7 +11,8 @@ import { EntityTag } from "components/advanced";
 import { useSearchParams } from "hooks";
 import React, { useMemo } from "react";
 import { CellProps, Column } from "react-table";
-import { StyledShortenedText, StyledTableTextGridCell } from "../EntityDetailUsedInTableStyles";
+import { TbAnchor } from "react-icons/tb";
+import { StyledAnchor, StyledShortenedText, StyledTableTextGridCell } from "../EntityDetailUsedInTableStyles";
 
 type CellType = CellProps<IResponseUsedInStatement<EntityEnums.UsedInPosition>>;
 
@@ -119,7 +120,14 @@ export const EntityDetailStatementsTable: React.FC<EntityDetailStatementsTable> 
 
           let content: React.ReactNode = "";
           if (anchorText) {
-            content = <StyledShortenedText>{anchorText}</StyledShortenedText>;
+            content = (
+              <StyledShortenedText>
+                <StyledAnchor>
+                  <TbAnchor size={12} strokeWidth={2} />
+                </StyledAnchor>
+                {anchorText}
+              </StyledShortenedText>
+            );
           } else if (statementText) {
             content = (
               <StyledShortenedText>{statement.data.text}</StyledShortenedText>

--- a/packages/client/src/pages/Main/containers/EntityDetailBox/EntityDetail/EntityDetailUsedInTable/EntityDetailUsedInTableStyles.tsx
+++ b/packages/client/src/pages/Main/containers/EntityDetailBox/EntityDetail/EntityDetailUsedInTable/EntityDetailUsedInTableStyles.tsx
@@ -5,13 +5,14 @@ export const StyledTableTextGridCell = styled.div`
   overflow: hidden;
   font-size: inherit;
 `;
-export const StyledShortenedText = styled.div`
+export const StyledShortenedText = styled.div<{ $italic?: boolean }>`
   display: inline-block;
   vertical-align: middle;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
   font-size: inherit;
+  font-style: ${({ $italic }) => ($italic ? "italic" : "normal")};
 `;
 export const StyledTagWrap = styled.div`
   display: inline-flex;

--- a/packages/client/src/pages/Main/containers/EntityDetailBox/EntityDetail/EntityDetailUsedInTable/EntityDetailUsedInTableStyles.tsx
+++ b/packages/client/src/pages/Main/containers/EntityDetailBox/EntityDetail/EntityDetailUsedInTable/EntityDetailUsedInTableStyles.tsx
@@ -14,6 +14,15 @@ export const StyledShortenedText = styled.div<{ $italic?: boolean }>`
   font-size: inherit;
   font-style: ${({ $italic }) => ($italic ? "italic" : "normal")};
 `;
+export const StyledAnchor = styled.div`
+  background-color: ${({ theme }) => theme.color.blue[400]};
+  color: ${({ theme }) => theme.color.white};
+  margin-right: 5px;
+  display: inline-flex;
+  vertical-align: middle;
+  padding: 2px;
+  border-radius: 50%;
+`;
 export const StyledTagWrap = styled.div`
   display: inline-flex;
   overflow: hidden;

--- a/packages/client/src/pages/Main/containers/EntityDetailBox/EntityDetail/EntityDetailUsedInTable/EntityDetailUsedInTableUtils.tsx
+++ b/packages/client/src/pages/Main/containers/EntityDetailBox/EntityDetail/EntityDetailUsedInTable/EntityDetailUsedInTableUtils.tsx
@@ -1,14 +1,11 @@
 import { IEntity } from "@inkvisitor/shared/types";
 import { EntityTag } from "components/advanced";
-import { StyledTagWrap } from "../EntityDetailStyles";
 import { StyledTableTextGridCell } from "./EntityDetailUsedInTableStyles";
 
 export const renderEntityTag = (entity: IEntity) => {
   return (
     <StyledTableTextGridCell>
-      <StyledTagWrap>
-        <EntityTag fullWidth entity={entity} />
-      </StyledTagWrap>
+      <EntityTag fullWidth entity={entity} />
     </StyledTableTextGridCell>
   );
 };

--- a/packages/client/src/pages/Main/containers/EntitySearchBox/EntitySearchBoxStyles.tsx
+++ b/packages/client/src/pages/Main/containers/EntitySearchBox/EntitySearchBoxStyles.tsx
@@ -82,10 +82,6 @@ export const StyledResultsHeader = styled.div`
 export const StyledResultHeading = styled.h6`
   width: 100%;
 `;
-export const StyledResultItem = styled.div`
-  display: inline-flex;
-  overflow: hidden;
-`;
 export const StyledTagLoaderWrap = styled.div`
   min-height: 3rem;
 `;

--- a/packages/client/src/pages/Main/containers/EntitySearchBox/EntitySearchResults/EntitySearchResults.tsx
+++ b/packages/client/src/pages/Main/containers/EntitySearchBox/EntitySearchResults/EntitySearchResults.tsx
@@ -1,6 +1,6 @@
-import { useSpring } from "@react-spring/web";
 import { EntityEnums } from "@inkvisitor/shared/enums";
 import { IResponseEntity } from "@inkvisitor/shared/types";
+import { useSpring } from "@react-spring/web";
 import { Button } from "components";
 import { EntityTag } from "components/advanced";
 import { useSearchParams } from "hooks";
@@ -8,20 +8,13 @@ import React, { useMemo } from "react";
 import { FaEdit } from "react-icons/fa";
 import { List } from "react-window";
 import { scrollOverscanCount } from "Theme/constants";
-import { StyledResultItem } from "../EntitySearchBoxStyles";
-import {
-  StyledResultsAnimatedWrap,
-  StyledRow,
-} from "./EntitySearchResultsStyles";
+import { StyledResultsAnimatedWrap, StyledRow } from "./EntitySearchResultsStyles";
 
 interface EntitySearchResults {
   results?: IResponseEntity[];
   height: number;
 }
-export const EntitySearchResults: React.FC<EntitySearchResults> = ({
-  results,
-  height,
-}) => {
+export const EntitySearchResults: React.FC<EntitySearchResults> = ({ results, height }) => {
   const data = useMemo(() => (results ? results : []), [results]);
   const animatedHeight = useSpring({
     height: `${height / 10}rem`,
@@ -57,25 +50,23 @@ const Row: React.FC<Row> = ({ data, index, style }) => {
 
   return (
     <StyledRow style={style}>
-      <StyledResultItem>
-        <EntityTag
-          entity={entity}
-          tooltipPosition="left"
-          fullWidth
-          button={
-            entity.class === EntityEnums.Class.Statement && (
-              <Button
-                tooltipLabel="open statement in editor"
-                color="plain"
-                inverted
-                shape="sharp"
-                icon={<FaEdit />}
-                onClick={() => setStatementId(entity.id)}
-              />
-            )
-          }
-        />
-      </StyledResultItem>
+      <EntityTag
+        entity={entity}
+        tooltipPosition="left"
+        fullWidth
+        button={
+          entity.class === EntityEnums.Class.Statement && (
+            <Button
+              tooltipLabel="open statement in editor"
+              color="plain"
+              inverted
+              shape="sharp"
+              icon={<FaEdit />}
+              onClick={() => setStatementId(entity.id)}
+            />
+          )
+        }
+      />
     </StyledRow>
   );
 };

--- a/packages/client/src/pages/Main/containers/StatementsListBox/StatementListTable/StatementListTable.tsx
+++ b/packages/client/src/pages/Main/containers/StatementsListBox/StatementListTable/StatementListTable.tsx
@@ -269,28 +269,42 @@ export const StatementListTable: React.FC<StatementListTable> = ({
         Header: "Text",
         accessor: "data",
         Cell: ({ row }: CellType) => {
-          const { usedInDocuments } = row.original;
+          const { anchorTexts, data, labels } = row.original;
 
-          const firstAnchorText = usedInDocuments[0]?.anchorText;
+          // Same fallback order as the entity-detail Statements table (each
+          // used only when the one above is empty):
+          //   1) document anchor span(s) - multiple joined with " ... "
+          //   2) statement text (deprecated but still in use sometimes)
+          //   3) statement label - rendered italic to mark it as a label
+          const anchorText = anchorTexts
+            ?.map((t) => t.trim())
+            .filter((t) => t)
+            .join(" ... ");
 
-          if (firstAnchorText) {
+          if (anchorText) {
             return (
               <StyledAbbreviatedLabel>
                 <StyledAnchor>
                   <TbAnchor size={12} strokeWidth={2} />
                 </StyledAnchor>
-                {firstAnchorText}
+                {anchorText}
               </StyledAbbreviatedLabel>
             );
           }
 
-          const { text } = row.original.data;
+          const text = data.text?.trim();
+          if (text) {
+            return <StyledAbbreviatedLabel>{data.text}</StyledAbbreviatedLabel>;
+          }
 
-          return (
-            <StyledAbbreviatedLabel>
-              {usedInDocuments[0]?.anchorText || text}
-            </StyledAbbreviatedLabel>
-          );
+          const label = labels?.[0]?.trim();
+          if (label) {
+            return (
+              <StyledAbbreviatedLabel $italic>{label}</StyledAbbreviatedLabel>
+            );
+          }
+
+          return <StyledAbbreviatedLabel />;
         },
       },
       {

--- a/packages/client/src/pages/Main/containers/StatementsListBox/StatementListTable/StatementListTableStyles.tsx
+++ b/packages/client/src/pages/Main/containers/StatementsListBox/StatementListTable/StatementListTableStyles.tsx
@@ -112,9 +112,9 @@ export const StyledTr = styled.tr<StyledTr>`
     content: "";
     position: absolute;
     left: 0;
-    top: 6%;
-    bottom: 6%;
-    width: 4px;
+    top: 9%;
+    bottom: 9%;
+    width: 5px;
     border-radius: 0 10px 10px 0;
     background-color: ${({ theme }) => theme.color["success"]};
     transform: scaleX(${({ $isOpened }) => ($isOpened ? 1 : 0)});

--- a/packages/client/src/pages/Main/containers/StatementsListBox/StatementListTable/StatementListTableStyles.tsx
+++ b/packages/client/src/pages/Main/containers/StatementsListBox/StatementListTable/StatementListTableStyles.tsx
@@ -77,19 +77,25 @@ export const StyledTr = styled.tr<StyledTr>`
   td {
     transition: box-shadow 0.2s ease-in-out;
     box-shadow: ${({ theme, $isAnnotatorHovered }) => {
-      const c = $isAnnotatorHovered ? theme.color.primaryRGBA : theme.color.primaryRGBA0;
+      const c = $isAnnotatorHovered
+        ? theme.color.statementHighlight
+        : theme.color.statementHighlight0;
       return `inset 0 2px 0 0 ${c}, inset 0 -2px 0 0 ${c}`;
     }};
   }
   td:first-child {
     box-shadow: ${({ theme, $isAnnotatorHovered }) => {
-      const c = $isAnnotatorHovered ? theme.color.primaryRGBA : theme.color.primaryRGBA0;
+      const c = $isAnnotatorHovered
+        ? theme.color.statementHighlight
+        : theme.color.statementHighlight0;
       return `inset 0 2px 0 0 ${c}, inset 0 -2px 0 0 ${c}, inset 2px 0 0 0 ${c}`;
     }};
   }
   td:last-child {
     box-shadow: ${({ theme, $isAnnotatorHovered }) => {
-      const c = $isAnnotatorHovered ? theme.color.primaryRGBA : theme.color.primaryRGBA0;
+      const c = $isAnnotatorHovered
+        ? theme.color.statementHighlight
+        : theme.color.statementHighlight0;
       return `inset 0 2px 0 0 ${c}, inset 0 -2px 0 0 ${c}, inset -2px 0 0 0 ${c}`;
     }};
   }

--- a/packages/client/src/pages/Main/containers/StatementsListBox/StatementListTable/StatementListTableStyles.tsx
+++ b/packages/client/src/pages/Main/containers/StatementsListBox/StatementListTable/StatementListTableStyles.tsx
@@ -178,13 +178,14 @@ export const StyledSelectionCheckbox = styled.div`
   display: flex;
 `;
 
-export const StyledAbbreviatedLabel = styled.div`
+export const StyledAbbreviatedLabel = styled.div<{ $italic?: boolean }>`
   overflow: hidden;
   display: -webkit-box;
   -webkit-box-orient: vertical;
   -webkit-line-clamp: 2;
   min-width: 5rem;
   font-size: ${({ theme }) => theme.fontSize["xs"]};
+  font-style: ${({ $italic }) => ($italic ? "italic" : "normal")};
 `;
 
 export const StyledAnchor = styled.div`

--- a/packages/client/src/pages/Main/containers/TerritoryTreeBox/ReorderTerritoryChildrenModal/ReorderTerritoryChildrenModal.tsx
+++ b/packages/client/src/pages/Main/containers/TerritoryTreeBox/ReorderTerritoryChildrenModal/ReorderTerritoryChildrenModal.tsx
@@ -15,7 +15,6 @@ import {
   StyledIndex,
   StyledList,
   StyledRow,
-  StyledTagWrap,
 } from "./ReorderTerritoryChildrenModalStyles";
 
 const REORDER_ITEM_TYPE = "REORDER_TERRITORY_CHILD";
@@ -67,9 +66,7 @@ const DraggableRow: React.FC<DraggableRow> = ({ child, index, moveRow }) => {
         <FaGripVertical />
       </StyledDragHandle>
       <StyledIndex>{index + 1}.</StyledIndex>
-      <StyledTagWrap>
-        <EntityTag fullWidth entity={child.territory} disableTooltip disableDrag />
-      </StyledTagWrap>
+      <EntityTag fullWidth entity={child.territory} disableTooltip disableDrag />
     </StyledRow>
   );
 };

--- a/packages/client/src/pages/Main/containers/TerritoryTreeBox/ReorderTerritoryChildrenModal/ReorderTerritoryChildrenModalStyles.tsx
+++ b/packages/client/src/pages/Main/containers/TerritoryTreeBox/ReorderTerritoryChildrenModal/ReorderTerritoryChildrenModalStyles.tsx
@@ -35,8 +35,3 @@ export const StyledIndex = styled.span`
   text-align: right;
   flex-shrink: 0;
 `;
-
-export const StyledTagWrap = styled.div`
-  display: grid;
-  pointer-events: none;
-`;

--- a/packages/client/src/pages/Stats/StatsDocumentTable/StatsDocumentTable.tsx
+++ b/packages/client/src/pages/Stats/StatsDocumentTable/StatsDocumentTable.tsx
@@ -108,15 +108,13 @@ const AuditChangesCell: React.FC<{ changes: object }> = ({ changes }) => {
               const entity = entitiesById[anchor];
               if (entity) {
                 return (
-                  <div style={{ display: "grid" }} key={index}>
-                    <EntityTag
-                      key={`${section.key}-${anchor}-${index}`}
-                      entity={entity}
-                      disableDoubleClick
-                      disableDrag
-                      fullWidth
-                    />
-                  </div>
+                  <EntityTag
+                    key={`${section.key}-${anchor}-${index}`}
+                    entity={entity}
+                    disableDoubleClick
+                    disableDrag
+                    fullWidth
+                  />
                 );
               }
 

--- a/packages/client/src/utils/utils.test.ts
+++ b/packages/client/src/utils/utils.test.ts
@@ -96,8 +96,8 @@ describe("getEntityLabel", () => {
           class: EntityEnums.Class.Statement,
           labels: ["label"],
           data: { text: "text" },
-        }),
-        ["anchor"]
+          anchorTexts: ["anchor"],
+        })
       )
     ).toBe("label");
   });
@@ -108,8 +108,8 @@ describe("getEntityLabel", () => {
           class: EntityEnums.Class.Statement,
           labels: [],
           data: { text: "text" },
-        }),
-        ["first", "second"]
+          anchorTexts: ["first", "second"],
+        })
       )
     ).toBe("first ... second");
   });

--- a/packages/client/src/utils/utils.test.ts
+++ b/packages/client/src/utils/utils.test.ts
@@ -89,6 +89,30 @@ describe("getEntityLabel", () => {
       )
     ).toBe("anchor text");
   });
+  it("prefers the label over anchor text and statement text", () => {
+    expect(
+      getEntityLabel(
+        asEntity({
+          class: EntityEnums.Class.Statement,
+          labels: ["label"],
+          data: { text: "text" },
+        }),
+        ["anchor"]
+      )
+    ).toBe("label");
+  });
+  it("uses anchor text over statement text when a statement has no label", () => {
+    expect(
+      getEntityLabel(
+        asEntity({
+          class: EntityEnums.Class.Statement,
+          labels: [],
+          data: { text: "text" },
+        }),
+        ["first", "second"]
+      )
+    ).toBe("first ... second");
+  });
 });
 
 describe("getShortLabelByLetterCount", () => {

--- a/packages/client/src/utils/utils.tsx
+++ b/packages/client/src/utils/utils.tsx
@@ -1,10 +1,5 @@
 import { classesAll } from "@inkvisitor/shared/dictionaries/entity";
-import {
-  EntityEnums,
-  RelationEnums,
-  UserEnums,
-  WarningTypeEnums,
-} from "@inkvisitor/shared/enums";
+import { EntityEnums, RelationEnums, UserEnums, WarningTypeEnums } from "@inkvisitor/shared/enums";
 import {
   EntityTooltip,
   IEntity,
@@ -29,10 +24,7 @@ import { DragItem, EntityDragItem } from "types";
 export const isFirstLabelEmpty = (labels: string[]) =>
   labels ? labels.length === 0 || labels[0] === "" : true;
 
-export const getEntityLabel = (
-  entity?: IResponseEntity,
-  anchorTexts?: string[]
-) => {
+export const getEntityLabel = (entity?: IResponseEntity) => {
   if (entity?.class === EntityEnums.Class.Statement) {
     // statement label logic:
     //   [1] If a user-defined label exists, show it.
@@ -43,7 +35,9 @@ export const getEntityLabel = (
     if (label) {
       return label;
     }
-    const anchorText = anchorTexts
+    // anchorTexts is stamped onto statement entities by server responses
+    // (Entity.applyAnchorTexts on the server)
+    const anchorText = entity.anchorTexts
       ?.map((t) => t.trim())
       .filter((t) => t)
       .join(" ... ");
@@ -55,10 +49,7 @@ export const getEntityLabel = (
   // non-statement
   return (entity?.labels && entity?.labels[0]) || "no label";
 };
-export const getShortLabelByLetterCount = (
-  label: string,
-  maxLetterCount: number
-) => {
+export const getShortLabelByLetterCount = (label: string, maxLetterCount: number) => {
   const isOversized = label.length > maxLetterCount;
   return isOversized ? label.slice(0, maxLetterCount).concat("...") : label;
 };
@@ -68,10 +59,7 @@ export const isValidEntityClass = (entityClass: EntityEnums.Class) => {
 };
 
 // TODO: not used, references not in statement data interface
-export const findPositionInStatement = (
-  statement: IStatement,
-  actant: IEntity
-) => {
+export const findPositionInStatement = (statement: IStatement, actant: IEntity) => {
   if (
     statement.data.actants
       .filter((a) => a.position === EntityEnums.Position.Subject)
@@ -101,36 +89,25 @@ export const findPositionInStatement = (
   } else if (statement.data.territory?.territoryId === actant.id) {
     return "territory";
   } else if (
-    statement.data.actants.find((act) =>
-      act.props.find((p) => p.value.entityId === actant.id)
-    )
+    statement.data.actants.find((act) => act.props.find((p) => p.value.entityId === actant.id))
   ) {
     return "actant property value";
   } else if (
-    statement.data.actants.find((act) =>
-      act.props.find((p) => p.type.entityId === actant.id)
-    )
+    statement.data.actants.find((act) => act.props.find((p) => p.type.entityId === actant.id))
   ) {
     return "actant property type";
   } else if (
-    statement.data.actions.find((act) =>
-      act.props.find((p) => p.value.entityId === actant.id)
-    )
+    statement.data.actions.find((act) => act.props.find((p) => p.value.entityId === actant.id))
   ) {
     return "action property value";
   } else if (
-    statement.data.actions.find((act) =>
-      act.props.find((p) => p.type.entityId === actant.id)
-    )
+    statement.data.actions.find((act) => act.props.find((p) => p.type.entityId === actant.id))
   ) {
     return "action property type";
   }
 };
 
-export const searchTree = (
-  element: IResponseTree,
-  matchingTitle: string
-): IResponseTree | null => {
+export const searchTree = (element: IResponseTree, matchingTitle: string): IResponseTree | null => {
   if (element.territory.id === matchingTitle) {
     return element;
   } else if (element.children != null) {
@@ -146,7 +123,7 @@ export const searchTree = (
 
 export const collectTerritoryChildren = (
   element: IResponseTree,
-  childArray: string[] = []
+  childArray: string[] = [],
 ): string[] => {
   if (element.children.length) {
     element.children.map((child) => {
@@ -166,7 +143,7 @@ export const dndHoverFn = (
   index: number,
   monitor: DropTargetMonitor,
   ref: React.RefObject<HTMLDivElement | HTMLTableRowElement | null>,
-  moveFn: (dragIndex: number, hoverIndex: number) => void
+  moveFn: (dragIndex: number, hoverIndex: number) => void,
 ) => {
   if (!ref?.current) {
     return;
@@ -201,7 +178,7 @@ export const dndHoverFnHorizontal = (
   index: number,
   monitor: DropTargetMonitor,
   ref: React.RefObject<HTMLDivElement | null>,
-  moveFn: (dragIndex: number, hoverIndex: number) => void
+  moveFn: (dragIndex: number, hoverIndex: number) => void,
 ) => {
   if (!ref.current) {
     return;
@@ -232,38 +209,24 @@ export const dndHoverFnHorizontal = (
 };
 
 // Returns one more level, because there's always empty subtree array on the deepest level
-export const getRelationTreeDepth = (
-  array: EntityTooltip.ISuperclassTree[]
-): number => {
-  return (
-    1 +
-    Math.max(
-      0,
-      ...array.map(({ subtrees = [] }) => getRelationTreeDepth(subtrees))
-    )
-  );
+export const getRelationTreeDepth = (array: EntityTooltip.ISuperclassTree[]): number => {
+  return 1 + Math.max(0, ...array.map(({ subtrees = [] }) => getRelationTreeDepth(subtrees)));
 };
 
 export const getEntityRelationRules = (
   entityClass: EntityEnums.Class,
   relationTypes?: RelationEnums.Type[],
-  isTemplate: boolean = false
+  isTemplate: boolean = false,
 ): RelationEnums.Type[] => {
   const typesToFilter = relationTypes ? relationTypes : RelationEnums.AllTypes;
 
   // A and C entity classes cannot have any relations, other classes might have only Classification and Related
   if (isTemplate) {
-    if (
-      entityClass === EntityEnums.Class.Action ||
-      entityClass === EntityEnums.Class.Concept
-    ) {
+    if (entityClass === EntityEnums.Class.Action || entityClass === EntityEnums.Class.Concept) {
       return [];
     } else {
       return typesToFilter.filter((rule) => {
-        return (
-          rule === RelationEnums.Type.Classification ||
-          rule === RelationEnums.Type.Related
-        );
+        return rule === RelationEnums.Type.Classification || rule === RelationEnums.Type.Related;
       });
     }
   }
@@ -276,9 +239,7 @@ export const getEntityRelationRules = (
     ) {
       return rule;
     } else if (
-      Relation.RelationRules[rule]?.allowedEntitiesPattern.some(
-        (pair) => pair[0] === entityClass
-      )
+      Relation.RelationRules[rule]?.allowedEntitiesPattern.some((pair) => pair[0] === entityClass)
     ) {
       return rule;
     }
@@ -287,15 +248,13 @@ export const getEntityRelationRules = (
 
 export const getRelationInvertedRules = (
   entityClass: EntityEnums.Class,
-  relationTypes?: RelationEnums.Type[]
+  relationTypes?: RelationEnums.Type[],
 ) => {
   const typesToFilter = relationTypes ? relationTypes : RelationEnums.AllTypes;
   return typesToFilter.filter((rule) => {
     if (
       Relation.RelationRules[rule]?.asymmetrical &&
-      Relation.RelationRules[rule]?.allowedEntitiesPattern.some(
-        (pair) => pair[1] === entityClass
-      )
+      Relation.RelationRules[rule]?.allowedEntitiesPattern.some((pair) => pair[1] === entityClass)
     ) {
       return rule;
     }
@@ -363,7 +322,7 @@ export const floorNumberToOneDecimal = (numberToFloor: number) => {
 export const getUserIcon = (
   userRole: UserEnums.Role,
   // size can be determined in parent component font-size instead
-  size?: number
+  size?: number,
 ): React.ReactNode => {
   if (userRole === UserEnums.Role.Owner) {
     return <FaUserGear size={size} />;
@@ -390,7 +349,7 @@ export const isWarningTBased = (warning: IWarning) => {
 // Utility function to compute differences between two objects
 export const computeDifferences = <T extends Record<string, any>>(
   original: T,
-  current: T
+  current: T,
 ): Partial<T> => {
   const differences: Partial<T> = {};
 
@@ -438,9 +397,7 @@ export const computeDifferences = <T extends Record<string, any>>(
 };
 
 // collect all anchors that has class Statememnt
-export const collectStatementAnchors = (
-  anchors: IAnchorsNode[]
-): IAnchorsNode[] => {
+export const collectStatementAnchors = (anchors: IAnchorsNode[]): IAnchorsNode[] => {
   return anchors.reduce((acc: any[], anchor) => {
     if (anchor.class === EntityEnums.Class.Statement) {
       acc.push(anchor);
@@ -453,9 +410,7 @@ export const collectStatementAnchors = (
 };
 
 // collect all anchors that have class Territory
-export const collectTerritoryAnchors = (
-  anchors: IAnchorsNode[]
-): IAnchorsNode[] => {
+export const collectTerritoryAnchors = (anchors: IAnchorsNode[]): IAnchorsNode[] => {
   return anchors.reduce((acc: IAnchorsNode[], anchor) => {
     if (anchor.class === EntityEnums.Class.Territory) {
       acc.push(anchor);
@@ -473,7 +428,7 @@ export const collectTerritoryAnchors = (
 // or nest, since multiple Ts can share one full-text).
 export const collectTerritoryAnchorsAtIndex = (
   anchors: IAnchorsNode[],
-  index: number
+  index: number,
 ): IAnchorsNode[] => {
   return anchors.reduce((acc: IAnchorsNode[], anchor) => {
     if (
@@ -498,7 +453,7 @@ export const collectTerritoryAnchorsAtIndex = (
 // their outermost occurrence.
 export const getTerritoryHierarchyAtIndex = (
   anchors: IAnchorsNode[],
-  index: number
+  index: number,
 ): { id: string; depth: number }[] => {
   const containing = collectTerritoryAnchorsAtIndex(anchors, index);
 
@@ -519,18 +474,14 @@ export const getTerritoryHierarchyAtIndex = (
         other !== node &&
         other.indexStart <= node.indexStart &&
         other.indexEnd >= node.indexEnd &&
-        (other.indexStart !== node.indexStart ||
-          other.indexEnd !== node.indexEnd)
+        (other.indexStart !== node.indexStart || other.indexEnd !== node.indexEnd),
     ).length;
     chain.push({ id: node.anchor, depth });
   }
   return chain;
 };
 
-export const getStatementOrderByIndex = (
-  index: number,
-  statements: IResponseStatement[]
-) => {
+export const getStatementOrderByIndex = (index: number, statements: IResponseStatement[]) => {
   let newOrder: number = EntityEnums.Order.Last;
 
   if (index + 1 > statements.length) {
@@ -540,14 +491,10 @@ export const getStatementOrderByIndex = (
     if (index < 1 && statements[0].data.territory) {
       // first one
       newOrder = EntityEnums.Order.First;
-    } else if (
-      statements[index - 1].data.territory &&
-      statements[index].data.territory
-    ) {
+    } else if (statements[index - 1].data.territory && statements[index].data.territory) {
       // somewhere between
       newOrder =
-        ((statements[index - 1].data.territory as IStatementDataTerritory)
-          .order +
+        ((statements[index - 1].data.territory as IStatementDataTerritory).order +
           (statements[index].data.territory as IStatementDataTerritory).order) /
         2;
     }
@@ -558,10 +505,7 @@ export const getStatementOrderByIndex = (
 // Mirror of getStatementOrderByIndex for Territories: given the target position
 // among sibling territories (sorted by their parent.order), compute the
 // parent.order for a new sibling inserted at that index.
-export const getTerritoryOrderByIndex = (
-  index: number,
-  siblings: ITerritory[]
-) => {
+export const getTerritoryOrderByIndex = (index: number, siblings: ITerritory[]) => {
   let newOrder: number = EntityEnums.Order.Last;
 
   if (index + 1 > siblings.length) {

--- a/packages/client/src/utils/utils.tsx
+++ b/packages/client/src/utils/utils.tsx
@@ -29,16 +29,28 @@ import { DragItem, EntityDragItem } from "types";
 export const isFirstLabelEmpty = (labels: string[]) =>
   labels ? labels.length === 0 || labels[0] === "" : true;
 
-export const getEntityLabel = (entity?: IResponseEntity) => {
+export const getEntityLabel = (
+  entity?: IResponseEntity,
+  anchorTexts?: string[]
+) => {
   if (entity?.class === EntityEnums.Class.Statement) {
     // statement label logic:
     //   [1] If a user-defined label exists, show it.
     //   [2] If no label but the statement has an anchor, show the anchor's text. If multiple anchors, concatenate them with " ... ".
     //   [3] If neither label nor anchor, show the Statement text.
     //   [4] If nothing is available, show "no label".
-    return (
-      (entity?.labels && entity?.labels[0]) || entity?.data.text || "no label"
-    );
+    const label = entity.labels && entity.labels[0];
+    if (label) {
+      return label;
+    }
+    const anchorText = anchorTexts
+      ?.map((t) => t.trim())
+      .filter((t) => t)
+      .join(" ... ");
+    if (anchorText) {
+      return anchorText;
+    }
+    return entity.data.text || "no label";
   }
   // non-statement
   return (entity?.labels && entity?.labels[0]) || "no label";

--- a/packages/server/src/models/document/document.test.ts
+++ b/packages/server/src/models/document/document.test.ts
@@ -324,3 +324,52 @@ describe("Document export filtering", () => {
     expect(filteredContent).toEqual("Text with <entity1>known entity</entity1> and <unknown1>unknown entity</unknown1> and another known");
   });
 });
+
+describe("Document.getAnchorTextsForEntities", function () {
+  const db = new Db();
+  // Document tag names exclude ".", so keep anchored ids dot-free.
+  const tagSafeId = () => Math.random().toString().replace(/\./g, "");
+  const twice = new Entity({ id: tagSafeId() });
+  const once = new Entity({ id: tagSafeId() });
+  const unanchored = new Entity({ id: tagSafeId() });
+
+  const doc = new Document({
+    content: `a<${twice.id}>first</${twice.id}>b<${twice.id}>second</${twice.id}>c<${once.id}>only</${once.id}>d`,
+  });
+
+  beforeAll(async () => {
+    await db.initDb();
+    // entities must exist before preprocess so their class lands in
+    // documents.entityIds and the anchors resolve.
+    await twice.save(db.connection);
+    await once.save(db.connection);
+    await unanchored.save(db.connection);
+    await doc.preprocess(db.connection);
+    await doc.save(db.connection);
+  });
+
+  afterAll(async () => {
+    await clean(db);
+  });
+
+  test("collects every anchor span per entity, in document order", async () => {
+    const map = await Document.getAnchorTextsForEntities(db.connection, [
+      twice.id,
+      once.id,
+    ]);
+    expect(map[twice.id]).toEqual(["first", "second"]);
+    expect(map[once.id]).toEqual(["only"]);
+  });
+
+  test("omits entities without anchors", async () => {
+    const map = await Document.getAnchorTextsForEntities(db.connection, [
+      unanchored.id,
+    ]);
+    expect(map[unanchored.id]).toBeUndefined();
+  });
+
+  test("returns an empty object for empty input", async () => {
+    const map = await Document.getAnchorTextsForEntities(db.connection, []);
+    expect(map).toEqual({});
+  });
+});

--- a/packages/server/src/models/document/document.ts
+++ b/packages/server/src/models/document/document.ts
@@ -440,6 +440,45 @@ export default class Document implements IDocument, IDbModel {
   }
 
   /**
+   * Batched anchor-text lookup: for each given entity id returns the content of
+   * every document anchor that points at it (node.anchor === id). One multi-index
+   * read + one tree traversal per document covers every id, so callers avoid a
+   * per-entity round-trip. Ids that are not anchored are absent from the result.
+   * @param db
+   * @param entityIds
+   * @returns map of entity id -> anchor contents (in document order)
+   */
+  static async getAnchorTextsForEntities(
+    db: Connection,
+    entityIds: string[]
+  ): Promise<Record<string, string[]>> {
+    const out: Record<string, string[]> = {};
+    if (!entityIds.length) {
+      return out;
+    }
+
+    const idSet = new Set(entityIds);
+    const docs = await Document.findByEntityIds(db, entityIds);
+    for (const docData of docs) {
+      const doc = new Document(docData);
+      const traverse = (nodes: AnchorsNode[]) => {
+        for (const node of nodes) {
+          if (idSet.has(node.anchor)) {
+            if (!out[node.anchor]) {
+              out[node.anchor] = [];
+            }
+            out[node.anchor].push(node.getShortContent());
+          }
+          traverse(node.children);
+        }
+      };
+      traverse(doc.anchors);
+    }
+
+    return out;
+  }
+
+  /**
    * Retrieves all documents
    * @param db Connection database connection
    * @returns Promise<IDocument[]> list of documents

--- a/packages/server/src/models/document/document.ts
+++ b/packages/server/src/models/document/document.ts
@@ -415,6 +415,31 @@ export default class Document implements IDocument, IDbModel {
   }
 
   /**
+   * Like findByEntityId but for a set of ids - returns every document (meta,
+   * content dropped) that references any of the given entity ids. A single
+   * multi-index getAll keeps this to one round-trip instead of one per id.
+   * @param db
+   * @param entityIds
+   * @returns
+   */
+  static async findByEntityIds(
+    db: Connection,
+    entityIds: string[]
+  ): Promise<IDocumentMeta[]> {
+    if (!entityIds.length) {
+      return [];
+    }
+    const entries = await rethink
+      .table(Document.table)
+      .getAll(...entityIds, { index: DbEnums.Indexes.DocumentEntityIds })
+      .without("content")
+      .distinct()
+      .run(db);
+
+    return entries && entries.length ? (entries as IDocumentMeta[]) : [];
+  }
+
+  /**
    * Retrieves all documents
    * @param db Connection database connection
    * @returns Promise<IDocument[]> list of documents

--- a/packages/server/src/models/entity/entity.ts
+++ b/packages/server/src/models/entity/entity.ts
@@ -641,6 +641,41 @@ export default class Entity implements IEntity, IDbModel {
   }
 
   /**
+   * Stamps the response-only anchorTexts field (see IEntity.anchorTexts) onto
+   * every Statement-class entity in the given map/list, so any client surface
+   * rendering the entity (EntityTag etc.) can show its document anchor spans.
+   * One batched document read covers all statements; entities without anchors
+   * are left untouched. Never persisted - the field is not declared on the
+   * Entity model, so fillFlatObject drops it if a client echoes it back.
+   * @param conn
+   * @param entities
+   */
+  static async applyAnchorTexts(
+    conn: Connection,
+    entities: Record<string, IEntity> | IEntity[]
+  ): Promise<void> {
+    const list = Array.isArray(entities) ? entities : Object.values(entities);
+    const statements = list.filter(
+      (e): e is IEntity => !!e && e.class === EntityEnums.Class.Statement
+    );
+    if (!statements.length) {
+      return;
+    }
+
+    const anchorTextsById = await Document.getAnchorTextsForEntities(
+      conn,
+      [...new Set(statements.map((s) => s.id))]
+    );
+
+    for (const statement of statements) {
+      const texts = anchorTextsById[statement.id];
+      if (texts && texts.length) {
+        statement.anchorTexts = texts;
+      }
+    }
+  }
+
+  /**
    * Finds entities which uses this entity as a template
    * @param db
    * @returns

--- a/packages/server/src/models/entity/response-search.ts
+++ b/packages/server/src/models/entity/response-search.ts
@@ -791,10 +791,6 @@ export class ResponseSearch {
       entities = sortByWordMatch(sortByLength(entities), query.usedLabel);
     }
 
-    // stamp document anchor spans onto statement results so tags can show
-    // them as labels (response-only field, see IEntity.anchorTexts)
-    await Entity.applyAnchorTexts(httpRequest.db.connection, entities);
-
     const out: ResponseEntity[] = [];
     for (const entityData of entities) {
       const response = new ResponseEntity(getEntityClass(entityData));
@@ -806,6 +802,13 @@ export class ResponseSearch {
       }
       out.push(response);
     }
+
+    // stamp document anchor spans onto statement results so tags can show
+    // them as labels (response-only field, see IEntity.anchorTexts). Must run
+    // on the wrapped responses: getEntityClass re-instantiates the entity via
+    // fillFlatObject, which drops undeclared fields - stamping the raw
+    // entities beforehand would be lost.
+    await Entity.applyAnchorTexts(httpRequest.db.connection, out);
 
     return out;
   }

--- a/packages/server/src/models/entity/response-search.ts
+++ b/packages/server/src/models/entity/response-search.ts
@@ -791,6 +791,10 @@ export class ResponseSearch {
       entities = sortByWordMatch(sortByLength(entities), query.usedLabel);
     }
 
+    // stamp document anchor spans onto statement results so tags can show
+    // them as labels (response-only field, see IEntity.anchorTexts)
+    await Entity.applyAnchorTexts(httpRequest.db.connection, entities);
+
     const out: ResponseEntity[] = [];
     for (const entityData of entities) {
       const response = new ResponseEntity(getEntityClass(entityData));

--- a/packages/server/src/models/entity/response.test.ts
+++ b/packages/server/src/models/entity/response.test.ts
@@ -602,14 +602,16 @@ describe("models/entity/response", function () {
     const anchoredTwice = new Statement({ id: tagSafeId() });
     const anchoredOnce = new Statement({ id: tagSafeId() });
     const notAnchored = new Statement({ id: tagSafeId() });
+    const rootStatement = new Statement({ id: tagSafeId() });
 
     const doc = new Document({
       id: Math.random().toString(),
-      content: `start<${anchoredTwice.id}>first span</${anchoredTwice.id}>mid<${anchoredTwice.id}>second span</${anchoredTwice.id}>gap<${anchoredOnce.id}>only span</${anchoredOnce.id}>end`,
+      content: `start<${anchoredTwice.id}>first span</${anchoredTwice.id}>mid<${anchoredTwice.id}>second span</${anchoredTwice.id}>gap<${anchoredOnce.id}>only span</${anchoredOnce.id}>x<${rootStatement.id}>root span</${rootStatement.id}>end`,
     });
 
     const detail = new Entity({ id: tagSafeId() });
     let entities: Record<string, IEntity>;
+    let rootResponse: ResponseEntityDetail;
 
     beforeAll(async () => {
       db = new Db();
@@ -619,6 +621,7 @@ describe("models/entity/response", function () {
       await anchoredTwice.save(db.connection);
       await anchoredOnce.save(db.connection);
       await notAnchored.save(db.connection);
+      await rootStatement.save(db.connection);
       await doc.preprocess(db.connection);
       await doc.save(db.connection);
 
@@ -629,6 +632,10 @@ describe("models/entity/response", function () {
         notAnchored.id,
       ]);
       entities = await response.populateEntitiesMap(db.connection);
+
+      // detail opened on a statement - the response root itself must be stamped
+      rootResponse = new ResponseEntityDetail(rootStatement);
+      await rootResponse.populateEntitiesMap(db.connection);
     });
 
     afterAll(async () => {
@@ -648,6 +655,12 @@ describe("models/entity/response", function () {
 
     it("should leave anchorTexts undefined for a statement without anchors", () => {
       expect(entities[notAnchored.id]?.anchorTexts).toBeUndefined();
+    });
+
+    it("should stamp the response root when the detail is a statement", () => {
+      // anchorTexts is not declared on the model class (deliberately - it must
+      // never be persisted), so read it through the response interface
+      expect((rootResponse as IEntity).anchorTexts).toEqual(["root span"]);
     });
   });
 });

--- a/packages/server/src/models/entity/response.test.ts
+++ b/packages/server/src/models/entity/response.test.ts
@@ -593,4 +593,70 @@ describe("models/entity/response", function () {
       ).toEqual(territory2.id);
     });
   });
+
+  describe("ResponseEntityDetail.populateUsedInStatementAnchors", function () {
+    let db: Db;
+    // Document tag names exclude ".", so keep anchored statement ids dot-free.
+    const tagSafeId = () => Math.random().toString().replace(/\./g, "");
+
+    const anchoredTwice = new Statement({ id: tagSafeId() });
+    const anchoredOnce = new Statement({ id: tagSafeId() });
+    const notAnchored = new Statement({ id: tagSafeId() });
+
+    const doc = new Document({
+      id: Math.random().toString(),
+      content: `start<${anchoredTwice.id}>first span</${anchoredTwice.id}>mid<${anchoredTwice.id}>second span</${anchoredTwice.id}>gap<${anchoredOnce.id}>only span</${anchoredOnce.id}>end`,
+    });
+
+    const detail = new Entity({ id: tagSafeId() });
+    let response: ResponseEntityDetail;
+
+    beforeAll(async () => {
+      db = new Db();
+      await db.initDb();
+      // statements must exist before preprocess so their class lands in
+      // documents.entityIds and the anchors resolve.
+      await anchoredTwice.save(db.connection);
+      await anchoredOnce.save(db.connection);
+      await notAnchored.save(db.connection);
+      await doc.preprocess(db.connection);
+      await doc.save(db.connection);
+
+      response = new ResponseEntityDetail(detail);
+      response.usedInStatements = [
+        {
+          position: EntityEnums.UsedInPosition.Actant,
+          statement: anchoredTwice,
+        },
+        { position: EntityEnums.UsedInPosition.Actant, statement: anchoredOnce },
+        { position: EntityEnums.UsedInPosition.Actant, statement: notAnchored },
+      ];
+      await response.populateUsedInStatementAnchors(db.connection);
+    });
+
+    afterAll(async () => {
+      await db.close();
+    });
+
+    it("should collect both anchor spans for a statement anchored twice", () => {
+      const entry = response.usedInStatements.find(
+        (us) => us.statement.id === anchoredTwice.id
+      );
+      expect(entry?.anchorTexts).toEqual(["first span", "second span"]);
+    });
+
+    it("should collect the single anchor span for a statement anchored once", () => {
+      const entry = response.usedInStatements.find(
+        (us) => us.statement.id === anchoredOnce.id
+      );
+      expect(entry?.anchorTexts).toEqual(["only span"]);
+    });
+
+    it("should leave anchorTexts undefined for a statement without anchors", () => {
+      const entry = response.usedInStatements.find(
+        (us) => us.statement.id === notAnchored.id
+      );
+      expect(entry?.anchorTexts).toBeUndefined();
+    });
+  });
 });

--- a/packages/server/src/models/entity/response.test.ts
+++ b/packages/server/src/models/entity/response.test.ts
@@ -16,7 +16,7 @@ import {
   IResponseUsedInStatementClassification,
   IResponseUsedInStatementIdentification,
 } from "@inkvisitor/shared/types/response-detail";
-import { IStatement } from "@inkvisitor/shared/types";
+import { IEntity, IStatement } from "@inkvisitor/shared/types";
 import { prepareEntity } from "./entity.test";
 import { Db } from "@service/rethink";
 import Document from "@models/document/document";
@@ -594,7 +594,7 @@ describe("models/entity/response", function () {
     });
   });
 
-  describe("ResponseEntityDetail.populateUsedInStatementAnchors", function () {
+  describe("ResponseEntityDetail.populateEntitiesMap anchor stamping", function () {
     let db: Db;
     // Document tag names exclude ".", so keep anchored statement ids dot-free.
     const tagSafeId = () => Math.random().toString().replace(/\./g, "");
@@ -609,7 +609,7 @@ describe("models/entity/response", function () {
     });
 
     const detail = new Entity({ id: tagSafeId() });
-    let response: ResponseEntityDetail;
+    let entities: Record<string, IEntity>;
 
     beforeAll(async () => {
       db = new Db();
@@ -622,41 +622,32 @@ describe("models/entity/response", function () {
       await doc.preprocess(db.connection);
       await doc.save(db.connection);
 
-      response = new ResponseEntityDetail(detail);
-      response.usedInStatements = [
-        {
-          position: EntityEnums.UsedInPosition.Actant,
-          statement: anchoredTwice,
-        },
-        { position: EntityEnums.UsedInPosition.Actant, statement: anchoredOnce },
-        { position: EntityEnums.UsedInPosition.Actant, statement: notAnchored },
-      ];
-      await response.populateUsedInStatementAnchors(db.connection);
+      const response = new ResponseEntityDetail(detail);
+      response.addLinkedEntities([
+        anchoredTwice.id,
+        anchoredOnce.id,
+        notAnchored.id,
+      ]);
+      entities = await response.populateEntitiesMap(db.connection);
     });
 
     afterAll(async () => {
       await db.close();
     });
 
-    it("should collect both anchor spans for a statement anchored twice", () => {
-      const entry = response.usedInStatements.find(
-        (us) => us.statement.id === anchoredTwice.id
-      );
-      expect(entry?.anchorTexts).toEqual(["first span", "second span"]);
+    it("should stamp both anchor spans for a statement anchored twice", () => {
+      expect(entities[anchoredTwice.id]?.anchorTexts).toEqual([
+        "first span",
+        "second span",
+      ]);
     });
 
-    it("should collect the single anchor span for a statement anchored once", () => {
-      const entry = response.usedInStatements.find(
-        (us) => us.statement.id === anchoredOnce.id
-      );
-      expect(entry?.anchorTexts).toEqual(["only span"]);
+    it("should stamp the single anchor span for a statement anchored once", () => {
+      expect(entities[anchoredOnce.id]?.anchorTexts).toEqual(["only span"]);
     });
 
     it("should leave anchorTexts undefined for a statement without anchors", () => {
-      const entry = response.usedInStatements.find(
-        (us) => us.statement.id === notAnchored.id
-      );
-      expect(entry?.anchorTexts).toBeUndefined();
+      expect(entities[notAnchored.id]?.anchorTexts).toBeUndefined();
     });
   });
 });

--- a/packages/server/src/models/entity/response.ts
+++ b/packages/server/src/models/entity/response.ts
@@ -1,5 +1,4 @@
 import { nonenumerable } from "@common/decorators";
-import { AnchorsNode } from "@models/document/anchors";
 import Document from "@models/document/document";
 import { UsedRelations } from "@models/relation/relations";
 import Statement from "@models/statement/statement";
@@ -339,25 +338,10 @@ export class ResponseEntityDetail
       return;
     }
 
-    const idSet = new Set(statementIds);
-    const anchorTextsByStatement: Record<string, string[]> = {};
-
-    const docs = await Document.findByEntityIds(conn, statementIds);
-    for (const docData of docs) {
-      const doc = new Document(docData);
-      const traverse = (nodes: AnchorsNode[]) => {
-        for (const node of nodes) {
-          if (idSet.has(node.anchor)) {
-            if (!anchorTextsByStatement[node.anchor]) {
-              anchorTextsByStatement[node.anchor] = [];
-            }
-            anchorTextsByStatement[node.anchor].push(node.getShortContent());
-          }
-          traverse(node.children);
-        }
-      };
-      traverse(doc.anchors);
-    }
+    const anchorTextsByStatement = await Document.getAnchorTextsForEntities(
+      conn,
+      statementIds
+    );
 
     for (const us of this.usedInStatements) {
       const texts = anchorTextsByStatement[us.statement.id];

--- a/packages/server/src/models/entity/response.ts
+++ b/packages/server/src/models/entity/response.ts
@@ -1,4 +1,6 @@
 import { nonenumerable } from "@common/decorators";
+import { AnchorsNode } from "@models/document/anchors";
+import Document from "@models/document/document";
 import { UsedRelations } from "@models/relation/relations";
 import Statement from "@models/statement/statement";
 import treeCache from "@service/treeCache";
@@ -235,6 +237,11 @@ export class ResponseEntityDetail
       this.addLinkedEntities(ud.resourceId);
     });
 
+    // Attach document anchor spans to each used-in statement so the detail
+    // Statements table can show them as its primary "Text" fallback. Reads
+    // this.usedInStatements, populated by walkStatementsDataEntities above.
+    await this.populateUsedInStatementAnchors(conn);
+
     // populateEntitiesMap depends on the fully-accumulated linkedEntitiesIds,
     // so it must come after every addLinkedEntities call above.
     this.entities = await this.populateEntitiesMap(conn);
@@ -314,6 +321,50 @@ export class ResponseEntityDetail
       this.addLinkedEntities(c.actantEntityId);
       this.addLinkedEntities(c.relationEntityId);
     });
+  }
+
+  /**
+   * Fills the anchorTexts field of every used-in statement with the content of
+   * the document anchors that point at that statement (node.anchor ===
+   * statement.id). A statement anchored several times yields several strings -
+   * the client joins them for display. One batched document read covers every
+   * used-in statement.
+   * @param conn
+   */
+  async populateUsedInStatementAnchors(conn: Connection): Promise<void> {
+    const statementIds = [
+      ...new Set(this.usedInStatements.map((us) => us.statement.id)),
+    ];
+    if (!statementIds.length) {
+      return;
+    }
+
+    const idSet = new Set(statementIds);
+    const anchorTextsByStatement: Record<string, string[]> = {};
+
+    const docs = await Document.findByEntityIds(conn, statementIds);
+    for (const docData of docs) {
+      const doc = new Document(docData);
+      const traverse = (nodes: AnchorsNode[]) => {
+        for (const node of nodes) {
+          if (idSet.has(node.anchor)) {
+            if (!anchorTextsByStatement[node.anchor]) {
+              anchorTextsByStatement[node.anchor] = [];
+            }
+            anchorTextsByStatement[node.anchor].push(node.getShortContent());
+          }
+          traverse(node.children);
+        }
+      };
+      traverse(doc.anchors);
+    }
+
+    for (const us of this.usedInStatements) {
+      const texts = anchorTextsByStatement[us.statement.id];
+      if (texts && texts.length) {
+        us.anchorTexts = texts;
+      }
+    }
   }
 
   /**

--- a/packages/server/src/models/entity/response.ts
+++ b/packages/server/src/models/entity/response.ts
@@ -92,8 +92,10 @@ export class ResponseEntity extends Entity implements IResponseEntity {
     }
 
     // stamp document anchor spans onto statement entities so tags can show
-    // them as labels (response-only field, see IEntity.anchorTexts)
-    await Entity.applyAnchorTexts(conn, entities);
+    // them as labels (response-only field, see IEntity.anchorTexts). The
+    // response root itself joins the batch - when the detail/tooltip is opened
+    // on a statement, its own tag (header row, detail tab) needs the spans too.
+    await Entity.applyAnchorTexts(conn, [...Object.values(entities), this]);
 
     return entities;
   }

--- a/packages/server/src/models/entity/response.ts
+++ b/packages/server/src/models/entity/response.ts
@@ -1,5 +1,4 @@
 import { nonenumerable } from "@common/decorators";
-import Document from "@models/document/document";
 import { UsedRelations } from "@models/relation/relations";
 import Statement from "@models/statement/statement";
 import treeCache from "@service/treeCache";
@@ -91,6 +90,10 @@ export class ResponseEntity extends Entity implements IResponseEntity {
     for (const entity of additionalEntities) {
       entities[entity.id] = entity;
     }
+
+    // stamp document anchor spans onto statement entities so tags can show
+    // them as labels (response-only field, see IEntity.anchorTexts)
+    await Entity.applyAnchorTexts(conn, entities);
 
     return entities;
   }
@@ -236,13 +239,10 @@ export class ResponseEntityDetail
       this.addLinkedEntities(ud.resourceId);
     });
 
-    // Attach document anchor spans to each used-in statement so the detail
-    // Statements table can show them as its primary "Text" fallback. Reads
-    // this.usedInStatements, populated by walkStatementsDataEntities above.
-    await this.populateUsedInStatementAnchors(conn);
-
     // populateEntitiesMap depends on the fully-accumulated linkedEntitiesIds,
-    // so it must come after every addLinkedEntities call above.
+    // so it must come after every addLinkedEntities call above. It also stamps
+    // anchorTexts onto statement entities (used-in statements included), which
+    // the detail Statements table reads for its "Text" fallback.
     this.entities = await this.populateEntitiesMap(conn);
 
     // apply casts from templates - must be done after populateEntitiesMap
@@ -320,35 +320,6 @@ export class ResponseEntityDetail
       this.addLinkedEntities(c.actantEntityId);
       this.addLinkedEntities(c.relationEntityId);
     });
-  }
-
-  /**
-   * Fills the anchorTexts field of every used-in statement with the content of
-   * the document anchors that point at that statement (node.anchor ===
-   * statement.id). A statement anchored several times yields several strings -
-   * the client joins them for display. One batched document read covers every
-   * used-in statement.
-   * @param conn
-   */
-  async populateUsedInStatementAnchors(conn: Connection): Promise<void> {
-    const statementIds = [
-      ...new Set(this.usedInStatements.map((us) => us.statement.id)),
-    ];
-    if (!statementIds.length) {
-      return;
-    }
-
-    const anchorTextsByStatement = await Document.getAnchorTextsForEntities(
-      conn,
-      statementIds
-    );
-
-    for (const us of this.usedInStatements) {
-      const texts = anchorTextsByStatement[us.statement.id];
-      if (texts && texts.length) {
-        us.anchorTexts = texts;
-      }
-    }
   }
 
   /**

--- a/packages/server/src/models/statement/response.ts
+++ b/packages/server/src/models/statement/response.ts
@@ -117,6 +117,10 @@ export class ResponseStatement extends Statement implements IResponseStatement {
       ...entities.map((x) => ({ [x.id]: x })),
       ...anchorEntities.map((x) => ({ [x.id]: x }))
     );
+
+    // stamp document anchor spans onto statement entities so tags can show
+    // them as labels (response-only field, see IEntity.anchorTexts)
+    await Entity.applyAnchorTexts(db, this.entities);
   }
 
   /**

--- a/packages/server/src/models/statement/response.ts
+++ b/packages/server/src/models/statement/response.ts
@@ -36,6 +36,7 @@ export class ResponseStatement extends Statement implements IResponseStatement {
   right: UserEnums.RoleMode = UserEnums.RoleMode.Read;
   warnings: IWarning[];
   usedInDocuments: IResponseUsedInDocument[];
+  anchorTexts?: string[];
 
   constructor(entity: IStatement) {
     super(entity);
@@ -47,6 +48,14 @@ export class ResponseStatement extends Statement implements IResponseStatement {
   async prepare(req: IRequest, settings?: ISetting[]) {
     this.right = this.getUserRoleMode(req.getUserOrFail());
     this.usedInDocuments = await this.findUsedInDocuments(req.db.connection);
+    // Display-friendly mirror of the statement's own anchor spans (see
+    // IResponseStatement.anchorTexts); derived from the already-loaded documents.
+    const anchorTexts = this.usedInDocuments
+      .map((d) => d.anchorText)
+      .filter((t) => t);
+    if (anchorTexts.length) {
+      this.anchorTexts = anchorTexts;
+    }
 
     await this.prepareEntities(req.db.connection);
     if (!this.isTemplate) {

--- a/packages/server/src/models/territory/response.ts
+++ b/packages/server/src/models/territory/response.ts
@@ -8,6 +8,7 @@ import {
 import Territory from "./territory";
 import Statement from "@models/statement/statement";
 import { ResponseStatement } from "@models/statement/response";
+import Document from "@models/document/document";
 import Entity from "@models/entity/entity";
 import { IRequest } from "src/custom_typings/request";
 import { findEntityById } from "@service/shorthands";
@@ -136,6 +137,22 @@ export class ResponseTerritory extends Territory implements IResponseTerritory {
         }
 
         responseStatements.push(responseStatement);
+      }
+    }
+
+    // Batch-load each statement's document anchor spans in a single query so the
+    // statement list Text column can show them without a per-statement
+    // round-trip. The preload (prepareSync) path never fills usedInDocuments, so
+    // this is the only anchor-text source for the list; the non-preload path
+    // fills usedInDocuments too but anchorTexts stays the display-friendly field.
+    const anchorTextsByStatement = await Document.getAnchorTextsForEntities(
+      req.db.connection,
+      responseStatements.map((rs) => rs.id)
+    );
+    for (const rs of responseStatements) {
+      const texts = anchorTextsByStatement[rs.id];
+      if (texts && texts.length) {
+        rs.anchorTexts = texts;
       }
     }
 

--- a/packages/server/src/models/territory/response.ts
+++ b/packages/server/src/models/territory/response.ts
@@ -1,4 +1,4 @@
-import { UserEnums } from "@inkvisitor/shared/enums";
+import { EntityEnums, UserEnums } from "@inkvisitor/shared/enums";
 import {
   IEntity,
   IResponseStatement,
@@ -140,19 +140,39 @@ export class ResponseTerritory extends Territory implements IResponseTerritory {
       }
     }
 
-    // Batch-load each statement's document anchor spans in a single query so the
-    // statement list Text column can show them without a per-statement
-    // round-trip. The preload (prepareSync) path never fills usedInDocuments, so
-    // this is the only anchor-text source for the list; the non-preload path
-    // fills usedInDocuments too but anchorTexts stays the display-friendly field.
-    const anchorTextsByStatement = await Document.getAnchorTextsForEntities(
-      req.db.connection,
-      responseStatements.map((rs) => rs.id)
-    );
-    for (const rs of responseStatements) {
-      const texts = anchorTextsByStatement[rs.id];
-      if (texts && texts.length) {
-        rs.anchorTexts = texts;
+    // Batch-load document anchor spans in a single query for both the statement
+    // rows (their own anchorTexts display field, used by the list Text column)
+    // and any statement-class entities in the entities map (stamped for
+    // EntityTag labels; see IEntity.anchorTexts). Only the preload path needs
+    // this: prepareSync never fills usedInDocuments, so rows/map would stay
+    // bare. The non-preload path already derives both per statement inside
+    // ResponseStatement.prepare (anchorTexts from usedInDocuments, map via
+    // prepareEntities' applyAnchorTexts) - re-running the batch there would be
+    // pure duplicate work.
+    if (usePreload) {
+      const mapStatements = Object.values(this.entities).filter(
+        (e) => !!e && e.class === EntityEnums.Class.Statement
+      );
+      const anchorTextsByStatement = await Document.getAnchorTextsForEntities(
+        req.db.connection,
+        [
+          ...new Set([
+            ...responseStatements.map((rs) => rs.id),
+            ...mapStatements.map((e) => e.id),
+          ]),
+        ]
+      );
+      for (const rs of responseStatements) {
+        const texts = anchorTextsByStatement[rs.id];
+        if (texts && texts.length) {
+          rs.anchorTexts = texts;
+        }
+      }
+      for (const e of mapStatements) {
+        const texts = anchorTextsByStatement[e.id];
+        if (texts && texts.length) {
+          e.anchorTexts = texts;
+        }
       }
     }
 

--- a/packages/server/src/models/user/response.ts
+++ b/packages/server/src/models/user/response.ts
@@ -3,6 +3,7 @@ import { findEntityById } from "@service/shorthands";
 import { UserEnums } from "@inkvisitor/shared/enums";
 import {
   IBookmarkFolder,
+  IEntity,
   IResponseBookmarkFolder,
   IResponseStoredTerritory,
   IResponseUser,
@@ -80,6 +81,15 @@ export class ResponseUser implements IResponseUser {
       }
       this.bookmarks.push(bookmarkResponse);
     }
+
+    // stamp document anchor spans onto bookmarked statements so tags can show
+    // them as labels (response-only field, see IEntity.anchorTexts); one
+    // batched read covers all folders
+    const bookmarkedEntities: IEntity[] = [];
+    for (const folder of this.bookmarks) {
+      bookmarkedEntities.push(...folder.entities);
+    }
+    await Entity.applyAnchorTexts(req.db.connection, bookmarkedEntities);
   }
 
   async unwindTerritories(req: IRequest): Promise<void> {

--- a/packages/server/src/modules/entities/entities.batch.test.ts
+++ b/packages/server/src/modules/entities/entities.batch.test.ts
@@ -11,6 +11,7 @@ import Statement, {
 import { Db } from "@service/rethink";
 import { pool } from "@middlewares/db";
 import { IResponseEntity } from "@inkvisitor/shared/types";
+import Document from "@models/document/document";
 
 describe("Entities batch method", function () {
   let authAgent: Awaited<ReturnType<typeof getAuthenticatedAgent>>;
@@ -97,6 +98,48 @@ describe("Entities batch method", function () {
           const foundIds = res.body.map((entity: IResponseEntity) => entity.id);
           expect(foundIds).toContain(statementId1);
           expect(foundIds).toContain(statementId2);
+        });
+
+      await clean(db);
+    });
+  });
+
+  describe("Anchored statement", () => {
+    it("should stamp anchorTexts onto the statement result", async () => {
+      const db = new Db();
+      await db.initDb();
+
+      // the statement id doubles as the document tag name, which excludes
+      // ".", so keep it dot-free
+      const statementId = `anchored${Math.random()
+        .toString()
+        .replace(/\./g, "")}`;
+      const statement = new Statement({
+        id: statementId,
+        data: new StatementData({
+          territory: new StatementTerritory({
+            territoryId: "test-territory-1",
+          }),
+        }),
+      });
+      await statement.save(db.connection);
+
+      // the statement must exist before preprocess so its class lands in
+      // documents.entityIds and the anchor resolves
+      const doc = new Document({
+        id: Math.random().toString(),
+        content: `pre<${statementId}>batch anchor span</${statementId}>post`,
+      });
+      await doc.preprocess(db.connection);
+      await doc.save(db.connection);
+
+      await authAgent
+        .post(`${apiPath}/entities/batch`)
+        .send({ ids: [statementId] })
+        .expect(200)
+        .expect((res) => {
+          expect(res.body.length).toBe(1);
+          expect(res.body[0].anchorTexts).toEqual(["batch anchor span"]);
         });
 
       await clean(db);

--- a/packages/server/src/modules/entities/entities.search.test.ts
+++ b/packages/server/src/modules/entities/entities.search.test.ts
@@ -1,4 +1,5 @@
 import { apiPath } from "@common/constants";
+import Document from "@models/document/document";
 import { StatementActant, StatementAction } from "@models/statement/statement";
 import { testErroneousResponse } from "@modules/common.test";
 import { Db } from "@service/rethink";
@@ -101,6 +102,18 @@ describe("Entities search (params)", function () {
       new StatementAction({ id: action.id, actionId: action.id }),
     ];
 
+    // statement anchored in a document - its id doubles as the document tag
+    // name, which excludes ".", so keep it dot-free
+    const [, anchoredStatement] = prepareStatement();
+    anchoredStatement.labels = ["anchored-statement"];
+    anchoredStatement.id = `anchored${Math.random()
+      .toString()
+      .replace(/\./g, "")}`;
+    const doc = new Document({
+      id: Math.random().toString(),
+      content: `pre<${anchoredStatement.id}>anchor span</${anchoredStatement.id}>post`,
+    });
+
     beforeAll(async () => {
       db = new Db();
       await db.initDb();
@@ -110,6 +123,12 @@ describe("Entities search (params)", function () {
       await entity.save(db.connection);
       await linkedEntity.save(db.connection);
       await statement.save(db.connection);
+
+      // the statement must exist before preprocess so its class lands in
+      // documents.entityIds and the anchor resolves
+      await anchoredStatement.save(db.connection);
+      await doc.preprocess(db.connection);
+      await doc.save(db.connection);
     });
 
     afterAll(async () => {
@@ -276,6 +295,24 @@ describe("Entities search (params)", function () {
               expect(res.body).toHaveLength(0);
             });
         });
+      });
+    });
+
+    describe("search returning an anchored statement", () => {
+      it("should stamp anchorTexts onto the statement result", async () => {
+        await authAgent
+          .get(`${apiPath}/entities`)
+          .query({
+            class: EntityEnums.Class.Statement,
+            label: anchoredStatement.labels[0],
+          })
+          .expect("Content-Type", /json/)
+          .expect(200)
+          .expect((res: Response) => {
+            expect(res.body).toHaveLength(1);
+            expect(res.body[0].id).toEqual(anchoredStatement.id);
+            expect(res.body[0].anchorTexts).toEqual(["anchor span"]);
+          });
       });
     });
   });

--- a/packages/server/src/modules/entities/index.ts
+++ b/packages/server/src/modules/entities/index.ts
@@ -1211,6 +1211,11 @@ export default Router()
         })
       );
 
+      // stamp document anchor spans onto statement results so tags can show
+      // them as labels (response-only field, see IEntity.anchorTexts). Must
+      // run on the wrapped responses - getEntityClass drops undeclared fields.
+      await Entity.applyAnchorTexts(request.db.connection, responses);
+
       return responses;
     })
   );

--- a/packages/server/src/modules/users/users.bookmarksget.test.ts
+++ b/packages/server/src/modules/users/users.bookmarksget.test.ts
@@ -13,6 +13,7 @@ import { getAuthenticatedAgent } from "@modules/testAuth";
 import User from "@models/user/user";
 import { IBookmarkFolder } from "@inkvisitor/shared/types";
 import { pool } from "@middlewares/db";
+import Document from "@models/document/document";
 
 describe("Users bookmarksGet", function () {
   let authAgent: Awaited<ReturnType<typeof getAuthenticatedAgent>>;
@@ -86,6 +87,57 @@ describe("Users bookmarksGet", function () {
         .expect((res) => {
           expect(res.body).toHaveLength(1);
           expect(res.body[0].entities).toHaveLength(1);
+        })
+        .expect(200);
+    });
+  });
+  describe("Bookmarked anchored statement", () => {
+    it("should stamp anchorTexts onto the bookmarked statement", async () => {
+      // the statement id doubles as the document tag name, which excludes
+      // ".", so keep it dot-free
+      const statementId = `anchored${Math.random()
+        .toString()
+        .replace(/\./g, "")}`;
+
+      await createEntity(
+        db,
+        new Statement({
+          id: statementId,
+          data: new StatementData({
+            territory: new StatementTerritory({ territoryId: "any" }),
+          }),
+        })
+      );
+
+      // the statement must exist before preprocess so its class lands in
+      // documents.entityIds and the anchor resolves
+      const doc = new Document({
+        id: Math.random().toString(),
+        content: `pre<${statementId}>bookmark anchor span</${statementId}>post`,
+      });
+      await doc.preprocess(db.connection);
+      await doc.save(db.connection);
+
+      const userId = Math.random().toString();
+      const user = new User({
+        id: userId,
+        bookmarks: [
+          {
+            id: "test-anchored",
+            name: "test-anchored",
+            entityIds: [statementId],
+          } as IBookmarkFolder,
+        ],
+      });
+      await user.save(db.connection);
+
+      await authAgent
+        .get(`${apiPath}/users/${userId}/bookmarks`)
+        .expect((res) => {
+          expect(res.body).toHaveLength(1);
+          expect(res.body[0].entities[0].anchorTexts).toEqual([
+            "bookmark anchor span",
+          ]);
         })
         .expect(200);
     });

--- a/packages/server/src/service/query/search.ts
+++ b/packages/server/src/service/query/search.ts
@@ -97,6 +97,11 @@ export default class QuerySearch {
     const filteredIds = this.results.filter(this.explore);
     const filtered = await Entity.findEntitiesByIds(db, filteredIds);
 
+    // stamp document anchor spans onto statement rows so tags can show them
+    // as labels (response-only field, see IEntity.anchorTexts); page-limited
+    // input, single batched read
+    await Entity.applyAnchorTexts(db, filtered);
+
     const columns =
       this.explore.view.mode === Explore.EViewMode.Table
         ? this.explore.view.columns

--- a/packages/shared/types/entity.ts
+++ b/packages/shared/types/entity.ts
@@ -19,6 +19,10 @@ export interface IEntity {
   templateData?: object;
   createdAt?: Date;
   updatedAt?: Date;
+  // response-only, never persisted: content of each document anchor pointing
+  // at this entity (only filled for Statement-class entities in response
+  // entities maps / lists; see Entity.applyAnchorTexts on the server)
+  anchorTexts?: string[];
 }
 
 export const entityAllowedFields: Record<keyof IEntity, boolean> = {
@@ -38,4 +42,5 @@ export const entityAllowedFields: Record<keyof IEntity, boolean> = {
   templateData: true,
   createdAt: true,
   updatedAt: true,
+  anchorTexts: false, // response-only computed field, not writable
 };

--- a/packages/shared/types/response-detail.ts
+++ b/packages/shared/types/response-detail.ts
@@ -50,6 +50,7 @@ export interface IResponseUsedInDocument {
 export interface IResponseUsedInStatement<PositionEnum> {
   statement: IStatement;
   position: PositionEnum;
+  anchorTexts?: string[]; // text of each document anchor whose anchor === statement.id (empty/undefined when the statement is not anchored)
 }
 
 export interface IResponseUsedInStatementProps {

--- a/packages/shared/types/response-detail.ts
+++ b/packages/shared/types/response-detail.ts
@@ -50,7 +50,6 @@ export interface IResponseUsedInDocument {
 export interface IResponseUsedInStatement<PositionEnum> {
   statement: IStatement;
   position: PositionEnum;
-  anchorTexts?: string[]; // text of each document anchor whose anchor === statement.id (empty/undefined when the statement is not anchored)
 }
 
 export interface IResponseUsedInStatementProps {

--- a/packages/shared/types/response-statement.ts
+++ b/packages/shared/types/response-statement.ts
@@ -38,6 +38,7 @@ export interface IResponseStatement extends IStatement {
   entities: { [key: string]: IEntity }; // all entities (IEntity) used in actions/actants, actions/actants.props.type/value, territory, references, tags, actant identifications and classifications
   // usedIn?: IStatement[];
   usedInDocuments: IResponseUsedInDocument[];
+  anchorTexts?: string[]; // content of each document anchor whose anchor === statement.id (empty/undefined when the statement is not anchored)
   warnings: IWarning[];
   right?: UserEnums.RoleMode;
 }


### PR DESCRIPTION
- Show anchor text in EntityDetail Statements table and StatementList table
- Last missing piece of showing anchor text in Statement EntityTag label from #2594
- Show warning ring around elvl newly in Suggester of AnnotatorMenu to promt user to choose the elvl before entity creation
- Fix EntityTag shortening for fullWidth tags so no element wrappers needed anymore

Close #3033
Close #2873
Close #2932
Close #3196