### PR TITLE
Client / Finetune api requests and cache

### DIFF
--- a/packages/client/src/app.tsx
+++ b/packages/client/src/app.tsx
@@ -1,5 +1,4 @@
 import { InterfaceEnums, UserEnums } from "@inkvisitor/shared/enums";
-import { getStoredUserId, getStoredUserRole, getStoredUsername } from "utils/userStorage";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import api from "api";
@@ -15,6 +14,7 @@ import {
   ActivatePage,
   BackupsPage,
   DocumentsPage,
+  ExplorerPage,
   LoginPage,
   MainPage,
   NotFoundPage,
@@ -35,7 +35,7 @@ import { heightHeader } from "Theme/constants";
 import GlobalStyle from "Theme/global";
 import theme from "Theme/theme";
 import { darkTheme } from "Theme/theme-dark";
-import { ExplorerPage } from "pages";
+import { getStoredUserRole } from "utils/userStorage";
 
 const clockPerformance = (
   profilerId: any,

--- a/packages/client/src/components/advanced/Annotator/AnnotatorWarningsModal.tsx
+++ b/packages/client/src/components/advanced/Annotator/AnnotatorWarningsModal.tsx
@@ -3,7 +3,7 @@ import { IResponseEntity } from "@inkvisitor/shared/types";
 import { ButtonGroup, Loader, Modal, ModalContent, ModalFooter, ModalHeader } from "components";
 import { Button } from "components/basic/Button/Button";
 import { EntityTagById } from "components/advanced/EntityTag/EntityTagById";
-import { useEntitiesQuery } from "hooks/react-query";
+import { WARNING_ANCHOR_ENTITIES_KEY, useEntitiesQuery } from "hooks/react-query";
 import React, { useMemo } from "react";
 import { FaExclamationTriangle } from "react-icons/fa";
 import { FaScissors } from "react-icons/fa6";
@@ -82,7 +82,7 @@ export const AnnotatorWarningsModal: React.FC<AnnotatorWarningsModalProps> = ({
   // Batch-fetch all anchor entities in a single request instead of letting each
   // EntityTagById fetch on its own. Only runs while the modal is open.
   const { data: anchorEntities, isFetching: isFetchingEntities } = useEntitiesQuery(
-    "warning-anchor-entities",
+    WARNING_ANCHOR_ENTITIES_KEY,
     anchorIds,
     { enabled: open }
   );

--- a/packages/client/src/components/advanced/Annotator/AnnotatorWarningsModal.tsx
+++ b/packages/client/src/components/advanced/Annotator/AnnotatorWarningsModal.tsx
@@ -1,10 +1,9 @@
 import { AsymmetricalAnchor } from "@inkvisitor/annotator/src/lib";
 import { IResponseEntity } from "@inkvisitor/shared/types";
-import { useQuery } from "@tanstack/react-query";
-import api from "api";
 import { ButtonGroup, Loader, Modal, ModalContent, ModalFooter, ModalHeader } from "components";
 import { Button } from "components/basic/Button/Button";
 import { EntityTagById } from "components/advanced/EntityTag/EntityTagById";
+import { useEntitiesQuery } from "hooks/react-query";
 import React, { useMemo } from "react";
 import { FaExclamationTriangle } from "react-icons/fa";
 import { FaScissors } from "react-icons/fa6";
@@ -82,14 +81,11 @@ export const AnnotatorWarningsModal: React.FC<AnnotatorWarningsModalProps> = ({
 
   // Batch-fetch all anchor entities in a single request instead of letting each
   // EntityTagById fetch on its own. Only runs while the modal is open.
-  const { data: anchorEntities, isFetching: isFetchingEntities } = useQuery({
-    queryKey: ["warning-anchor-entities", anchorIds],
-    queryFn: async () => {
-      const res = await api.entitiesGet(anchorIds);
-      return res.data ?? [];
-    },
-    enabled: open && anchorIds.length > 0 && api.isLoggedIn(),
-  });
+  const { data: anchorEntities, isFetching: isFetchingEntities } = useEntitiesQuery(
+    "warning-anchor-entities",
+    anchorIds,
+    { enabled: open }
+  );
 
   const entityMap = useMemo(() => {
     const map: Record<string, IResponseEntity> = {};

--- a/packages/client/src/components/advanced/ApplyTemplateModal/ApplyTemplateModal.tsx
+++ b/packages/client/src/components/advanced/ApplyTemplateModal/ApplyTemplateModal.tsx
@@ -1,5 +1,4 @@
 import { entitiesDictKeys } from "@inkvisitor/shared/dictionaries";
-import { getStoredUserId, getStoredUserRole, getStoredUsername } from "utils/userStorage";
 import { UserEnums } from "@inkvisitor/shared/enums";
 import { IEntity, IResponseGeneric, Relation } from "@inkvisitor/shared/types";
 import { UseMutationResult, useQueryClient } from "@tanstack/react-query";
@@ -19,6 +18,7 @@ import { applyTemplate, InstRelations } from "constructors";
 import { useDetailQuery } from "hooks/react-query";
 import React, { useEffect, useState } from "react";
 import { toast } from "react-toastify";
+import { getStoredUserRole } from "utils/userStorage";
 import { getShortLabelByLetterCount } from "utils/utils";
 
 interface ApplyTemplateModal {
@@ -58,7 +58,7 @@ export const ApplyTemplateModal: React.FC<ApplyTemplateModal> = ({
       const newRelations: Relation.IRelation[] = InstRelations(
         relations,
         templateToApply.id,
-        entity.id
+        entity.id,
       );
 
       setNewRelations(newRelations);
@@ -72,7 +72,7 @@ export const ApplyTemplateModal: React.FC<ApplyTemplateModal> = ({
       const entityAfterTemplateApplied: IEntity = await applyTemplate(
         templateToApply,
         entity,
-        getStoredUserRole() as UserEnums.Role
+        getStoredUserRole() as UserEnums.Role,
       );
 
       if (entityAfterTemplateApplied) {
@@ -88,10 +88,10 @@ export const ApplyTemplateModal: React.FC<ApplyTemplateModal> = ({
         toast.info(
           `Template "${getShortLabelByLetterCount(
             templateToApply.labels[0] || "",
-            120
+            120,
           )}" applied to ${
             entitiesDictKeys[entity.class].label
-          } "${getShortLabelByLetterCount(entity.labels[0] || "", 120)}"`
+          } "${getShortLabelByLetterCount(entity.labels[0] || "", 120)}"`,
         );
 
         updateEntityMutation.mutate(entityAfterTemplateApplied);

--- a/packages/client/src/components/advanced/EntityDropzone/EntityDropzone.tsx
+++ b/packages/client/src/components/advanced/EntityDropzone/EntityDropzone.tsx
@@ -1,10 +1,10 @@
 import { EntityEnums, UserEnums } from "@inkvisitor/shared/enums";
-import { getStoredUserId, getStoredUserRole, getStoredUsername } from "utils/userStorage";
 import { IEntity, IStatement, ITerritory } from "@inkvisitor/shared/types";
 import { Dropzone } from "components";
 import { InstTemplate } from "constructors";
 import React, { ReactElement, useState } from "react";
 import { EntityDragItem } from "types";
+import { getStoredUserRole } from "utils/userStorage";
 
 interface EntityDropzone {
   categoryTypes: EntityEnums.ExtendedClass[];
@@ -39,11 +39,11 @@ export const EntityDropzone: React.FC<EntityDropzone> = ({
   const [isWrongDropCategory, setIsWrongDropCategory] = useState(false);
 
   const handleInstantiateTemplate = async (
-    templateToDuplicate: IEntity | IStatement | ITerritory
+    templateToDuplicate: IEntity | IStatement | ITerritory,
   ) => {
     const newEntity = await InstTemplate(
       templateToDuplicate,
-      getStoredUserRole() as UserEnums.Role
+      getStoredUserRole() as UserEnums.Role,
     );
     if (newEntity) {
       onSelected(newEntity.id);
@@ -51,10 +51,7 @@ export const EntityDropzone: React.FC<EntityDropzone> = ({
     }
   };
 
-  const handleDropped = (
-    newDropped: EntityDragItem,
-    instantiateTemplate?: boolean
-  ) => {
+  const handleDropped = (newDropped: EntityDragItem, instantiateTemplate?: boolean) => {
     if (!isWrongDropCategory) {
       if (instantiateTemplate && !disableTemplateInstantiation) {
         newDropped.entity && handleInstantiateTemplate(newDropped.entity);

--- a/packages/client/src/components/advanced/Page/Page.tsx
+++ b/packages/client/src/components/advanced/Page/Page.tsx
@@ -1,11 +1,10 @@
 import { UserEnums } from "@inkvisitor/shared/enums";
-import { getAppEnv } from "utils/appEnv";
-import { getStoredUserId, getStoredUserRole, getStoredUsername } from "utils/userStorage";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import api from "api";
 import { Header, Loader } from "components";
 import { LeftHeader, RightHeader, UserCustomizationModal } from "components/advanced";
 import { useSearchParams } from "hooks";
+import { useUserQuery } from "hooks/react-query";
 import useKeyLift from "hooks/useKeyLift";
 import useKeypress from "hooks/useKeyPress";
 import React, { useCallback, useEffect, useMemo, useState } from "react";
@@ -16,8 +15,9 @@ import { setLastClickedIndex } from "redux/features/statementList/lastClickedInd
 import { setUsername } from "redux/features/usernameSlice";
 import { useAppDispatch, useAppSelector } from "redux/hooks";
 import theme, { ThemeColor } from "Theme/theme";
+import { getAppEnv } from "utils/appEnv";
+import { getStoredUserId, getStoredUserRole } from "utils/userStorage";
 import { StyledPage, StyledPageContent } from "./PageStyles";
-import { useUserQuery } from "hooks/react-query";
 
 interface Page {
   children?: React.ReactNode;
@@ -41,8 +41,8 @@ export const Page: React.FC<Page> = ({ children }) => {
     environmentName === "production"
       ? "muni"
       : environmentName in theme.color
-      ? (environmentName as keyof ThemeColor)
-      : "black";
+        ? (environmentName as keyof ThemeColor)
+        : "black";
 
   const location = useLocation();
   const navigate = useNavigate();

--- a/packages/client/src/components/advanced/UserTag/UserTag.tsx
+++ b/packages/client/src/components/advanced/UserTag/UserTag.tsx
@@ -1,8 +1,7 @@
 import { UserEnums } from "@inkvisitor/shared/enums";
 import { getStoredUserId, getStoredUserRole, getStoredUsername } from "utils/userStorage";
-import { useQuery } from "@tanstack/react-query";
-import api from "api";
 import { Tag } from "components/basic/Tag/Tag";
+import { useUserByIdQuery } from "hooks/react-query";
 import React, { useMemo } from "react";
 import { useTheme } from "styled-components";
 import { getUserIcon } from "utils/iconUtils";
@@ -33,14 +32,7 @@ export const UserTag: React.FC<UserTagProps> = ({
   const currentUserId = getStoredUserId();
   const color = currentUserId === userId ? "primary" : "info";
 
-  const { data: dataUser } = useQuery({
-    queryKey: ["user-tag", userId],
-    queryFn: async () => {
-      const res = await api.usersGet(userId, { ignoreErrorToast: true });
-      return res.data;
-    },
-    enabled: Boolean(userId) && !disableFetch,
-  });
+  const { data: dataUser } = useUserByIdQuery(userId, !disableFetch, true);
 
   const variantColors = getVariantColors(theme, color, variant);
   const label = getUserLabel(dataUser, userId);

--- a/packages/client/src/components/advanced/UserTag/UserTag.tsx
+++ b/packages/client/src/components/advanced/UserTag/UserTag.tsx
@@ -1,10 +1,10 @@
 import { UserEnums } from "@inkvisitor/shared/enums";
-import { getStoredUserId, getStoredUserRole, getStoredUsername } from "utils/userStorage";
 import { Tag } from "components/basic/Tag/Tag";
 import { useUserByIdQuery } from "hooks/react-query";
 import React, { useMemo } from "react";
 import { useTheme } from "styled-components";
 import { getUserIcon } from "utils/iconUtils";
+import { getStoredUserId } from "utils/userStorage";
 import { StyledUserIcon, StyledUserLabel, StyledUserTag, StyledUserTagWrap } from "./UserTagStyles";
 import { getUserLabel, getVariantColors, UserTagSize, UserTagVariant } from "./utils";
 

--- a/packages/client/src/components/advanced/UserTag/UserTag.tsx
+++ b/packages/client/src/components/advanced/UserTag/UserTag.tsx
@@ -32,7 +32,7 @@ export const UserTag: React.FC<UserTagProps> = ({
   const currentUserId = getStoredUserId();
   const color = currentUserId === userId ? "primary" : "info";
 
-  const { data: dataUser } = useUserByIdQuery(userId, !disableFetch, true);
+  const { data: dataUser } = useUserByIdQuery(userId, !disableFetch);
 
   const variantColors = getVariantColors(theme, color, variant);
   const label = getUserLabel(dataUser, userId);

--- a/packages/client/src/components/basic/Message/Message.tsx
+++ b/packages/client/src/components/basic/Message/Message.tsx
@@ -2,10 +2,9 @@ import React, { useMemo } from "react";
 
 import { WarningTypeEnums } from "@inkvisitor/shared/enums";
 import { IEntity, IWarning } from "@inkvisitor/shared/types";
-import { useQuery } from "@tanstack/react-query";
 import { WarningIcon } from "./WarningIcon";
-import api from "api";
 import { EntityTag } from "components/advanced";
+import { useEntitiesQuery } from "hooks/react-query";
 import { EntityColors } from "types";
 import {
   StyledMessage,
@@ -56,14 +55,10 @@ export const Message: React.FC<Message> = ({ warning, entities }) => {
 
   // Single batched fallback for ids missing from the provided map. The shared
   // cache key lets multiple warnings referencing the same entities dedupe.
-  const { data: fetchedEntities } = useQuery({
-    queryKey: ["message-warning-entities", missingEntityIds],
-    queryFn: async () => {
-      const res = await api.entitiesGet(missingEntityIds);
-      return res.data ?? [];
-    },
-    enabled: missingEntityIds.length > 0 && api.isLoggedIn(),
-  });
+  const { data: fetchedEntities } = useEntitiesQuery(
+    "message-warning-entities",
+    missingEntityIds
+  );
 
   // Provided entities plus any fetched fallbacks.
   const extendedEntities = useMemo(() => {

--- a/packages/client/src/components/basic/Message/Message.tsx
+++ b/packages/client/src/components/basic/Message/Message.tsx
@@ -4,7 +4,7 @@ import { WarningTypeEnums } from "@inkvisitor/shared/enums";
 import { IEntity, IWarning } from "@inkvisitor/shared/types";
 import { WarningIcon } from "./WarningIcon";
 import { EntityTag } from "components/advanced";
-import { useEntitiesQuery } from "hooks/react-query";
+import { MESSAGE_WARNING_ENTITIES_KEY, useEntitiesQuery } from "hooks/react-query";
 import { EntityColors } from "types";
 import {
   StyledMessage,
@@ -56,7 +56,7 @@ export const Message: React.FC<Message> = ({ warning, entities }) => {
   // Single batched fallback for ids missing from the provided map. The shared
   // cache key lets multiple warnings referencing the same entities dedupe.
   const { data: fetchedEntities } = useEntitiesQuery(
-    "message-warning-entities",
+    MESSAGE_WARNING_ENTITIES_KEY,
     missingEntityIds
   );
 

--- a/packages/client/src/hooks/react-query/index.tsx
+++ b/packages/client/src/hooks/react-query/index.tsx
@@ -1,8 +1,10 @@
+import { DETAIL_TAB_ENTITIES_KEY } from "./queryKeys";
 import { useAuditQuery } from "./useAuditQuery";
 import { useBookmarksQuery } from "./useBookmarksQuery";
 import { useDetailQuery } from "./useDetailQuery";
 import { useDocumentQuery } from "./useDocumentQuery";
 import { useDocumentsQuery } from "./useDocumentsQuery";
+import { useEntitiesQuery } from "./useEntitiesQuery";
 import { useOrderedLanguageDict } from "./useOrderedLanguageDict";
 import { useResourcesWithDocumentsQuery } from "./useResourcesWithDocumentsQuery";
 import { useSavedQueriesQuery } from "./useSavedQueriesQuery";
@@ -14,11 +16,13 @@ import { useUsersGetMoreQuery } from "./useUsersGetMoreQuery";
 import { useUsersSimplifiedQuery } from "./useUsersSimplifiedQuery";
 
 export {
+  DETAIL_TAB_ENTITIES_KEY,
   useAuditQuery,
   useBookmarksQuery,
   useDetailQuery,
   useDocumentQuery,
   useDocumentsQuery,
+  useEntitiesQuery,
   useOrderedLanguageDict,
   useResourcesWithDocumentsQuery,
   useSavedQueriesQuery,

--- a/packages/client/src/hooks/react-query/index.tsx
+++ b/packages/client/src/hooks/react-query/index.tsx
@@ -1,4 +1,9 @@
-import { DETAIL_TAB_ENTITIES_KEY } from "./queryKeys";
+import {
+  BATCH_RELATION_ELIGIBILITY_KEY,
+  DETAIL_TAB_ENTITIES_KEY,
+  MESSAGE_WARNING_ENTITIES_KEY,
+  WARNING_ANCHOR_ENTITIES_KEY,
+} from "./queryKeys";
 import { useAuditQuery } from "./useAuditQuery";
 import { useBookmarksQuery } from "./useBookmarksQuery";
 import { useDetailQuery } from "./useDetailQuery";
@@ -16,7 +21,10 @@ import { useUsersGetMoreQuery } from "./useUsersGetMoreQuery";
 import { useUsersSimplifiedQuery } from "./useUsersSimplifiedQuery";
 
 export {
+  BATCH_RELATION_ELIGIBILITY_KEY,
   DETAIL_TAB_ENTITIES_KEY,
+  MESSAGE_WARNING_ENTITIES_KEY,
+  WARNING_ANCHOR_ENTITIES_KEY,
   useAuditQuery,
   useBookmarksQuery,
   useDetailQuery,

--- a/packages/client/src/hooks/react-query/index.tsx
+++ b/packages/client/src/hooks/react-query/index.tsx
@@ -9,7 +9,7 @@ import { useSavedQueriesQuery } from "./useSavedQueriesQuery";
 import { useStatementQuery } from "./useStatementQuery";
 import { useTemplatesQuery } from "./useTemplatesQuery";
 import { useTreeQuery } from "./useTreeQuery";
-import { useUserQuery } from "./useUserQuery";
+import { useUserByIdQuery, useUserQuery } from "./useUserQuery";
 import { useUsersGetMoreQuery } from "./useUsersGetMoreQuery";
 import { useUsersSimplifiedQuery } from "./useUsersSimplifiedQuery";
 
@@ -25,6 +25,7 @@ export {
   useStatementQuery,
   useTemplatesQuery,
   useTreeQuery,
+  useUserByIdQuery,
   useUserQuery,
   useUsersGetMoreQuery,
   useUsersSimplifiedQuery,

--- a/packages/client/src/hooks/react-query/queryKeys.ts
+++ b/packages/client/src/hooks/react-query/queryKeys.ts
@@ -1,3 +1,8 @@
 // Query keys shared between the component that fetches the data and the
 // (many) places that invalidate it after a mutation.
+// Every useEntitiesQuery caller draws its key from here, so the whole namespace
+// is visible in one place and two call sites cannot pick the same string.
 export const DETAIL_TAB_ENTITIES_KEY = "detail-tab-entities";
+export const WARNING_ANCHOR_ENTITIES_KEY = "warning-anchor-entities";
+export const MESSAGE_WARNING_ENTITIES_KEY = "message-warning-entities";
+export const BATCH_RELATION_ELIGIBILITY_KEY = "batch-relation-eligibility";

--- a/packages/client/src/hooks/react-query/queryKeys.ts
+++ b/packages/client/src/hooks/react-query/queryKeys.ts
@@ -1,0 +1,3 @@
+// Query keys shared between the component that fetches the data and the
+// (many) places that invalidate it after a mutation.
+export const DETAIL_TAB_ENTITIES_KEY = "detail-tab-entities";

--- a/packages/client/src/hooks/react-query/useEntitiesQuery.tsx
+++ b/packages/client/src/hooks/react-query/useEntitiesQuery.tsx
@@ -1,0 +1,23 @@
+// batch-fetch a set of entities by ids
+import { useQuery } from "@tanstack/react-query";
+import api from "api";
+
+// The prefix keeps each caller's cache entries separate, so invalidating one
+// feature's entities does not refetch the others.
+export function useEntitiesQuery(
+  queryKeyPrefix: string,
+  entityIds: string[],
+  options: { enabled?: boolean; staleTime?: number } = {},
+) {
+  const { enabled = true, staleTime } = options;
+
+  return useQuery({
+    queryKey: [queryKeyPrefix, entityIds],
+    queryFn: async () => {
+      const res = await api.entitiesGet(entityIds);
+      return res.data ?? [];
+    },
+    enabled: api.isLoggedIn() && entityIds.length > 0 && enabled,
+    staleTime,
+  });
+}

--- a/packages/client/src/hooks/react-query/useUserQuery.tsx
+++ b/packages/client/src/hooks/react-query/useUserQuery.tsx
@@ -1,14 +1,18 @@
 // manage user data for current user
 import { useQuery } from "@tanstack/react-query";
-import { getStoredUserId, getStoredUserRole, getStoredUsername } from "utils/userStorage";
 import api from "api";
+import { getStoredUserId } from "utils/userStorage";
 
-export function useUserQuery(enabled = true) {
-  const userId = getStoredUserId();
+// fetch any user by id, shares cache with useUserQuery when the id matches the current user
+export function useUserByIdQuery(
+  userId: string | null | undefined,
+  enabled = true,
+  ignoreErrorToast = false,
+) {
   return useQuery({
     queryKey: ["user", userId],
     queryFn: async () => {
-      const res = await api.usersGet(userId as string);
+      const res = await api.usersGet(userId as string, { ignoreErrorToast });
       return res.data ?? undefined;
     },
     enabled: !!userId && api.isLoggedIn() && enabled,
@@ -17,4 +21,8 @@ export function useUserQuery(enabled = true) {
     // assigned by admin / owner
     refetchOnWindowFocus: true,
   });
+}
+
+export function useUserQuery(enabled = true) {
+  return useUserByIdQuery(getStoredUserId(), enabled);
 }

--- a/packages/client/src/hooks/react-query/useUserQuery.tsx
+++ b/packages/client/src/hooks/react-query/useUserQuery.tsx
@@ -4,15 +4,16 @@ import api from "api";
 import { getStoredUserId } from "utils/userStorage";
 
 // fetch any user by id, shares cache with useUserQuery when the id matches the current user
-export function useUserByIdQuery(
-  userId: string | null | undefined,
-  enabled = true,
-  ignoreErrorToast = false,
-) {
+// the shared cache entry means only one queryFn survives per id, so the toast behaviour
+// is fixed here rather than passed in by the caller
+export function useUserByIdQuery(userId: string | null | undefined, enabled = true) {
   return useQuery({
     queryKey: ["user", userId],
     queryFn: async () => {
-      const res = await api.usersGet(userId as string, { ignoreErrorToast });
+      const res = await api.usersGet(userId as string, {
+        // typically used in batch in tables like audit so ignore error toast avoids spamming
+        ignoreErrorToast: true,
+      });
       return res.data ?? undefined;
     },
     enabled: !!userId && api.isLoggedIn() && enabled,

--- a/packages/client/src/hooks/useSearchParamsContext.tsx
+++ b/packages/client/src/hooks/useSearchParamsContext.tsx
@@ -1,5 +1,3 @@
-import { useQuery } from "@tanstack/react-query";
-import api from "api";
 import React, {
   createContext,
   ReactElement,
@@ -58,11 +56,7 @@ const arrJoinChar = ",";
 
 export const useSearchParams = () => useContext(SearchParamsContext);
 
-export const SearchParamsProvider = ({
-  children,
-}: {
-  children: ReactElement;
-}) => {
+export const SearchParamsProvider = ({ children }: { children: ReactElement }) => {
   const navigate = useNavigate();
   const location = useLocation();
 
@@ -86,54 +80,31 @@ export const SearchParamsProvider = ({
   }
 
   const [territoryId, setTerritoryId] = useState<string>(
-    typeof parsedParams.territory === "string" ? parsedParams.territory : ""
+    typeof parsedParams.territory === "string" ? parsedParams.territory : "",
   );
   const [statementId, setStatementId] = useState<string>(
-    typeof parsedParams.statement === "string" ? parsedParams.statement : ""
+    typeof parsedParams.statement === "string" ? parsedParams.statement : "",
   );
   const [selectedDetailId, setSelectedDetailId] = useState<string>(
-    typeof parsedParams.selectedDetail === "string"
-      ? parsedParams.selectedDetail
-      : ""
+    typeof parsedParams.selectedDetail === "string" ? parsedParams.selectedDetail : "",
   );
 
   const [detailId, setDetailId] = useState<string>(
-    typeof parsedParams.detail === "string" ? parsedParams.detail : ""
+    typeof parsedParams.detail === "string" ? parsedParams.detail : "",
   );
-
-  const stringToBoolean = (string: string) => {
-    if (string.toLowerCase() === "true") {
-      return true;
-    } else if (string.toLowerCase() === "false") {
-      return false;
-    } else {
-      console.log("Invalid url params boolean string");
-      return null;
-    }
-  };
 
   // Editor is open by default; the URL only records the non-default (closed)
   // state via the `editorClosed` token.
   const [editorOpened, setEditorOpened] = useState<boolean>(
-    "editorClosed" in parsedParams ? false : true
+    "editorClosed" in parsedParams ? false : true,
   );
 
-  const [disablePush, setDisablePush] = useState(false);
   const isLoggingOutRef = React.useRef(false);
   const isHandlingLocationChangeRef = React.useRef(false);
 
   const getDetailIdArray = () => {
     return detailId.length > 0 ? detailId.split(arrJoinChar) : [];
   };
-
-  const { data } = useQuery({
-    queryKey: ["detail-tab-entities", getDetailIdArray()],
-    queryFn: async () => {
-      const res = await api.entitiesSearch({ entityIds: getDetailIdArray() });
-      return res.data;
-    },
-    enabled: api.isLoggedIn() && getDetailIdArray().length > 9,
-  });
 
   const appendDetailId = (id: string, maxCount: number = maxTabCount) => {
     const detailIdArray = getDetailIdArray();
@@ -142,15 +113,7 @@ export const SearchParamsProvider = ({
       if (detailIdArray.length < maxCount) {
         newDetailIdArray.push([...detailIdArray, id]);
       } else {
-        newDetailIdArray.push([
-          ...detailIdArray.splice(1, detailIdArray.length),
-          id,
-        ]);
-        // toast.info(
-        //   `Tab [${
-        //     data ? getEntityLabel(data[0]) : detailIdArray
-        //   }] canceled from detail`
-        // );
+        newDetailIdArray.push([...detailIdArray.splice(1, detailIdArray.length), id]);
       }
       setDetailId(newDetailIdArray.join(arrJoinChar));
     }
@@ -170,14 +133,10 @@ export const SearchParamsProvider = ({
     } else {
       // merge with existing
       // remove already added ids and add them at the end
-      const filteredArray: string[] = detailIdArray.filter(
-        (id) => !ids.includes(id)
-      );
+      const filteredArray: string[] = detailIdArray.filter((id) => !ids.includes(id));
       newDetailIdArray = filteredArray.concat(ids);
       if (newDetailIdArray.length > maxCount) {
-        newDetailIdArray = newDetailIdArray.slice(
-          newDetailIdArray.length - maxCount
-        );
+        newDetailIdArray = newDetailIdArray.slice(newDetailIdArray.length - maxCount);
       }
     }
 
@@ -193,9 +152,7 @@ export const SearchParamsProvider = ({
     const detailIdArray = getDetailIdArray();
     const index = detailIdArray.indexOf(id);
 
-    const newIds = detailIdArray
-      .filter((detailId) => detailId !== id)
-      .join(arrJoinChar);
+    const newIds = detailIdArray.filter((detailId) => detailId !== id).join(arrJoinChar);
 
     if (selectedDetailId === id) {
       if (index + 1 === detailIdArray.length) {
@@ -224,11 +181,7 @@ export const SearchParamsProvider = ({
   };
 
   const handleHistoryPush = () => {
-    if (
-      !disablePush &&
-      !isLoggingOutRef.current &&
-      !isHandlingLocationChangeRef.current
-    ) {
+    if (!isLoggingOutRef.current && !isHandlingLocationChangeRef.current) {
       const hashString = params.toString();
       // Remove the = symbol for editorClosed parameter
       const cleanHash = hashString
@@ -252,29 +205,20 @@ export const SearchParamsProvider = ({
     isLoggingOutRef.current = isLoggingOut;
   };
 
-  const hasSearchParams = useMemo(
-    () => parsedParamsSearch?.hash?.length > 0,
-    [parsedParamsSearch]
-  );
+  const hasSearchParams = useMemo(() => parsedParamsSearch?.hash?.length > 0, [parsedParamsSearch]);
 
   useEffect(() => {
     // Change from the inside of the app to this state
     if (!hasSearchParams) {
-      territoryId
-        ? params.set("territory", territoryId)
-        : params.delete("territory");
-      statementId
-        ? params.set("statement", statementId)
-        : params.delete("statement");
+      territoryId ? params.set("territory", territoryId) : params.delete("territory");
+      statementId ? params.set("statement", statementId) : params.delete("statement");
 
       selectedDetailId
         ? params.set("selectedDetail", selectedDetailId)
         : params.delete("selectedDetail");
       detailId ? params.set("detail", detailId) : params.delete("detail");
 
-      editorOpened
-        ? params.delete("editorClosed")
-        : params.set("editorClosed", "");
+      editorOpened ? params.delete("editorClosed") : params.set("editorClosed", "");
 
       handleHistoryPush();
     }
@@ -285,21 +229,15 @@ export const SearchParamsProvider = ({
       const paramsTemp = new URLSearchParams(location.hash.substring(1));
       const parsedParamsTemp = Object.fromEntries(paramsTemp);
 
-      parsedParamsTemp.territory
-        ? setTerritoryId(parsedParamsTemp.territory)
-        : setTerritoryId("");
+      parsedParamsTemp.territory ? setTerritoryId(parsedParamsTemp.territory) : setTerritoryId("");
 
-      parsedParamsTemp.statement
-        ? setStatementId(parsedParamsTemp.statement)
-        : setStatementId("");
+      parsedParamsTemp.statement ? setStatementId(parsedParamsTemp.statement) : setStatementId("");
 
       parsedParamsTemp.selectedDetail
         ? setSelectedDetailId(parsedParamsTemp.selectedDetail)
         : setSelectedDetailId("");
 
-      parsedParamsTemp.detail
-        ? setDetailId(parsedParamsTemp.detail)
-        : setDetailId("");
+      parsedParamsTemp.detail ? setDetailId(parsedParamsTemp.detail) : setDetailId("");
 
       // Handle editorClosed parameter (editor open unless explicitly closed)
       setEditorOpened(!("editorClosed" in parsedParamsTemp));

--- a/packages/client/src/pages/Main/MainPage.tsx
+++ b/packages/client/src/pages/Main/MainPage.tsx
@@ -1,5 +1,4 @@
 import { EntityEnums, UserEnums } from "@inkvisitor/shared/enums";
-import { getStoredUserId, getStoredUserRole, getStoredUsername } from "utils/userStorage";
 import { IStatement } from "@inkvisitor/shared/types";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import api from "api";
@@ -22,12 +21,10 @@ import { RiMenuFoldFill, RiMenuUnfoldFill } from "react-icons/ri";
 import { VscClose, VscCloseAll } from "react-icons/vsc";
 import { setDetailBoxState } from "redux/features/layout/mainPage/detailBoxStateSlice";
 import { setEditorBoxState } from "redux/features/layout/mainPage/editorBoxStateSlice";
-import { setSecondPanelExpanded } from "redux/features/layout/mainPage/secondPanelExpandedSlice";
-import { setThirdPanelExpanded } from "redux/features/layout/mainPage/thirdPanelExpandedSlice";
-import { ToggleFourthPanelBoxButton } from "./components/ToggleFourthPanelBoxButton";
-import { RefreshBoxButton } from "./components/RefreshBoxButton";
 import { setPanelWidths } from "redux/features/layout/mainPage/panelWidthsSlice";
+import { setSecondPanelExpanded } from "redux/features/layout/mainPage/secondPanelExpandedSlice";
 import { setSecondPanelRealWidth } from "redux/features/layout/mainPage/secondPanelRealWidthSlice";
+import { setThirdPanelExpanded } from "redux/features/layout/mainPage/thirdPanelExpandedSlice";
 import { setThirdPanelRealWidth } from "redux/features/layout/mainPage/thirdPanelRealWidthSlice";
 import { setDisableStatementListScroll } from "redux/features/statementList/disableStatementListScrollSlice";
 import { setIsLoading } from "redux/features/statementList/isLoadingSlice";
@@ -43,7 +40,10 @@ import {
   THIRD_PANEL_MIN_WIDTH,
 } from "Theme/constants";
 import { ButtonSize, DetailBoxState, EditorBoxState } from "types";
+import { getStoredUserRole } from "utils/userStorage";
 import { floorNumberToOneDecimal } from "utils/utils";
+import { RefreshBoxButton } from "./components/RefreshBoxButton";
+import { ToggleFourthPanelBoxButton } from "./components/ToggleFourthPanelBoxButton";
 import { MemoizedAnnotatorBox } from "./containers/AnnotatorBox/AnnotatorBox";
 import { MemoizedEntityBookmarkBox } from "./containers/EntityBookmarkBox/EntityBookmarkBox";
 import { MemoizedEntityDetailBox } from "./containers/EntityDetailBox/EntityDetailBox";
@@ -53,9 +53,9 @@ import { MemoizedStatementListBox } from "./containers/StatementsListBox/Stateme
 import { MemoizedTemplateListBox } from "./containers/TemplateListBox/TemplateListBox";
 import { MemoizedTerritoryTreeBox } from "./containers/TerritoryTreeBox/TerritoryTreeBox";
 import { useBoxLayout } from "./hooks/useBoxLayout";
-import { useVerticalSeparators } from "./hooks/useVerticalSeparators";
 import { usePanelToggles } from "./hooks/usePanelToggles";
 import { useTerritoryNavigation } from "./hooks/useTerritoryNavigation";
+import { useVerticalSeparators } from "./hooks/useVerticalSeparators";
 
 type FourthPanelBoxes = "search" | "bookmarks" | "templates";
 

--- a/packages/client/src/pages/Main/components/RefreshBoxButton.tsx
+++ b/packages/client/src/pages/Main/components/RefreshBoxButton.tsx
@@ -26,11 +26,9 @@ export const RefreshBoxButton: React.FC<RefreshBoxButton> = ({ queriesToRefresh,
         const uid = getStoredUserId();
         await Promise.all(
           queriesToRefresh.map(async (queryToRefresh) => {
-            const queryKey =
-              queryToRefresh === "user" && uid ? ["user", uid] : [queryToRefresh];
+            const queryKey = queryToRefresh === "user" && uid ? ["user", uid] : [queryToRefresh];
             await queryClient.invalidateQueries({ queryKey });
-            await queryClient.refetchQueries({ queryKey, type: "active" });
-          })
+          }),
         );
       }}
     />

--- a/packages/client/src/pages/Main/components/RefreshBoxButton.tsx
+++ b/packages/client/src/pages/Main/components/RefreshBoxButton.tsx
@@ -1,8 +1,8 @@
-import React from "react";
-import { getStoredUserId, getStoredUserRole, getStoredUsername } from "utils/userStorage";
 import { useQueryClient } from "@tanstack/react-query";
 import { Button } from "components";
+import React from "react";
 import { BiRefresh } from "react-icons/bi";
+import { getStoredUserId } from "utils/userStorage";
 
 interface RefreshBoxButton {
   queriesToRefresh: string[];

--- a/packages/client/src/pages/Main/containers/EntityBookmarkBox/EntityBookmarkFolder/EntityBookmarkFolder.tsx
+++ b/packages/client/src/pages/Main/containers/EntityBookmarkBox/EntityBookmarkFolder/EntityBookmarkFolder.tsx
@@ -1,5 +1,4 @@
 import { classesAll } from "@inkvisitor/shared/dictionaries/entity";
-import { getStoredUserId, getStoredUserRole, getStoredUsername } from "utils/userStorage";
 import { UserEnums } from "@inkvisitor/shared/enums";
 import { IBookmarkFolder, IResponseBookmarkFolder } from "@inkvisitor/shared/types";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
@@ -9,9 +8,10 @@ import { EntitySuggester } from "components/advanced";
 import React, { useRef, useState } from "react";
 import { DropTargetMonitor, useDrop } from "react-dnd";
 import { FaFolder, FaFolderOpen, FaRegFolder, FaRegFolderOpen } from "react-icons/fa";
-import { IcoTrash } from "Theme/icons";
 import { MdEdit } from "react-icons/md";
+import { IcoTrash } from "Theme/icons";
 import { DragItem, ItemTypes } from "types";
+import { getStoredUserRole } from "utils/userStorage";
 import { EntityBookmarkTable } from "../EntityBookmarkTable/EntityBookmarkTable";
 import {
   StyledEditButtonWrap,

--- a/packages/client/src/pages/Main/containers/EntityDetailBox/EntityDetail/EntityDetail.tsx
+++ b/packages/client/src/pages/Main/containers/EntityDetailBox/EntityDetail/EntityDetail.tsx
@@ -1,7 +1,7 @@
 import { entitiesDictKeys } from "@inkvisitor/shared/dictionaries";
-import { getStoredUserId, getStoredUserRole, getStoredUsername } from "utils/userStorage";
 import { EntityEnums, RelationEnums, UserEnums } from "@inkvisitor/shared/enums";
 import {
+  DropdownItem,
   IEntity,
   IProp,
   IReference,
@@ -31,8 +31,6 @@ import { toast } from "react-toastify";
 import { useAppSelector } from "redux/hooks";
 import { rootTerritoryId } from "Theme/constants";
 import { DraggedPropRowCategory } from "types";
-import { DropdownItem } from "@inkvisitor/shared/types";
-import { getEntityLabel, getEntityRelationRules, getShortLabelByLetterCount } from "utils/utils";
 import {
   ENTITY_DETAIL_SCROLLBAR_ID,
   ENTITY_DETAIL_SCROLL_CONTAINER_ID,
@@ -40,6 +38,8 @@ import {
   usedInSectionId,
 } from "utils/deleteEntityConflict";
 import { openRestoredEntity } from "utils/openRestoredEntity";
+import { getStoredUserRole } from "utils/userStorage";
+import { getEntityLabel, getEntityRelationRules, getShortLabelByLetterCount } from "utils/utils";
 import { EntityReferenceTable } from "../../EntityReferenceTable/EntityReferenceTable";
 import { PropGroup } from "../../PropGroup/PropGroup";
 import { EntityDetailCreateTemplateModal } from "./EntityDetailCreateTemplateModal/EntityDetailCreateTemplateModal";
@@ -137,7 +137,7 @@ export const EntityDetail: React.FC<EntityDetail> = ({ detailId, entity, error, 
     if (!isIncompleteEntityDetail) return;
     toast.error(
       "Entity detail could not be loaded: the same query key was used for a different API response. Please contact support.",
-      { toastId: `incomplete-entity-detail-${detailId}` }
+      { toastId: `incomplete-entity-detail-${detailId}` },
     );
   }, [isIncompleteEntityDetail, detailId]);
 
@@ -156,7 +156,7 @@ export const EntityDetail: React.FC<EntityDetail> = ({ detailId, entity, error, 
   const handleAskForTemplateApply = (templateIdToApply: string) => {
     if (templates) {
       const templateThatIsGoingToBeApplied = templates.find(
-        (template: IEntity) => template.id === templateIdToApply
+        (template: IEntity) => template.id === templateIdToApply,
       );
 
       if (templateThatIsGoingToBeApplied) {
@@ -178,7 +178,7 @@ export const EntityDetail: React.FC<EntityDetail> = ({ detailId, entity, error, 
 
   const templates = useMemo(
     () => allTemplates?.filter((template: IEntity) => template.class === entity?.class),
-    [allTemplates, entity?.class]
+    [allTemplates, entity?.class],
   );
 
   // refresh the template list when the user opens the dropdown, but only once
@@ -237,10 +237,7 @@ export const EntityDetail: React.FC<EntityDetail> = ({ detailId, entity, error, 
 
       // read the open statement from cache (the editor already fetched it) -
       // no need to subscribe and fetch it here just for this check
-      const statement = queryClient.getQueryData<IResponseStatement>([
-        "statement",
-        statementId,
-      ]);
+      const statement = queryClient.getQueryData<IResponseStatement>(["statement", statementId]);
       if (
         statementId &&
         (statementId === entity?.id ||
@@ -323,7 +320,7 @@ export const EntityDetail: React.FC<EntityDetail> = ({ detailId, entity, error, 
         />,
         {
           autoClose: 5000,
-        }
+        },
       );
 
       // hide selected territory if T removed
@@ -357,13 +354,13 @@ export const EntityDetail: React.FC<EntityDetail> = ({ detailId, entity, error, 
     const relationTypes = getEntityRelationRules(
       entity.class,
       RelationEnums.EntityDetailTypes,
-      entity.isTemplate
+      entity.isTemplate,
     );
     relationTypes.forEach((relationType: RelationEnums.Type) => {
       entity.relations[relationType as keyof Relation.IUsedRelations]?.connections.forEach(
         (connection: Relation.IConnection<Relation.IRelation>) => {
           relationDeleteMutation.mutate(connection.id);
-        }
+        },
       );
     });
 
@@ -444,7 +441,7 @@ export const EntityDetail: React.FC<EntityDetail> = ({ detailId, entity, error, 
         // 3rd level
         newProps[pi1].children.forEach((prop2, pi2) => {
           newProps[pi1].children[pi2].children = newProps[pi1].children[pi2].children.filter(
-            (child) => child.id !== propId
+            (child) => child.id !== propId,
           );
         });
       });
@@ -579,7 +576,7 @@ export const EntityDetail: React.FC<EntityDetail> = ({ detailId, entity, error, 
 
   // Single state to manage collapsed sections
   const [collapsedSections, setCollapsedSections] = useState<Set<EntityDetailSection>>(
-    new Set([EntityDetailSection.Protocol, EntityDetailSection.Validation])
+    new Set([EntityDetailSection.Protocol, EntityDetailSection.Validation]),
   );
 
   const toggleSection = (sectionId: EntityDetailSection) => {
@@ -641,9 +638,7 @@ export const EntityDetail: React.FC<EntityDetail> = ({ detailId, entity, error, 
                       {entity.warnings
                         .filter((w) => w.position?.section === IWarningPositionSection.Entity)
                         .map((warning, key) => {
-                          return (
-                            <Message key={key} warning={warning} entities={entity.entities} />
-                          );
+                          return <Message key={key} warning={warning} entities={entity.entities} />;
                         })}
                     </StyledDetailWarnings>
                   )}
@@ -728,12 +723,12 @@ export const EntityDetail: React.FC<EntityDetail> = ({ detailId, entity, error, 
                         {entity.warnings &&
                           entity.warnings
                             .filter(
-                              (w) => w.position?.section === IWarningPositionSection.Valencies
+                              (w) => w.position?.section === IWarningPositionSection.Valencies,
                             )
                             .map((warning, key) => {
                               return (
-                            <Message key={key} warning={warning} entities={entity.entities} />
-                          );
+                                <Message key={key} warning={warning} entities={entity.entities} />
+                              );
                             })}
                       </StyledDetailWarnings>
                       <StyledDetailSectionContent>
@@ -769,8 +764,8 @@ export const EntityDetail: React.FC<EntityDetail> = ({ detailId, entity, error, 
                           .filter((w) => w.position?.section === IWarningPositionSection.Relations)
                           .map((warning, key) => {
                             return (
-                            <Message key={key} warning={warning} entities={entity.entities} />
-                          );
+                              <Message key={key} warning={warning} entities={entity.entities} />
+                            );
                           })}
                       </StyledDetailWarnings>
                     )}
@@ -1043,9 +1038,7 @@ export const EntityDetail: React.FC<EntityDetail> = ({ detailId, entity, error, 
                   <EntityDetailExpandIcon
                     isExpanded={isSectionExpanded(EntityDetailSection.RelationAudits)}
                   />
-                  <StyledDetailSectionHeading>
-                    Relation audits
-                  </StyledDetailSectionHeading>
+                  <StyledDetailSectionHeading>Relation audits</StyledDetailSectionHeading>
                 </StyledDetailSectionHeader>
                 {isSectionExpanded(EntityDetailSection.RelationAudits) && (
                   <StyledDetailSectionContent>

--- a/packages/client/src/pages/Main/containers/EntityDetailBox/EntityDetail/EntityDetail.tsx
+++ b/packages/client/src/pages/Main/containers/EntityDetailBox/EntityDetail/EntityDetail.tsx
@@ -23,7 +23,7 @@ import {
 } from "components/advanced";
 import { CMetaProp, DProps } from "constructors";
 import { useIsInViewport, useSearchParams } from "hooks";
-import { useAuditQuery, useTemplatesQuery } from "hooks/react-query";
+import { DETAIL_TAB_ENTITIES_KEY, useAuditQuery, useTemplatesQuery } from "hooks/react-query";
 import { invalidateAllExplorerQueries } from "pages/Query/useQueryData";
 import React, { useEffect, useMemo, useState } from "react";
 import { FaPlus } from "react-icons/fa";
@@ -263,7 +263,7 @@ export const EntityDetail: React.FC<EntityDetail> = ({ detailId, entity, error, 
         queryClient.invalidateQueries({ queryKey: ["bookmarks"] });
       }
       if (variables.labels !== undefined) {
-        queryClient.invalidateQueries({ queryKey: ["detail-tab-entities"] });
+        queryClient.invalidateQueries({ queryKey: [DETAIL_TAB_ENTITIES_KEY] });
       }
       if (entity?.isTemplate) {
         queryClient.invalidateQueries({ queryKey: ["templates"] });

--- a/packages/client/src/pages/Main/containers/EntityDetailBox/EntityDetail/EntityDetailCreateTemplateModal/EntityDetailCreateTemplateModal.tsx
+++ b/packages/client/src/pages/Main/containers/EntityDetailBox/EntityDetail/EntityDetailCreateTemplateModal/EntityDetailCreateTemplateModal.tsx
@@ -1,5 +1,5 @@
 import { UserEnums } from "@inkvisitor/shared/enums";
-import { getStoredUserId, getStoredUserRole, getStoredUsername } from "utils/userStorage";
+import { getStoredUserRole } from "utils/userStorage";
 import { IEntity, IResponseGeneric } from "@inkvisitor/shared/types";
 import { UseMutationResult, useMutation, useQueryClient } from "@tanstack/react-query";
 import api from "api";

--- a/packages/client/src/pages/Main/containers/EntityDetailBox/EntityDetail/EntityDetailHeaderRow/EntityDetailHeaderRow.tsx
+++ b/packages/client/src/pages/Main/containers/EntityDetailBox/EntityDetail/EntityDetailHeaderRow/EntityDetailHeaderRow.tsx
@@ -1,6 +1,5 @@
 import { EntityEnums, UserEnums } from "@inkvisitor/shared/enums";
-import { getStoredUserId, getStoredUserRole, getStoredUsername } from "utils/userStorage";
-import { IEntity, IResponseGeneric, IStatement } from "@inkvisitor/shared/types";
+import { IEntity, IStatement } from "@inkvisitor/shared/types";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import api from "api";
 import { Button, ButtonGroup } from "components";
@@ -11,13 +10,14 @@ import React, { useState } from "react";
 import { AiOutlineLink } from "react-icons/ai";
 import { CgListTree } from "react-icons/cg";
 import { FaClone, FaEdit } from "react-icons/fa";
-import { IcoTrash } from "Theme/icons";
 import { MdCleaningServices } from "react-icons/md";
 import { toast } from "react-toastify";
 import { setTreeInitialized } from "redux/features/territoryTree/treeInitializeSlice";
 import { useAppDispatch } from "redux/hooks";
-import { StyledActantHeaderRow, StyledGrClone, StyledTagWrap } from "./EntityDetailHeaderRowStyles";
+import { IcoTrash } from "Theme/icons";
 import { ButtonSize } from "types";
+import { getStoredUserRole } from "utils/userStorage";
+import { StyledActantHeaderRow, StyledGrClone, StyledTagWrap } from "./EntityDetailHeaderRowStyles";
 
 interface EntityDetailHeaderRow {
   entity: IEntity;

--- a/packages/client/src/pages/Main/containers/EntityDetailBox/EntityDetailBox.tsx
+++ b/packages/client/src/pages/Main/containers/EntityDetailBox/EntityDetailBox.tsx
@@ -1,9 +1,7 @@
 import { IResponseEntity } from "@inkvisitor/shared/types";
-import api from "api";
 import { useSearchParams } from "hooks";
-import { useDetailQuery } from "hooks/react-query";
+import { DETAIL_TAB_ENTITIES_KEY, useDetailQuery, useEntitiesQuery } from "hooks/react-query";
 import React, { useCallback, useEffect, useState } from "react";
-import { useQuery } from "@tanstack/react-query";
 import { EntityDetail } from "./EntityDetail/EntityDetail";
 import { StyledTabGroup } from "./EntityDetailBoxStyles";
 import { EntityDetailTab } from "./EntityDetailTab/EntityDetailTab";
@@ -21,7 +19,7 @@ export const EntityDetailBox: React.FC<EntityDetailBox> = ({ onTabOpen, maxTabs 
   const dispatch = useAppDispatch();
   const ping: number = useAppSelector((state) => state.ping);
   const detailBoxState: DetailBoxState = useAppSelector(
-    (state) => state.layout.mainPage.detailBoxState
+    (state) => state.layout.mainPage.detailBoxState,
   );
   const detailBoxMinimized = detailBoxState === DetailBoxState.Minimized;
 
@@ -45,13 +43,8 @@ export const EntityDetailBox: React.FC<EntityDetailBox> = ({ onTabOpen, maxTabs 
 
   const [entities, setEntities] = useState<IResponseEntity[]>([]);
 
-  const { data, error } = useQuery({
-    queryKey: ["detail-tab-entities", detailIdArray],
-    queryFn: async () => {
-      const res = await api.entitiesGet(detailIdArray);
-      return res.data ?? [];
-    },
-    enabled: api.isLoggedIn() && detailIdArray.length > 0,
+  const { data, error } = useEntitiesQuery(DETAIL_TAB_ENTITIES_KEY, detailIdArray, {
+    staleTime: 1000 * 30, // 30 seconds
   });
 
   useEffect(() => {
@@ -95,7 +88,7 @@ export const EntityDetailBox: React.FC<EntityDetailBox> = ({ onTabOpen, maxTabs 
           [dragIndex, 1],
           [hoverIndex, 0, prevEntities[dragIndex]],
         ],
-      })
+      }),
     );
   }, []);
 
@@ -111,36 +104,32 @@ export const EntityDetailBox: React.FC<EntityDetailBox> = ({ onTabOpen, maxTabs 
     }
   }, [detailBoxMinimized]);
 
-  const {
-    data: entity,
-    error: entityError,
-    isFetching,
-  } = useDetailQuery(selectedDetailId);
+  const { data: entity, error: entityError, isFetching } = useDetailQuery(selectedDetailId);
 
   return (
     <>
       {entities && entities.length > 0 && (
         <StyledTabGroup>
           {entities.map((entity, key) => (
-              <EntityDetailTab
-                key={key}
-                index={key}
-                entity={entity}
-                onClick={() => {
-                  if (detailBoxMinimized) {
-                    dispatch(setDetailBoxState(DetailBoxState.Normal));
-                  }
-                  onTabOpen?.();
-                  setSelectedDetailId(entity.id);
-                }}
-                onClose={() => handleClose(entity.id)}
-                isSelected={selectedDetailId === entity.id}
-                moveRow={moveRow}
-                onDragEnd={() => {
-                  replaceDetailIds(entities.map((e) => e.id));
-                }}
-              />
-            ))}
+            <EntityDetailTab
+              key={key}
+              index={key}
+              entity={entity}
+              onClick={() => {
+                if (detailBoxMinimized) {
+                  dispatch(setDetailBoxState(DetailBoxState.Normal));
+                }
+                onTabOpen?.();
+                setSelectedDetailId(entity.id);
+              }}
+              onClose={() => handleClose(entity.id)}
+              isSelected={selectedDetailId === entity.id}
+              moveRow={moveRow}
+              onDragEnd={() => {
+                replaceDetailIds(entities.map((e) => e.id));
+              }}
+            />
+          ))}
         </StyledTabGroup>
       )}
 
@@ -153,11 +142,7 @@ export const EntityDetailBox: React.FC<EntityDetailBox> = ({ onTabOpen, maxTabs 
             isFetching={isFetching}
           />
         ) : (
-          <>
-            {(ping === -10 || ping >= 0) && !detailBoxMinimized && (
-              <Loader show />
-            )}
-          </>
+          <>{(ping === -10 || ping >= 0) && !detailBoxMinimized && <Loader show />}</>
         )}
       </>
     </>

--- a/packages/client/src/pages/Main/containers/EntitySearchBox/EntitySearchBox.tsx
+++ b/packages/client/src/pages/Main/containers/EntitySearchBox/EntitySearchBox.tsx
@@ -1,5 +1,4 @@
 import { entityStatusDict } from "@inkvisitor/shared/dictionaries";
-import { getStoredUserId, getStoredUserRole, getStoredUsername } from "utils/userStorage";
 import { entitiesDict } from "@inkvisitor/shared/dictionaries/entity";
 import { EntityEnums, SearchEnums, UserEnums } from "@inkvisitor/shared/enums";
 import { DropdownItem, IEntity } from "@inkvisitor/shared/types";
@@ -25,6 +24,7 @@ import { FaPlus } from "react-icons/fa";
 import { RiCloseFill } from "react-icons/ri";
 import { setExpandedOptions } from "redux/features/entitySearch/expandedOptionsSlice";
 import { useAppDispatch, useAppSelector } from "redux/hooks";
+import { getStoredUserRole } from "utils/userStorage";
 import { EntitySearchAdvancedOptions } from "./EntitySearchAdvancedOptions/EntitySearchAdvancedOptions";
 import {
   StyledBoxContent,

--- a/packages/client/src/pages/Main/containers/StatementEditorBox/StatementEditorBox.tsx
+++ b/packages/client/src/pages/Main/containers/StatementEditorBox/StatementEditorBox.tsx
@@ -11,7 +11,7 @@ import { StatementEditor } from "./StatementEditor/StatementEditor";
 import { StyledEditorEmptyState } from "./StatementEditorBoxStyles";
 import { useAppSelector } from "redux/hooks";
 import { computeDifferences } from "utils/utils";
-import { useStatementQuery, useUserQuery } from "hooks/react-query";
+import { DETAIL_TAB_ENTITIES_KEY, useStatementQuery, useUserQuery } from "hooks/react-query";
 import { EditorBoxState } from "types";
 
 export const StatementEditorBox: React.FC = () => {
@@ -57,7 +57,7 @@ export const StatementEditorBox: React.FC = () => {
       queryClient.invalidateQueries({ queryKey: ["audit", statementId] });
 
       if (variables.labels?.[0] !== undefined) {
-        queryClient.invalidateQueries({ queryKey: ["detail-tab-entities"] });
+        queryClient.invalidateQueries({ queryKey: [DETAIL_TAB_ENTITIES_KEY] });
       }
       if (statement && statement.isTemplate) {
         queryClient.invalidateQueries({ queryKey: ["templates"] });

--- a/packages/client/src/pages/Main/containers/StatementsListBox/StatementListBox.tsx
+++ b/packages/client/src/pages/Main/containers/StatementsListBox/StatementListBox.tsx
@@ -46,7 +46,12 @@ import {
 } from "./StatementListBoxStyles";
 import { StatementListHeader } from "./StatementListHeader/StatementListHeader";
 import { StatementListTable } from "./StatementListTable/StatementListTable";
-import { useDocumentQuery, useResourcesWithDocumentsQuery, useUserQuery } from "hooks/react-query";
+import {
+  DETAIL_TAB_ENTITIES_KEY,
+  useDocumentQuery,
+  useResourcesWithDocumentsQuery,
+  useUserQuery,
+} from "hooks/react-query";
 
 const initialData: {
   statements: IResponseStatement[];
@@ -202,7 +207,7 @@ export const StatementListBox: React.FC = () => {
               appendDetailId,
             });
             queryClient.invalidateQueries({
-              queryKey: ["detail-tab-entities"],
+              queryKey: [DETAIL_TAB_ENTITIES_KEY],
             });
             queryClient.invalidateQueries({ queryKey: ["tree"] });
             queryClient.invalidateQueries({ queryKey: ["territory"] });
@@ -215,7 +220,7 @@ export const StatementListBox: React.FC = () => {
 
       if (detailIdArray.includes(sId)) {
         removeDetailId(sId);
-        queryClient.invalidateQueries({ queryKey: ["detail-tab-entities"] });
+        queryClient.invalidateQueries({ queryKey: [DETAIL_TAB_ENTITIES_KEY] });
       }
       dispatch(setRowsExpanded(rowsExpanded.filter((r) => r !== sId)));
       queryClient.invalidateQueries({ queryKey: ["tree"] });

--- a/packages/client/src/pages/Main/containers/StatementsListBox/StatementListBox.tsx
+++ b/packages/client/src/pages/Main/containers/StatementsListBox/StatementListBox.tsx
@@ -1,5 +1,5 @@
 import { EntityEnums, UserEnums } from "@inkvisitor/shared/enums";
-import { getStoredUserId, getStoredUserRole, getStoredUsername } from "utils/userStorage";
+import { getStoredUserRole } from "utils/userStorage";
 import {
   IDocument,
   IEntity,

--- a/packages/client/src/pages/Main/containers/TemplateListBox/TemplateListBox.tsx
+++ b/packages/client/src/pages/Main/containers/TemplateListBox/TemplateListBox.tsx
@@ -1,13 +1,16 @@
-import { entitiesDict, entitiesDictKeys } from "@inkvisitor/shared/dictionaries";
-import { getStoredUserId, getStoredUserRole, getStoredUsername } from "utils/userStorage";
+import { entitiesDict } from "@inkvisitor/shared/dictionaries";
 import { EntityEnums, UserEnums } from "@inkvisitor/shared/enums";
 import { IEntity } from "@inkvisitor/shared/types";
 import { Button, Input, Loader } from "components";
+import { getStoredUserRole } from "utils/userStorage";
 
 import Dropdown, { EntityTag } from "components/advanced";
+import { useDebounce } from "hooks";
 import { useTemplatesQuery } from "hooks/react-query";
 import React, { useMemo, useState } from "react";
 import { FaPlus } from "react-icons/fa";
+import { useSelector } from "react-redux";
+import { selectPanelWidth } from "redux/features/layout/mainPage/panelWidthsSlice";
 import { IcoTrashSimple } from "Theme/icons";
 import {
   StyledBoxContent,
@@ -21,10 +24,6 @@ import {
 } from "./TemplateListBoxStyles";
 import { TemplateListCreateModal } from "./TemplateListCreateModal/TemplateListCreateModal";
 import { TemplateListRemoveModal } from "./TemplateListRemoveModal/TemplateListRemoveModal";
-import { selectPanelWidth } from "redux/features/layout/mainPage/panelWidthsSlice";
-import { useSelector } from "react-redux";
-import { useDebounce } from "hooks";
-import { useAppSelector } from "redux/hooks";
 
 interface TemplateListBox {}
 export const TemplateListBox: React.FC<TemplateListBox> = () => {

--- a/packages/client/src/pages/Main/containers/TemplateListBox/TemplateListRemoveModal/TemplateListRemoveModal.tsx
+++ b/packages/client/src/pages/Main/containers/TemplateListBox/TemplateListRemoveModal/TemplateListRemoveModal.tsx
@@ -4,6 +4,7 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import api from "api";
 import { Submit } from "components";
 import { useSearchParams } from "hooks";
+import { DETAIL_TAB_ENTITIES_KEY } from "hooks/react-query";
 import React, { useEffect, useState } from "react";
 import { toast } from "react-toastify";
 import { getEntityLabel, getShortLabelByLetterCount } from "utils/utils";
@@ -32,7 +33,7 @@ export const TemplateListRemoveModal: React.FC<TemplateListRemoveModal> = ({
     onSuccess: (data, variables) => {
       if (detailIdArray.includes(removeEntityId)) {
         removeDetailId(removeEntityId);
-        queryClient.invalidateQueries({ queryKey: ["detail-tab-entities"] });
+        queryClient.invalidateQueries({ queryKey: [DETAIL_TAB_ENTITIES_KEY] });
       }
       entityToRemove &&
         toast.warning(

--- a/packages/client/src/pages/Main/containers/TerritoryTreeBox/ContextMenuSubmitDelete/ContextMenuSubmitDelete.tsx
+++ b/packages/client/src/pages/Main/containers/TerritoryTreeBox/ContextMenuSubmitDelete/ContextMenuSubmitDelete.tsx
@@ -3,6 +3,7 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import api from "api";
 import { Submit, ToastWithLink } from "components";
 import { useSearchParams } from "hooks";
+import { DETAIL_TAB_ENTITIES_KEY } from "hooks/react-query";
 import React, { useEffect, useState } from "react";
 import { toast } from "react-toastify";
 import { getShortLabelByLetterCount } from "utils/utils";
@@ -53,7 +54,7 @@ export const ContextMenuSubmitDelete: React.FC<ContextMenuSubmitDelete> = ({
             });
             queryClient.invalidateQueries({ queryKey: ["tree"] });
             queryClient.invalidateQueries({
-              queryKey: ["detail-tab-entities"],
+              queryKey: [DETAIL_TAB_ENTITIES_KEY],
             });
             queryClient.invalidateQueries({ queryKey: ["statement"] });
           }}
@@ -67,7 +68,7 @@ export const ContextMenuSubmitDelete: React.FC<ContextMenuSubmitDelete> = ({
         setTerritoryId("");
       }
       removeDetailId(territoryActant.id);
-      queryClient.invalidateQueries({ queryKey: ["detail-tab-entities"] });
+      queryClient.invalidateQueries({ queryKey: [DETAIL_TAB_ENTITIES_KEY] });
       queryClient.invalidateQueries({ queryKey: ["tree"] });
       queryClient.invalidateQueries({ queryKey: ["statement"] });
       queryClient.invalidateQueries({ queryKey: ["bookmarks"] });

--- a/packages/client/src/pages/Main/containers/TerritoryTreeBox/TerritoryTreeBox.tsx
+++ b/packages/client/src/pages/Main/containers/TerritoryTreeBox/TerritoryTreeBox.tsx
@@ -1,12 +1,12 @@
 import { EntityEnums, UserEnums } from "@inkvisitor/shared/enums";
-import { getStoredUserId, getStoredUserRole, getStoredUsername } from "utils/userStorage";
 import { IResponseTree, IUser } from "@inkvisitor/shared/types";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import api from "api";
 import { Button, ButtonGroup, CustomScrollbar, Loader } from "components";
 import { EntityCreateModal } from "components/advanced";
 import { useSearchParams } from "hooks";
-import { COLLAPSED_PANEL_WIDTH } from "Theme/constants";
+import { useUserQuery } from "hooks/react-query";
+import { useTreeQuery } from "hooks/react-query/useTreeQuery";
 import React, { useEffect, useMemo, useState } from "react";
 import { BsFilter } from "react-icons/bs";
 import { FaPlus, FaStar } from "react-icons/fa";
@@ -16,7 +16,9 @@ import { setFilterOpen } from "redux/features/territoryTree/filterOpenSlice";
 import { setSelectedTerritoryPath } from "redux/features/territoryTree/selectedTerritoryPathSlice";
 import { setTreeInitialized } from "redux/features/territoryTree/treeInitializeSlice";
 import { useAppDispatch, useAppSelector } from "redux/hooks";
-import { ButtonSize, ITerritoryFilter } from "types";
+import { COLLAPSED_PANEL_WIDTH } from "Theme/constants";
+import { ITerritoryFilter } from "types";
+import { getStoredUserId, getStoredUserRole } from "utils/userStorage";
 import { searchTree } from "utils/utils";
 import { StyledNoResults, StyledTreeWrapper } from "./TerritoryTreeBoxStyles";
 import { TerritoryTreeFilter } from "./TerritoryTreeFilter/TerritoryTreeFilter";
@@ -29,8 +31,6 @@ import {
   markNodesWithFilters,
 } from "./TerritoryTreeFilterUtils";
 import { MemoizedTerritoryTreeNode } from "./TerritoryTreeNode/TerritoryTreeNode";
-import { useTreeQuery } from "hooks/react-query/useTreeQuery";
-import { useUserQuery } from "hooks/react-query";
 
 const initFilterSettings: ITerritoryFilter = {
   starred: false,

--- a/packages/client/src/pages/Query/Explorer/ExplorerTable/ExplorerTableBatchActionModal/BatchActionAddRelation.tsx
+++ b/packages/client/src/pages/Query/Explorer/ExplorerTable/ExplorerTableBatchActionModal/BatchActionAddRelation.tsx
@@ -1,6 +1,6 @@
 import { EntityEnums, RelationEnums } from "@inkvisitor/shared/enums";
 import { IEntity, Relation } from "@inkvisitor/shared/types";
-import { useMutation, useQuery } from "@tanstack/react-query";
+import { useMutation } from "@tanstack/react-query";
 import theme from "Theme/theme";
 import api from "api";
 import {
@@ -12,6 +12,7 @@ import {
   ModalHeader,
 } from "components";
 import Dropdown, { EntitySuggester, EntityTag } from "components/advanced";
+import { useEntitiesQuery } from "hooks/react-query";
 import React, { useMemo, useState } from "react";
 import { toast } from "react-toastify";
 import {
@@ -49,15 +50,8 @@ export const BatchActionAddRelation: React.FC<BatchActionAddRelationProps> = ({
     data: fetchedEntities,
     isLoading: isLoadingEntities,
     isError: isEntitiesFetchError,
-  } = useQuery({
-    queryKey: ["batchRelationEligibility", selectedEntityIds],
-    queryFn: async () => {
-      const res = await api.entitiesGet(selectedEntityIds);
-      return res.data;
-    },
-    enabled:
-      selectedEntityIds.length > 0 &&
-      selectedEntityIds.length < RELATION_ELIGIBILITY_FETCH_MAX,
+  } = useEntitiesQuery("batchRelationEligibility", selectedEntityIds, {
+    enabled: !isLargeSelection,
   });
 
   const selectedEntities = useMemo<IEntity[]>(() => {

--- a/packages/client/src/pages/Query/Explorer/ExplorerTable/ExplorerTableBatchActionModal/BatchActionAddRelation.tsx
+++ b/packages/client/src/pages/Query/Explorer/ExplorerTable/ExplorerTableBatchActionModal/BatchActionAddRelation.tsx
@@ -1,11 +1,6 @@
 import { EntityEnums, RelationEnums } from "@inkvisitor/shared/enums";
 import { IEntity, Relation } from "@inkvisitor/shared/types";
-<<<<<<< HEAD
 import { useMutation } from "@tanstack/react-query";
-import theme from "Theme/theme";
-=======
-import { useMutation, useQuery } from "@tanstack/react-query";
->>>>>>> dev
 import api from "api";
 import { Button, ButtonGroup, Modal, ModalContent, ModalFooter, ModalHeader } from "components";
 import Dropdown, { EntitySuggester, EntityTag } from "components/advanced";
@@ -46,19 +41,8 @@ export const BatchActionAddRelation: React.FC<BatchActionAddRelationProps> = ({
     data: fetchedEntities,
     isLoading: isLoadingEntities,
     isError: isEntitiesFetchError,
-<<<<<<< HEAD
   } = useEntitiesQuery("batchRelationEligibility", selectedEntityIds, {
     enabled: !isLargeSelection,
-=======
-  } = useQuery({
-    queryKey: ["batchRelationEligibility", selectedEntityIds],
-    queryFn: async () => {
-      const res = await api.entitiesGet(selectedEntityIds);
-      return res.data;
-    },
-    enabled:
-      selectedEntityIds.length > 0 && selectedEntityIds.length < RELATION_ELIGIBILITY_FETCH_MAX,
->>>>>>> dev
   });
 
   const selectedEntities = useMemo<IEntity[]>(() => {

--- a/packages/client/src/pages/Query/Explorer/ExplorerTable/ExplorerTableBatchActionModal/BatchActionAddRelation.tsx
+++ b/packages/client/src/pages/Query/Explorer/ExplorerTable/ExplorerTableBatchActionModal/BatchActionAddRelation.tsx
@@ -4,7 +4,7 @@ import { useMutation } from "@tanstack/react-query";
 import api from "api";
 import { Button, ButtonGroup, Modal, ModalContent, ModalFooter, ModalHeader } from "components";
 import Dropdown, { EntitySuggester, EntityTag } from "components/advanced";
-import { useEntitiesQuery } from "hooks/react-query";
+import { BATCH_RELATION_ELIGIBILITY_KEY, useEntitiesQuery } from "hooks/react-query";
 import React, { useMemo, useState } from "react";
 import { toast } from "react-toastify";
 import { BatchActionApplyConfirm, needsBatchActionConfirm } from "./BatchActionApplyConfirm";
@@ -41,7 +41,7 @@ export const BatchActionAddRelation: React.FC<BatchActionAddRelationProps> = ({
     data: fetchedEntities,
     isLoading: isLoadingEntities,
     isError: isEntitiesFetchError,
-  } = useEntitiesQuery("batchRelationEligibility", selectedEntityIds, {
+  } = useEntitiesQuery(BATCH_RELATION_ELIGIBILITY_KEY, selectedEntityIds, {
     enabled: !isLargeSelection,
   });
 

--- a/packages/client/src/pages/Users/containers/UserList/UserList.tsx
+++ b/packages/client/src/pages/Users/containers/UserList/UserList.tsx
@@ -1,5 +1,4 @@
 import { userRoleDict } from "@inkvisitor/shared/dictionaries";
-import { getStoredUserId, getStoredUserRole, getStoredUsername } from "utils/userStorage";
 import { EntityEnums, UserEnums } from "@inkvisitor/shared/enums";
 import { IResponseUser, IUser, IUserRight } from "@inkvisitor/shared/types";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
@@ -15,6 +14,7 @@ import { toast } from "react-toastify";
 import { IcoTrash } from "Theme/icons";
 import { ButtonSize } from "types";
 import { getUserIcon } from "utils/iconUtils";
+import { getStoredUserId, getStoredUserRole } from "utils/userStorage";
 import { UserListEmailInput } from "./UserListEmailInput/UserListEmailInput";
 import { UserListIcon } from "./UserListIcon/UserListIcon";
 import {
@@ -593,9 +593,7 @@ export const UserList: React.FC<UserList> = React.memo(() => {
                 icon={<IcoTrash size={14} />}
                 color="danger"
                 tooltipLabel={deleteTooltip}
-                disabled={
-                  userId === getStoredUserId() || role === UserEnums.Role.Owner
-                }
+                disabled={userId === getStoredUserId() || role === UserEnums.Role.Owner}
                 onClick={() => {
                   setRemovingUserId(userId);
                 }}
@@ -638,9 +636,7 @@ export const UserList: React.FC<UserList> = React.memo(() => {
                 icon={active ? <FaToggleOn size={14} /> : <FaToggleOff size={14} />}
                 shape="rounded-right-sm"
                 disabled={
-                  !verified ||
-                  userId === getStoredUserId() ||
-                  role === UserEnums.Role.Owner
+                  !verified || userId === getStoredUserId() || role === UserEnums.Role.Owner
                 }
                 color={active ? "success" : "danger"}
                 tooltipLabel={activateTooltip}

--- a/packages/server/env/example.env
+++ b/packages/server/env/example.env
@@ -18,6 +18,10 @@ BACKUP_DIR=/backup
 # serving swagger file from file (empty to disable), ie. ./swagger.json
 SWAGGER_FILE=
 
+# Log "Slow query(<ms>): <route>" lines for requests over 200ms.
+# Enabled unless set to 0/false/no/off (unset = enabled).
+LOG_SLOW_QUERIES=
+
 PORT=3000
 
 # Flag for enabling SSL - loads cert.pem & key.pem from 'secret' dir

--- a/packages/server/src/middlewares/profiler.ts
+++ b/packages/server/src/middlewares/profiler.ts
@@ -2,11 +2,22 @@ import { Response, Request, NextFunction } from "express";
 
 const threshold = 200; // 200 ms
 
+// Slow query logging is on unless LOG_SLOW_QUERIES explicitly disables it, so
+// an unset variable keeps the previous behaviour.
+const enabled = !["0", "false", "no", "off"].includes(
+  (process.env.LOG_SLOW_QUERIES || "").trim().toLowerCase()
+);
+
 export default function profilerMiddleware(
   req: Request,
   res: Response,
   next: NextFunction
 ): void {
+  if (!enabled) {
+    next();
+    return;
+  }
+
   const start = Date.now();
   res.once("finish", () => {
     const elapsed = Date.now() - start;


### PR DESCRIPTION
1. Fixes a query-key collision (the real payload).
useSearchParamsContext ran a useQuery on key ["detail-tab-entities", ids] calling api.entitiesSearch, while EntityDetailBox used the same key calling api.entitiesGet. Two response shapes, one cache entry, colliding once a user opened >9 detail tabs. The stray query is deleted (its result only fed a commented-out toast), and all keys now live in a new queryKeys.ts.

2. Extracts two shared hooks.
- useEntitiesQuery(keyPrefix, ids, opts) — replaces four hand-rolled useQuery blocks that each batch-fetched entities by id, each with a slightly different enabled guard. Now one guard: isLoggedIn && ids.length > 0 && enabled.
- useUserByIdQuery(userId, enabled) — UserTag moves off its private ["user-tag", id] key onto the shared ["user", id], inheriting staleTime: 60s. Since the v5 default is 0, this strictly reduces refetches on window focus.

3. Drops a redundant refetch. RefreshBoxButton no longer calls refetchQueries({ type: "active" }) after invalidateQueries — invalidation already defaults to refetchType: "active".

4. Server: LOG_SLOW_QUERIES env flag gates the 200ms profiler middleware. Unset means enabled, so no deployment changes.

5. useSearchParamsContext dead code + formatting. Removes disablePush (never set true) and an unused stringToBoolean. The remaining ~24 files are prettier reflow to printWidth: 100 plus an organize-imports sweep — mechanical, but it's the bulk of the line count.