### PR TITLE
2076 mark paragraph breaks more clearly

### DIFF
--- a/packages/annotator/jest.setup.js
+++ b/packages/annotator/jest.setup.js
@@ -11,8 +11,11 @@ global.ResizeObserver = class ResizeObserver {
   disconnect() {}
 };
 
-// Mock getContext for canvas
-HTMLCanvasElement.prototype.getContext = jest.fn(() => ({
+// Mock getContext for canvas. Plain function (not arrow) so `this` is the
+// canvas element — real contexts expose it as ctx.canvas.
+HTMLCanvasElement.prototype.getContext = jest.fn(function () {
+  return {
+  canvas: this,
   fillRect: jest.fn(),
   fillText: jest.fn(),
   measureText: jest.fn(() => ({ width: 100 })),
@@ -36,7 +39,8 @@ HTMLCanvasElement.prototype.getContext = jest.fn(() => ({
   globalAlpha: 1,
   globalCompositeOperation: 'source-over',
   reset: jest.fn(),
-}));
+  };
+});
 
 // Mock canvas dimensions
 Object.defineProperty(HTMLCanvasElement.prototype, 'width', {

--- a/packages/annotator/src/caretClampViewport.test.ts
+++ b/packages/annotator/src/caretClampViewport.test.ts
@@ -18,6 +18,8 @@ function setup(value: string): Annotator {
 function drawCaretX(a: Annotator, charWidth: number): number[] {
   const calls: number[] = [];
   const ctx = {
+    // 800 CSS px viewport at ratio 1, same as the mocked canvas element.
+    canvas: { width: 800 },
     fillStyle: "",
     globalAlpha: 1,
     globalCompositeOperation: "",

--- a/packages/annotator/src/drawLineProportional.test.ts
+++ b/packages/annotator/src/drawLineProportional.test.ts
@@ -13,6 +13,8 @@ import { DrawingOptions } from "./lib/Annotator";
 const mkCtx = () => {
   const rects: number[][] = [];
   const ctx = {
+    // Wide enough that the caret edge pin never engages in these tests.
+    canvas: { width: 10000 },
     fillRect: (x: number, y: number, w: number, h: number) =>
       rects.push([x, y, w, h]),
     fillStyle: "",

--- a/packages/annotator/src/lib/Annotator.ts
+++ b/packages/annotator/src/lib/Annotator.ts
@@ -27,6 +27,11 @@ import {
   HighlightMode,
   HOVER_DEBOUNCE_MS,
   LINE_HEIGHT,
+  PARAGRAPH_INDENT_DEFAULT,
+  PARAGRAPH_INDENT_EM,
+  PARAGRAPH_MARK_ALPHA,
+  PARAGRAPH_MARK_GAP_RATIO,
+  PARAGRAPH_MARK_GLYPH,
   SELECTION_EDGE_SCROLL_SPEED,
   SELECTION_HANDLE_BAR_WIDTH_PX,
   SELECTION_HANDLE_GRAB_CHAR_FACTOR,
@@ -130,6 +135,8 @@ interface PersistedSettings {
   proportional?: boolean;
   fontFamily?: string;
   fontSize?: number;
+  paragraphIndent?: boolean;
+  showParagraphMarks?: boolean;
 }
 
 // DrawingOptions bundles required sizes shared by multiple components while drawing into canvas
@@ -154,6 +161,12 @@ export interface DrawingOptions {
    * `col * charWidth`. Absent on the monospace path.
    */
   columnToPixelX?: (absLine: number, col: number) => number;
+  /**
+   * Horizontal origin of a visual line in device px — the paragraph indent
+   * (#2076) on a paragraph's first line, 0 elsewhere. Column 0 of that line sits
+   * here, so every rect drawn on it is shifted by this much.
+   */
+  lineXOrigin?: (absLine: number) => number;
 }
 
 export interface Selected {
@@ -321,6 +334,15 @@ export class Annotator {
    */
   private highlightColor: string | undefined = undefined;
 
+  /**
+   * Indent the first visual line of every paragraph (#2076). Left-aligned text
+   * gives no other cue whether a break is a paragraph or a soft wrap.
+   */
+  private paragraphIndent = PARAGRAPH_INDENT_DEFAULT;
+
+  /** Draw a ¶ at the end of each paragraph (Word's "formatting marks"). */
+  private showParagraphMarks = false;
+
   /** Debug FPS counter — smoothed frames-per-second of draw() calls. */
   private showFps = false;
   private lastFrameTime = 0;
@@ -467,6 +489,10 @@ export class Annotator {
 
     this.inputText = inputText;
     this.text = new Text(this.inputText, charsAtLine);
+    // Wrapping depends on the indent, so apply the default before the first
+    // draw; loadSettings below re-wraps again only if the user stored the
+    // opposite choice.
+    this.text.setParagraphIndent(this.paragraphIndentUnits());
 
     this.cursor = new Cursor(this.ratio, 0, 0);
 
@@ -899,7 +925,8 @@ export class Annotator {
       this.charWidth,
       this.viewport.scrollOffsetY,
       this.viewport.lineStart,
-      this.proportionalHitTest()
+      this.proportionalHitTest(),
+      this.drawLineXOrigin()
     );
 
     // Clamp to valid line range
@@ -971,7 +998,8 @@ export class Annotator {
       this.charWidth,
       this.viewport.scrollOffsetY,
       this.viewport.lineStart,
-      this.proportionalHitTest()
+      this.proportionalHitTest(),
+      this.drawLineXOrigin()
     );
 
     tempCursor.yLine = Math.max(0, Math.min(tempCursor.yLine, Math.max(0, this.text.noLines - 1)));
@@ -1170,6 +1198,10 @@ export class Annotator {
     if (this.lines) {
       this.lines.lineHeight = this.lineHeight;
     }
+    // The indent is expressed in ems and in the wrap unit of the active mode, so
+    // both a size change and a monospace/proportional switch re-derive it. Set
+    // before the re-wrap below, which is what consumes it.
+    this.text.paragraphIndent = this.paragraphIndentUnits();
     // Rebuild (or clear) the prefix tables for the new font; recalculates lines.
     this.text.setMeasurer(
       this.proportional ? new CanvasMeasurer(this.ctx, this.font) : undefined,
@@ -1259,13 +1291,54 @@ export class Annotator {
   }
 
   /**
+   * Paragraph indent (#2076) in the unit {@link Text} wraps in: device px under
+   * a proportional measurer, whole character columns on the monospace grid
+   * (rounded, at least one column so the indent never vanishes at small sizes).
+   * 0 while the setting is off.
+   */
+  private paragraphIndentUnits(): number {
+    if (!this.paragraphIndent) {
+      return 0;
+    }
+    const px = PARAGRAPH_INDENT_EM * this.fontSize * this.ratio;
+    if (this.proportional) {
+      return px;
+    }
+    return this.charWidth > 0 ? Math.max(1, Math.round(px / this.charWidth)) : 0;
+  }
+
+  /**
+   * Device-px horizontal origin of a visual line: {@link Text.lineXOrigin} in
+   * wrap units, converted the same way a column is (identity in proportional,
+   * `× charWidth` on the monospace grid).
+   */
+  private lineXOriginPx(absLine: number): number {
+    const origin = this.text.lineXOrigin(absLine);
+    if (origin === 0) {
+      return 0;
+    }
+    return this.proportional ? origin : origin * this.charWidth;
+  }
+
+  /**
+   * The line-origin resolver to put on DrawingOptions / pass to a hit-test, or
+   * undefined while no paragraph is indented (so the callee keeps its plain
+   * x=0 path). Mirror of {@link drawColumnToPixelX}.
+   */
+  private drawLineXOrigin(): ((absLine: number) => number) | undefined {
+    return this.paragraphIndent ? (absLine) => this.lineXOriginPx(absLine) : undefined;
+  }
+
+  /**
    * Device-px x of a selection-handle boundary point (#3108).
    * Proportional uses measured offsets; monospace keeps `col * charWidth`.
    */
   private handleX(pt: IAbsCoordinates): number {
-    return this.proportional
-      ? this.text.columnToPixelX(pt.yLine, pt.xLine)
-      : pt.xLine * this.charWidth;
+    return (
+      (this.proportional
+        ? this.text.columnToPixelX(pt.yLine, pt.xLine)
+        : pt.xLine * this.charWidth) + this.lineXOriginPx(pt.yLine)
+    );
   }
 
   /**
@@ -1342,7 +1415,8 @@ export class Annotator {
       this.charWidth,
       this.viewport.scrollOffsetY,
       this.viewport.lineStart,
-      this.proportionalHitTest()
+      this.proportionalHitTest(),
+      this.drawLineXOrigin()
     );
     this.cursor.yLine = Math.max(
       0,
@@ -1438,7 +1512,8 @@ export class Annotator {
       this.charWidth,
       this.viewport.scrollOffsetY,
       this.viewport.lineStart,
-      this.proportionalHitTest()
+      this.proportionalHitTest(),
+      this.drawLineXOrigin()
     );
     return this.text.clampVisual(tmp.xLine, tmp.yLine);
   }
@@ -1931,7 +2006,8 @@ export class Annotator {
       this.charWidth,
       this.viewport.scrollOffsetY,
       this.viewport.lineStart,
-      this.proportionalHitTest()
+      this.proportionalHitTest(),
+      this.drawLineXOrigin()
     );
     this.cursor.yLine = Math.max(
       0,
@@ -2001,6 +2077,15 @@ export class Annotator {
     items.push({ separator: true });
     items.push(
       {
+        label: `${this.paragraphIndent ? "✓ " : ""}Indent paragraphs`,
+        onClick: () => this.setParagraphIndent(!this.paragraphIndent),
+      },
+      {
+        label: `${this.showParagraphMarks ? "✓ " : ""}Show paragraph marks`,
+        onClick: () => this.setShowParagraphMarks(!this.showParagraphMarks),
+      },
+      { separator: true },
+      {
         label: `${this.showFps ? "✓ " : ""}Show FPS counter`,
         onClick: () => this.setShowFps(!this.showFps),
       },
@@ -2067,6 +2152,26 @@ export class Annotator {
         label: "Highlight color",
         value: this.getHighlightColor(),
         onChange: (hex) => this.setHighlightColor(hex),
+      },
+      {
+        type: "segmented",
+        label: "Indent paragraphs",
+        options: [
+          { label: "On", value: 1 },
+          { label: "Off", value: 0 },
+        ],
+        value: this.paragraphIndent ? 1 : 0,
+        onChange: (v) => this.setParagraphIndent(v === 1),
+      },
+      {
+        type: "segmented",
+        label: "Paragraph marks",
+        options: [
+          { label: "On", value: 1 },
+          { label: "Off", value: 0 },
+        ],
+        value: this.showParagraphMarks ? 1 : 0,
+        onChange: (v) => this.setShowParagraphMarks(v === 1),
       },
       {
         type: "segmented",
@@ -2497,7 +2602,8 @@ export class Annotator {
 
     const columnToPixelX = this.drawColumnToPixelX();
     const toPx = (yLine: number, xLine: number): number =>
-      columnToPixelX ? columnToPixelX(yLine, xLine) : xLine * this.charWidth;
+      (columnToPixelX ? columnToPixelX(yLine, xLine) : xLine * this.charWidth) +
+      this.lineXOriginPx(yLine);
 
     // Only rows the main text renderer paints are eligible; a marker whose
     // endpoint is off-screen is simply skipped (a multi-screen territory shows
@@ -2632,6 +2738,32 @@ export class Annotator {
     return null;
   }
 
+  /** Device-px width of the text on an absolute visual line. */
+  private lineWidthPx(absLine: number): number {
+    return this.proportional
+      ? this.text.pixelWidthOfLine(absLine)
+      : this.text.getLine(absLine).length * this.charWidth;
+  }
+
+  /**
+   * Paragraph mark (#2076) at the end of a paragraph's last line, in the text
+   * colour at reduced opacity so it reads as chrome. `x` is where the line's
+   * text ends; the glyph is pulled back inside the canvas when a full-width line
+   * would push it past the right edge. Assumes the caller has set the text font
+   * and the `middle` baseline, as the main draw loop does.
+   */
+  private drawParagraphMark(x: number, y: number): void {
+    const glyphW = this.ctx.measureText(PARAGRAPH_MARK_GLYPH).width;
+    const markX = Math.min(
+      x + PARAGRAPH_MARK_GAP_RATIO * this.charWidth,
+      this.width - glyphW
+    );
+    const prevAlpha = this.ctx.globalAlpha;
+    this.ctx.globalAlpha = PARAGRAPH_MARK_ALPHA;
+    this.ctx.fillText(PARAGRAPH_MARK_GLYPH, markX, y);
+    this.ctx.globalAlpha = prevAlpha;
+  }
+
   /**
    * draw resets the canvas and redraws the scene anew.
    * First draw lines with text, then allow each component to draw their own logic.
@@ -2667,8 +2799,19 @@ export class Annotator {
     const renderEndCond = this.viewport.lineEnd - this.viewport.lineStart;
     for (let renderLine = 0; renderLine <= renderEndCond; renderLine++) {
       const textLine = textToRender[renderLine];
+      const absLine = this.viewport.lineStart + renderLine;
+      const originPx = this.lineXOriginPx(absLine);
+      const y = (renderLine + 0.5) * this.lineHeight;
       if (textLine) {
-        this.ctx.fillText(textLine, 0, (renderLine + 0.5) * this.lineHeight);
+        this.ctx.fillText(textLine, originPx, y);
+      }
+      if (
+        this.showParagraphMarks &&
+        absLine >= 0 &&
+        absLine < this.text.noLines &&
+        this.text.isParagraphEnd(absLine)
+      ) {
+        this.drawParagraphMark(originPx + this.lineWidthPx(absLine), y);
       }
     }
 
@@ -2701,6 +2844,7 @@ export class Annotator {
         caretVisible:
           this.canvasFocused && this.caretBlink.isVisible() && !caretRepaintsOverHighlights,
         columnToPixelX: this.drawColumnToPixelX(),
+        lineXOrigin: this.drawLineXOrigin(),
       });
     }
 
@@ -2728,6 +2872,7 @@ export class Annotator {
           charWidth: this.charWidth,
           charsAtLine: this.text.charsAtLine,
           columnToPixelX: this.drawColumnToPixelX(),
+          lineXOrigin: this.drawLineXOrigin(),
         });
       }
       this.hoverHighlighter.style.opacity = baseHoverOpacity;
@@ -2866,6 +3011,7 @@ export class Annotator {
           charWidth: this.charWidth,
           charsAtLine: this.text.charsAtLine,
           columnToPixelX: this.drawColumnToPixelX(),
+          lineXOrigin: this.drawLineXOrigin(),
         });
       }
 
@@ -2917,6 +3063,7 @@ export class Annotator {
               charWidth: this.charWidth,
               charsAtLine: this.text.charsAtLine,
               columnToPixelX: this.drawColumnToPixelX(),
+              lineXOrigin: this.drawLineXOrigin(),
               // Keep newline-only lines of the resized span visible (#2885).
               minFillWidth: this.caretWidth * this.ratio,
             });
@@ -2939,6 +3086,7 @@ export class Annotator {
           caretOpacity: this.caretOpacityValue(),
           caretVisible: this.canvasFocused && this.caretBlink.isVisible(),
           columnToPixelX: this.drawColumnToPixelX(),
+          lineXOrigin: this.drawLineXOrigin(),
         });
       }
     }
@@ -3053,10 +3201,23 @@ export class Annotator {
     if (typeof parsed.showFps === "boolean") {
       this.showFps = parsed.showFps;
     }
+    if (typeof parsed.showParagraphMarks === "boolean") {
+      this.showParagraphMarks = parsed.showParagraphMarks;
+    }
+    // Paragraph indent (#2076). It feeds the wrap budget, so it is applied by
+    // the same applyFontChange re-wrap as the font settings below — which runs
+    // whenever this differs from the default, even if no font setting is stored.
+    let fontChanged = false;
+    if (
+      typeof parsed.paragraphIndent === "boolean" &&
+      parsed.paragraphIndent !== this.paragraphIndent
+    ) {
+      this.paragraphIndent = parsed.paragraphIndent;
+      fontChanged = true;
+    }
 
     // Font settings (#2487). Set the fields first, then re-derive font/layout
     // once (no redraw — the constructor draws right after loadSettings).
-    let fontChanged = false;
     if (typeof parsed.fontSize === "number") {
       this.fontSize = Math.max(1, parsed.fontSize);
       fontChanged = true;
@@ -3084,6 +3245,10 @@ export class Annotator {
     this.showFps = false;
     this.lastFrameTime = 0;
     this.fps = 0;
+    // Paragraph rendering back to defaults (#2076); applyFontChange below
+    // re-derives the indent in wrap units and re-wraps.
+    this.paragraphIndent = PARAGRAPH_INDENT_DEFAULT;
+    this.showParagraphMarks = false;
     // Font settings back to defaults (#2487).
     this.proportional = false;
     this.fontSize = DEFAULT_FONT_SIZE;
@@ -3118,6 +3283,8 @@ export class Annotator {
         proportional: this.proportional,
         fontFamily: this.proportionalFontFamily,
         fontSize: this.fontSize,
+        paragraphIndent: this.paragraphIndent,
+        showParagraphMarks: this.showParagraphMarks,
       };
       localStorage.setItem(SETTINGS_STORAGE_KEY, JSON.stringify(data));
     } catch {
@@ -3157,6 +3324,40 @@ export class Annotator {
   setHighlightColor(hex: string): void {
     this.highlightColor = hex;
     this.cursor.style = { ...this.cursor.style, color: hex };
+    this.saveSettings();
+    this.draw();
+  }
+
+  /** Whether the paragraph first-line indent is on (#2076). */
+  getParagraphIndent(): boolean {
+    return this.paragraphIndent;
+  }
+
+  /**
+   * Toggle the paragraph first-line indent. The indent shortens the first line's
+   * wrap budget, so this re-wraps the document; the caret is carried through the
+   * re-wrap by its document offset. Persisted.
+   */
+  setParagraphIndent(on: boolean): void {
+    this.paragraphIndent = on;
+    this.cursor.reconcileOffsetsFromVisual(this.text);
+    this.text.setParagraphIndent(this.paragraphIndentUnits());
+    this.cursor.syncVisualFromOffset(this.text);
+    this.saveSettings();
+    this.draw();
+  }
+
+  /** Whether the end-of-paragraph ¶ marks are shown (#2076). */
+  getShowParagraphMarks(): boolean {
+    return this.showParagraphMarks;
+  }
+
+  /**
+   * Toggle the ¶ mark drawn at the end of each paragraph. Purely painted over
+   * the existing layout — no re-wrap. Persisted.
+   */
+  setShowParagraphMarks(show: boolean): void {
+    this.showParagraphMarks = show;
     this.saveSettings();
     this.draw();
   }

--- a/packages/annotator/src/lib/Annotator.ts
+++ b/packages/annotator/src/lib/Annotator.ts
@@ -135,7 +135,6 @@ interface PersistedSettings {
   proportional?: boolean;
   fontFamily?: string;
   fontSize?: number;
-  paragraphIndent?: boolean;
   showParagraphMarks?: boolean;
 }
 
@@ -489,9 +488,7 @@ export class Annotator {
 
     this.inputText = inputText;
     this.text = new Text(this.inputText, charsAtLine);
-    // Wrapping depends on the indent, so apply the default before the first
-    // draw; loadSettings below re-wraps again only if the user stored the
-    // opposite choice.
+    // Wrapping depends on the indent, so it is in place before the first draw.
     this.text.setParagraphIndent(this.paragraphIndentUnits());
 
     this.cursor = new Cursor(this.ratio, 0, 0);
@@ -2077,10 +2074,6 @@ export class Annotator {
     items.push({ separator: true });
     items.push(
       {
-        label: `${this.paragraphIndent ? "✓ " : ""}Indent paragraphs`,
-        onClick: () => this.setParagraphIndent(!this.paragraphIndent),
-      },
-      {
         label: `${this.showParagraphMarks ? "✓ " : ""}Show paragraph marks`,
         onClick: () => this.setShowParagraphMarks(!this.showParagraphMarks),
       },
@@ -2152,26 +2145,6 @@ export class Annotator {
         label: "Highlight color",
         value: this.getHighlightColor(),
         onChange: (hex) => this.setHighlightColor(hex),
-      },
-      {
-        type: "segmented",
-        label: "Indent paragraphs",
-        options: [
-          { label: "On", value: 1 },
-          { label: "Off", value: 0 },
-        ],
-        value: this.paragraphIndent ? 1 : 0,
-        onChange: (v) => this.setParagraphIndent(v === 1),
-      },
-      {
-        type: "segmented",
-        label: "Paragraph marks",
-        options: [
-          { label: "On", value: 1 },
-          { label: "Off", value: 0 },
-        ],
-        value: this.showParagraphMarks ? 1 : 0,
-        onChange: (v) => this.setShowParagraphMarks(v === 1),
       },
       {
         type: "segmented",
@@ -3204,20 +3177,9 @@ export class Annotator {
     if (typeof parsed.showParagraphMarks === "boolean") {
       this.showParagraphMarks = parsed.showParagraphMarks;
     }
-    // Paragraph indent (#2076). It feeds the wrap budget, so it is applied by
-    // the same applyFontChange re-wrap as the font settings below — which runs
-    // whenever this differs from the default, even if no font setting is stored.
-    let fontChanged = false;
-    if (
-      typeof parsed.paragraphIndent === "boolean" &&
-      parsed.paragraphIndent !== this.paragraphIndent
-    ) {
-      this.paragraphIndent = parsed.paragraphIndent;
-      fontChanged = true;
-    }
-
     // Font settings (#2487). Set the fields first, then re-derive font/layout
     // once (no redraw — the constructor draws right after loadSettings).
+    let fontChanged = false;
     if (typeof parsed.fontSize === "number") {
       this.fontSize = Math.max(1, parsed.fontSize);
       fontChanged = true;
@@ -3245,9 +3207,6 @@ export class Annotator {
     this.showFps = false;
     this.lastFrameTime = 0;
     this.fps = 0;
-    // Paragraph rendering back to defaults (#2076); applyFontChange below
-    // re-derives the indent in wrap units and re-wraps.
-    this.paragraphIndent = PARAGRAPH_INDENT_DEFAULT;
     this.showParagraphMarks = false;
     // Font settings back to defaults (#2487).
     this.proportional = false;
@@ -3283,7 +3242,6 @@ export class Annotator {
         proportional: this.proportional,
         fontFamily: this.proportionalFontFamily,
         fontSize: this.fontSize,
-        paragraphIndent: this.paragraphIndent,
         showParagraphMarks: this.showParagraphMarks,
       };
       localStorage.setItem(SETTINGS_STORAGE_KEY, JSON.stringify(data));
@@ -3336,14 +3294,14 @@ export class Annotator {
   /**
    * Toggle the paragraph first-line indent. The indent shortens the first line's
    * wrap budget, so this re-wraps the document; the caret is carried through the
-   * re-wrap by its document offset. Persisted.
+   * re-wrap by its document offset. Not stored — the indent is on for everyone
+   * (see {@link PARAGRAPH_INDENT_DEFAULT}), and this is the host's way out.
    */
   setParagraphIndent(on: boolean): void {
     this.paragraphIndent = on;
     this.cursor.reconcileOffsetsFromVisual(this.text);
     this.text.setParagraphIndent(this.paragraphIndentUnits());
     this.cursor.syncVisualFromOffset(this.text);
-    this.saveSettings();
     this.draw();
   }
 

--- a/packages/annotator/src/lib/Annotator.ts
+++ b/packages/annotator/src/lib/Annotator.ts
@@ -141,6 +141,7 @@ interface PersistedSettings {
   fontFamily?: string;
   fontSize?: number;
   showParagraphMarks?: boolean;
+  paragraphIndent?: boolean;
 }
 
 // DrawingOptions bundles required sizes shared by multiple components while drawing into canvas
@@ -2152,6 +2153,16 @@ export class Annotator {
         onChange: (px) => this.setFontSize(px),
       },
       {
+        type: "segmented",
+        label: "Paragraph indent",
+        options: [
+          { label: "Off", value: 0 },
+          { label: "On", value: 1 },
+        ],
+        value: this.paragraphIndent ? 1 : 0,
+        onChange: (v) => this.setParagraphIndent(v === 1),
+      },
+      {
         type: "color",
         label: "Highlight color",
         value: this.getHighlightColor(),
@@ -3323,6 +3334,12 @@ export class Annotator {
     // Font settings (#2487). Set the fields first, then re-derive font/layout
     // once (no redraw — the constructor draws right after loadSettings).
     let fontChanged = false;
+    // The indent feeds the wrap the same way the font does, so it shares the
+    // re-derive below rather than carrying its own re-wrap.
+    if (typeof parsed.paragraphIndent === "boolean") {
+      this.paragraphIndent = parsed.paragraphIndent;
+      fontChanged = true;
+    }
     if (typeof parsed.fontSize === "number") {
       this.fontSize = Math.max(1, parsed.fontSize);
       fontChanged = true;
@@ -3351,6 +3368,7 @@ export class Annotator {
     this.lastFrameTime = 0;
     this.fps = 0;
     this.showParagraphMarks = false;
+    this.paragraphIndent = PARAGRAPH_INDENT_DEFAULT;
     // Font settings back to defaults (#2487).
     this.proportional = false;
     this.fontSize = DEFAULT_FONT_SIZE;
@@ -3386,6 +3404,7 @@ export class Annotator {
         fontFamily: this.proportionalFontFamily,
         fontSize: this.fontSize,
         showParagraphMarks: this.showParagraphMarks,
+        paragraphIndent: this.paragraphIndent,
       };
       localStorage.setItem(SETTINGS_STORAGE_KEY, JSON.stringify(data));
     } catch {
@@ -3437,14 +3456,15 @@ export class Annotator {
   /**
    * Toggle the paragraph first-line indent. The indent shortens the first line's
    * wrap budget, so this re-wraps the document; the caret is carried through the
-   * re-wrap by its document offset. Not stored — the indent is on for everyone
-   * (see {@link PARAGRAPH_INDENT_DEFAULT}), and this is the host's way out.
+   * re-wrap by its document offset. Persisted; on by default
+   * (see {@link PARAGRAPH_INDENT_DEFAULT}).
    */
   setParagraphIndent(on: boolean): void {
     this.paragraphIndent = on;
     this.cursor.reconcileOffsetsFromVisual(this.text);
     this.text.setParagraphIndent(this.paragraphIndentUnits());
     this.cursor.syncVisualFromOffset(this.text);
+    this.saveSettings();
     this.draw();
   }
 

--- a/packages/annotator/src/lib/Annotator.ts
+++ b/packages/annotator/src/lib/Annotator.ts
@@ -1,19 +1,5 @@
-import Cursor, { DIRECTION } from "./Cursor";
-import Highlighter, { IAbsCoordinates, CursorStyle } from "./Highlighter";
-import History, { HistorySnapshot } from "./History";
-import { ContextMenu, ContextMenuItem } from "./ContextMenu";
-import { CaretBlink } from "./CaretBlink";
-import { ResizePulse } from "./ResizePulse";
-import { HoverHighlightFade } from "./HoverHighlightFade";
-import { SettingsOverlay, SettingControl } from "./SettingsOverlay";
-import Keys from "./Keys";
-import { Lines } from "./Lines";
-import Scroller from "./Scroller";
-import Text, { Tag, SegmentPosition, CaretAffinity } from "./Text";
 import { drawAnchorMarker } from "./AnchorMarker";
-import { CanvasMeasurer } from "./TextMeasurer";
-import Viewport from "./Viewport";
-import { AsymmetricalAnchor, Warnings, WarningData } from "./warnings";
+import { CaretBlink } from "./CaretBlink";
 import {
   ANCHOR_MARKER_ARM_H_RATIO,
   ANCHOR_MARKER_ARM_W_RATIO,
@@ -22,11 +8,12 @@ import {
   ANCHOR_MARKER_STACK_STEP_PX,
   DEFAULT_FONT,
   DEFAULT_FONT_SIZE,
-  PROPORTIONAL_FONT,
   EditMode,
   HighlightMode,
   HOVER_DEBOUNCE_MS,
+  LIGHT_MENU_COLORS,
   LINE_HEIGHT,
+  MenuColors,
   PARAGRAPH_INDENT_DEFAULT,
   PARAGRAPH_INDENT_EM,
   PARAGRAPH_MARK_ALPHA,
@@ -37,15 +24,28 @@ import {
   PARAGRAPH_MARK_LINE_WIDTH_PX,
   PARAGRAPH_MARK_OVERHANG_RATIO,
   PARAGRAPH_MARK_STEM_GAP_RATIO,
+  PROPORTIONAL_FONT,
   SELECTION_EDGE_SCROLL_SPEED,
   SELECTION_HANDLE_BAR_WIDTH_PX,
   SELECTION_HANDLE_GRAB_CHAR_FACTOR,
   SELECTION_HANDLE_KNOB_RADIUS_PX,
   VIEWPORT_END_BUFFER_ROWS,
   VIEWPORT_START_BUFFER_ROWS,
-  LIGHT_MENU_COLORS,
-  MenuColors,
 } from "./constants";
+import { ContextMenu, ContextMenuItem } from "./ContextMenu";
+import Cursor, { DIRECTION } from "./Cursor";
+import Highlighter, { CursorStyle, IAbsCoordinates } from "./Highlighter";
+import History, { HistorySnapshot } from "./History";
+import { HoverHighlightFade } from "./HoverHighlightFade";
+import Keys from "./Keys";
+import { Lines } from "./Lines";
+import { ResizePulse } from "./ResizePulse";
+import Scroller from "./Scroller";
+import { SettingControl, SettingsOverlay } from "./SettingsOverlay";
+import Text, { SegmentPosition, Tag } from "./Text";
+import { CanvasMeasurer } from "./TextMeasurer";
+import Viewport from "./Viewport";
+import { AsymmetricalAnchor, WarningData, Warnings } from "./warnings";
 
 // Updated regex to properly handle tags with attributes
 // Opening tags: <tagname attr="value"> or <tagname>
@@ -382,6 +382,7 @@ export class Annotator {
     y: number;
     w: number;
     h: number;
+    kind: "start" | "end";
     tag: Tag;
   }[] = [];
 
@@ -1095,9 +1096,7 @@ export class Annotator {
     const scrollTrackLines = this.scrollExtentLineCount() + this.viewport.startBuffer;
     this.scroller?.setRunnerSize((this.viewport.noLines / scrollTrackLines) * 100);
 
-    this.scroller?.setViewportSize(
-      Math.min(100, (this.viewport.noLines / scrollTrackLines) * 100)
-    );
+    this.scroller?.setViewportSize(Math.min(100, (this.viewport.noLines / scrollTrackLines) * 100));
 
     if (this.settingsOverlay.isOpen) {
       this.settingsOverlay.reposition(this.element);
@@ -2695,6 +2694,7 @@ export class Annotator {
           y: box.y - pad,
           w: box.w + 2 * pad,
           h: box.h + 2 * pad,
+          kind: p.kind,
           tag: p.tag,
         });
       }
@@ -2839,17 +2839,21 @@ export class Annotator {
   private drawPendingParagraphMarks(): void {
     for (const mark of this.pendingParagraphMarks) {
       let shiftX = 0;
-      // One marker cleared per pass, so the bound is their number. A mark held
-      // at the right edge cannot move, which ends the search rather than
-      // spinning on a marker it can never clear.
+      // One marker cleared per pass, so the bound is their number.
       for (let pass = 0; pass <= this.anchorMarkerHitboxes.length; pass++) {
-        const { left, top, markW, h } = this.paragraphMarkGeometry(
-          mark.x,
-          mark.y,
-          shiftX
-        );
+        const { left, top, markW, h } = this.paragraphMarkGeometry(mark.x, mark.y, shiftX);
+        // The geometry pins `left` at the right edge, so a mark held there
+        // cannot move — no shift clears a marker it may still overlap.
+        if (left >= this.width - markW) {
+          break;
+        }
+        // Only end markers (┘) push the mark aside. A start marker (┌) opens
+        // toward the text, so the mark reads fine inside its corner, and
+        // dodging it would indent the marks at territory openings while the
+        // plain ones stay at the margin — an uneven column of pilcrows.
         const clash = this.anchorMarkerHitboxes.find(
           (hb) =>
+            hb.kind === "end" &&
             left < hb.x + hb.w &&
             left + markW > hb.x &&
             top < hb.y + hb.h &&
@@ -2858,11 +2862,9 @@ export class Annotator {
         if (!clash) {
           break;
         }
-        const clearOf = clash.x + clash.w;
-        if (clearOf <= left) {
-          break;
-        }
-        shiftX += clearOf - left;
+        // A clash overlaps the mark, so its right edge always lies past `left`
+        // and the shift below is strictly positive.
+        shiftX += clash.x + clash.w - left;
       }
       this.drawParagraphMark(mark.x, mark.y, shiftX);
     }

--- a/packages/annotator/src/lib/Annotator.ts
+++ b/packages/annotator/src/lib/Annotator.ts
@@ -347,6 +347,13 @@ export class Annotator {
   /** Draw a ¶ at the end of each paragraph (Word's "formatting marks"). */
   private showParagraphMarks = false;
 
+  /**
+   * Paragraph marks found while painting the text, drawn once the anchor markers
+   * are down so each can be placed clear of them. Anchor points in the same
+   * scroll-translated space the text pass uses; emptied at the top of each frame.
+   */
+  private pendingParagraphMarks: { x: number; y: number }[] = [];
+
   /** Debug FPS counter — smoothed frames-per-second of draw() calls. */
   private showFps = false;
   private lastFrameTime = 0;
@@ -2724,43 +2731,64 @@ export class Annotator {
   }
 
   /**
-   * Paragraph mark (#2076) at the end of a paragraph's last line, stroked in the
-   * text colour at reduced opacity so it reads as chrome. `x` is where the line's
-   * text ends and `y` its vertical middle; the mark is pulled back inside the
-   * canvas when a full-width line would push it past the right edge.
-   *
-   * The shape is a pilcrow: two stems under a bar that overhangs the trailing
-   * one, with a solid bowl on the leading stem — a half disc, its flat side
-   * lying along that stem. Every measure derives from the line height, so it
-   * scales with the font without depending on it.
-   *
-   * The bowl is filled and the lines stroked, in two passes: one path carrying
-   * both would lay the fill and the stroke over each other, and at this alpha
-   * the overlap reads as a darker rim.
+   * Where a paragraph mark sits and how big each of its parts is, for an anchor
+   * point `x` (the end of the line's text), `y` (the line's vertical middle) and
+   * a rightward `shiftX` used to dodge an anchor marker. The mark is pulled back
+   * inside the canvas when a full-width line would push it past the right edge,
+   * which also caps how far a shift can carry it.
    */
-  private drawParagraphMark(x: number, y: number): void {
+  private paragraphMarkGeometry(x: number, y: number, shiftX: number) {
     const h = PARAGRAPH_MARK_HEIGHT_RATIO * this.lineHeight;
     const bowlR = PARAGRAPH_MARK_BOWL_RATIO * h;
     const stemGap = PARAGRAPH_MARK_STEM_GAP_RATIO * h;
     const overhang = PARAGRAPH_MARK_OVERHANG_RATIO * stemGap;
     const lineWidth = PARAGRAPH_MARK_LINE_WIDTH_PX * this.ratio;
-    // A stroke straddles its line, so the bowl clears the stem and the cap by
-    // half of one to sit against their edges rather than their centres.
+    // A part straddles its line, so the bowl clears the stem and the cap by half
+    // of one to sit against their edges rather than their centres.
     const half = lineWidth / 2;
     const capLead = PARAGRAPH_MARK_CAP_LEAD_PX * this.ratio;
     const markW = bowlR + half + stemGap + overhang;
 
     const left = Math.min(
-      x + PARAGRAPH_MARK_GAP_RATIO * this.charWidth,
+      x + PARAGRAPH_MARK_GAP_RATIO * this.charWidth + shiftX,
       this.width - markW
     );
-    const stemX = left + bowlR + half; // the bowl hangs off this stem's left side
-    const rightX = stemX + stemGap;
     const top = y - h / 2;
-    const bottom = top + h;
+    return {
+      h,
+      bowlR,
+      stemGap,
+      overhang,
+      lineWidth,
+      half,
+      capLead,
+      markW,
+      left,
+      top,
+      stemX: left + bowlR + half, // the bowl hangs off this stem's left side
+      rightX: left + bowlR + half + stemGap,
+      bottom: top + h,
+    };
+  }
+
+  /**
+   * Paragraph mark (#2076) at the end of a paragraph's last line, in the text
+   * colour at reduced opacity so it reads as chrome.
+   *
+   * The shape is a pilcrow: two stems under a bar that overhangs the trailing
+   * one, with a solid bowl on the leading stem — a half disc, its flat side
+   * lying along that stem. Every measure derives from the line height, so it
+   * scales with the font without depending on it.
+   */
+  private drawParagraphMark(x: number, y: number, shiftX: number = 0): void {
+    const { bowlR, overhang, half, capLead, top, stemX, rightX, bottom } =
+      this.paragraphMarkGeometry(x, y, shiftX);
 
     this.ctx.save();
     this.ctx.globalAlpha = PARAGRAPH_MARK_ALPHA;
+    // The highlight passes run before this one and leave their blend mode
+    // behind, so the mark states its own rather than inheriting one.
+    this.ctx.globalCompositeOperation = "source-over";
     this.ctx.fillStyle = this.fontColor;
 
     // One path, one fill. Painting the parts separately lays them over each
@@ -2784,7 +2812,7 @@ export class Annotator {
     rect(stemX - half, top - half, stemX + half, bottom);
     rect(rightX - half, top - half, rightX + half, bottom);
     // The foot is off for now.
-    // rect(stemX - overhang, bottom - lineWidth, rightX + overhang, bottom);
+    // rect(stemX - overhang, bottom - 2 * half, rightX + overhang, bottom);
 
     // The bowl, its flat side on the stem's left edge and its top on the cap's.
     // Canvas angles run with y pointing down, so sweeping forwards from PI/2 to
@@ -2798,6 +2826,46 @@ export class Annotator {
 
     this.ctx.fill();
     this.ctx.restore();
+  }
+
+  /**
+   * Draw the paragraph marks held over from the text pass, each nudged right
+   * until it clears the anchor markers drawn this frame (#2076). A paragraph
+   * ending where a Territory anchor does — an empty paragraph between sections
+   * is the common one, since both marks then sit at the left margin — would
+   * otherwise land the two glyphs on top of each other. The anchor marker
+   * carries a hover target and is the meaningful one, so the mark gives way.
+   */
+  private drawPendingParagraphMarks(): void {
+    for (const mark of this.pendingParagraphMarks) {
+      let shiftX = 0;
+      // One marker cleared per pass, so the bound is their number. A mark held
+      // at the right edge cannot move, which ends the search rather than
+      // spinning on a marker it can never clear.
+      for (let pass = 0; pass <= this.anchorMarkerHitboxes.length; pass++) {
+        const { left, top, markW, h } = this.paragraphMarkGeometry(
+          mark.x,
+          mark.y,
+          shiftX
+        );
+        const clash = this.anchorMarkerHitboxes.find(
+          (hb) =>
+            left < hb.x + hb.w &&
+            left + markW > hb.x &&
+            top < hb.y + hb.h &&
+            top + h > hb.y
+        );
+        if (!clash) {
+          break;
+        }
+        const clearOf = clash.x + clash.w;
+        if (clearOf <= left) {
+          break;
+        }
+        shiftX += clearOf - left;
+      }
+      this.drawParagraphMark(mark.x, mark.y, shiftX);
+    }
   }
 
   /**
@@ -2816,6 +2884,7 @@ export class Annotator {
     // #2887 — clear last frame's marker hover targets; the HIGHLIGHT draw below
     // repopulates them. Cleared unconditionally so RAW/SEMI frames leave none.
     this.anchorMarkerHitboxes = [];
+    this.pendingParagraphMarks = [];
 
     this.syncLineNumbersCanvasToMain();
 
@@ -2847,7 +2916,12 @@ export class Annotator {
         absLine < this.text.noLines &&
         this.text.isParagraphEnd(absLine)
       ) {
-        this.drawParagraphMark(originPx + this.lineWidthPx(absLine), y);
+        // Held over: the marks are placed against the anchor markers, which are
+        // not drawn until later in this frame.
+        this.pendingParagraphMarks.push({
+          x: originPx + this.lineWidthPx(absLine),
+          y,
+        });
       }
     }
 
@@ -3134,6 +3208,10 @@ export class Annotator {
     if (!this.selectionHidden) {
       this.drawSelectionHandles();
     }
+
+    // Last inside the translated context: the anchor markers are down by now, so
+    // each mark can be placed clear of them (#2076).
+    this.drawPendingParagraphMarks();
 
     this.ctx.restore();
 

--- a/packages/annotator/src/lib/Annotator.ts
+++ b/packages/annotator/src/lib/Annotator.ts
@@ -30,8 +30,13 @@ import {
   PARAGRAPH_INDENT_DEFAULT,
   PARAGRAPH_INDENT_EM,
   PARAGRAPH_MARK_ALPHA,
+  PARAGRAPH_MARK_BOWL_RATIO,
+  PARAGRAPH_MARK_CAP_OVERHANG_RATIO,
+  PARAGRAPH_MARK_FOOT_OVERHANG_RATIO,
   PARAGRAPH_MARK_GAP_RATIO,
-  PARAGRAPH_MARK_GLYPH,
+  PARAGRAPH_MARK_HEIGHT_RATIO,
+  PARAGRAPH_MARK_LINE_WIDTH_PX,
+  PARAGRAPH_MARK_STEM_GAP_RATIO,
   SELECTION_EDGE_SCROLL_SPEED,
   SELECTION_HANDLE_BAR_WIDTH_PX,
   SELECTION_HANDLE_GRAB_CHAR_FACTOR,
@@ -2719,22 +2724,57 @@ export class Annotator {
   }
 
   /**
-   * Paragraph mark (#2076) at the end of a paragraph's last line, in the text
-   * colour at reduced opacity so it reads as chrome. `x` is where the line's
-   * text ends; the glyph is pulled back inside the canvas when a full-width line
-   * would push it past the right edge. Assumes the caller has set the text font
-   * and the `middle` baseline, as the main draw loop does.
+   * Paragraph mark (#2076) at the end of a paragraph's last line, stroked in the
+   * text colour at reduced opacity so it reads as chrome. `x` is where the line's
+   * text ends and `y` its vertical middle; the mark is pulled back inside the
+   * canvas when a full-width line would push it past the right edge.
+   *
+   * The shape is a pilcrow: the two stems capped by a bar at the top and
+   * standing on a foot, each running a little past the trailing stem, with a
+   * bowl hung off the leading one — a half circle, its ends meeting that stem
+   * where the bar and the curve part company. Every measure derives from the
+   * line height, so it scales with the font without depending on it.
    */
   private drawParagraphMark(x: number, y: number): void {
-    const glyphW = this.ctx.measureText(PARAGRAPH_MARK_GLYPH).width;
-    const markX = Math.min(
+    const h = PARAGRAPH_MARK_HEIGHT_RATIO * this.lineHeight;
+    const bowlR = PARAGRAPH_MARK_BOWL_RATIO * h;
+    const stemGap = PARAGRAPH_MARK_STEM_GAP_RATIO * h;
+    const footOverhang = PARAGRAPH_MARK_FOOT_OVERHANG_RATIO * stemGap;
+    const capOverhang = PARAGRAPH_MARK_CAP_OVERHANG_RATIO * stemGap;
+    // The foot's left overhang stays within the bowl, so the width is set by
+    // whichever of the two reaches further right.
+    const markW =
+      bowlR + stemGap + Math.max(footOverhang, capOverhang);
+
+    const left = Math.min(
       x + PARAGRAPH_MARK_GAP_RATIO * this.charWidth,
-      this.width - glyphW
+      this.width - markW
     );
-    const prevAlpha = this.ctx.globalAlpha;
+    const stemX = left + bowlR; // the bowl hangs off this stem's left side
+    const rightX = stemX + stemGap;
+    const top = y - h / 2;
+    const bottom = top + h;
+
+    this.ctx.save();
     this.ctx.globalAlpha = PARAGRAPH_MARK_ALPHA;
-    this.ctx.fillText(PARAGRAPH_MARK_GLYPH, markX, y);
-    this.ctx.globalAlpha = prevAlpha;
+    this.ctx.strokeStyle = this.fontColor;
+    this.ctx.lineWidth = PARAGRAPH_MARK_LINE_WIDTH_PX * this.ratio;
+    this.ctx.lineCap = "round";
+    this.ctx.beginPath();
+    this.ctx.moveTo(stemX, top);
+    this.ctx.lineTo(rightX + capOverhang, top);
+    this.ctx.moveTo(stemX, top);
+    this.ctx.lineTo(stemX, bottom);
+    this.ctx.moveTo(rightX, top);
+    this.ctx.lineTo(rightX, bottom);
+    this.ctx.moveTo(stemX - footOverhang, bottom);
+    this.ctx.lineTo(rightX + footOverhang, bottom);
+    // The bowl. Canvas angles run with y pointing down, so sweeping forwards
+    // from PI/2 to -PI/2 passes through PI — bulging left, away from the stems.
+    this.ctx.moveTo(stemX, top + 2 * bowlR);
+    this.ctx.arc(stemX, top + bowlR, bowlR, Math.PI / 2, -Math.PI / 2, false);
+    this.ctx.stroke();
+    this.ctx.restore();
   }
 
   /**

--- a/packages/annotator/src/lib/Annotator.ts
+++ b/packages/annotator/src/lib/Annotator.ts
@@ -31,11 +31,11 @@ import {
   PARAGRAPH_INDENT_EM,
   PARAGRAPH_MARK_ALPHA,
   PARAGRAPH_MARK_BOWL_RATIO,
-  PARAGRAPH_MARK_CAP_OVERHANG_RATIO,
-  PARAGRAPH_MARK_FOOT_OVERHANG_RATIO,
+  PARAGRAPH_MARK_CAP_LEAD_PX,
   PARAGRAPH_MARK_GAP_RATIO,
   PARAGRAPH_MARK_HEIGHT_RATIO,
   PARAGRAPH_MARK_LINE_WIDTH_PX,
+  PARAGRAPH_MARK_OVERHANG_RATIO,
   PARAGRAPH_MARK_STEM_GAP_RATIO,
   SELECTION_EDGE_SCROLL_SPEED,
   SELECTION_HANDLE_BAR_WIDTH_PX,
@@ -2729,51 +2729,74 @@ export class Annotator {
    * text ends and `y` its vertical middle; the mark is pulled back inside the
    * canvas when a full-width line would push it past the right edge.
    *
-   * The shape is a pilcrow: the two stems capped by a bar at the top and
-   * standing on a foot, each running a little past the trailing stem, with a
-   * bowl hung off the leading one — a half circle, its ends meeting that stem
-   * where the bar and the curve part company. Every measure derives from the
-   * line height, so it scales with the font without depending on it.
+   * The shape is a pilcrow: two stems under a bar that overhangs the trailing
+   * one, with a solid bowl on the leading stem — a half disc, its flat side
+   * lying along that stem. Every measure derives from the line height, so it
+   * scales with the font without depending on it.
+   *
+   * The bowl is filled and the lines stroked, in two passes: one path carrying
+   * both would lay the fill and the stroke over each other, and at this alpha
+   * the overlap reads as a darker rim.
    */
   private drawParagraphMark(x: number, y: number): void {
     const h = PARAGRAPH_MARK_HEIGHT_RATIO * this.lineHeight;
     const bowlR = PARAGRAPH_MARK_BOWL_RATIO * h;
     const stemGap = PARAGRAPH_MARK_STEM_GAP_RATIO * h;
-    const footOverhang = PARAGRAPH_MARK_FOOT_OVERHANG_RATIO * stemGap;
-    const capOverhang = PARAGRAPH_MARK_CAP_OVERHANG_RATIO * stemGap;
-    // The foot's left overhang stays within the bowl, so the width is set by
-    // whichever of the two reaches further right.
-    const markW =
-      bowlR + stemGap + Math.max(footOverhang, capOverhang);
+    const overhang = PARAGRAPH_MARK_OVERHANG_RATIO * stemGap;
+    const lineWidth = PARAGRAPH_MARK_LINE_WIDTH_PX * this.ratio;
+    // A stroke straddles its line, so the bowl clears the stem and the cap by
+    // half of one to sit against their edges rather than their centres.
+    const half = lineWidth / 2;
+    const capLead = PARAGRAPH_MARK_CAP_LEAD_PX * this.ratio;
+    const markW = bowlR + half + stemGap + overhang;
 
     const left = Math.min(
       x + PARAGRAPH_MARK_GAP_RATIO * this.charWidth,
       this.width - markW
     );
-    const stemX = left + bowlR; // the bowl hangs off this stem's left side
+    const stemX = left + bowlR + half; // the bowl hangs off this stem's left side
     const rightX = stemX + stemGap;
     const top = y - h / 2;
     const bottom = top + h;
 
     this.ctx.save();
     this.ctx.globalAlpha = PARAGRAPH_MARK_ALPHA;
-    this.ctx.strokeStyle = this.fontColor;
-    this.ctx.lineWidth = PARAGRAPH_MARK_LINE_WIDTH_PX * this.ratio;
-    this.ctx.lineCap = "round";
+    this.ctx.fillStyle = this.fontColor;
+
+    // One path, one fill. Painting the parts separately lays them over each
+    // other wherever they meet, and two passes at this alpha compound into a
+    // dark spot at every junction. Filling the union paints each pixel once, so
+    // the parts may overlap freely — which is what lets the cap reach out over
+    // the bowl and close the notch its curve leaves.
+    //
+    // Under the nonzero fill rule the subpaths must wind the same way or an
+    // overlap cancels to a hole, so every one of them runs clockwise on screen.
+    const rect = (x0: number, y0: number, x1: number, y1: number) => {
+      this.ctx.moveTo(x0, y0);
+      this.ctx.lineTo(x1, y0);
+      this.ctx.lineTo(x1, y1);
+      this.ctx.lineTo(x0, y1);
+      this.ctx.closePath();
+    };
+
     this.ctx.beginPath();
-    this.ctx.moveTo(stemX, top);
-    this.ctx.lineTo(rightX + capOverhang, top);
-    this.ctx.moveTo(stemX, top);
-    this.ctx.lineTo(stemX, bottom);
-    this.ctx.moveTo(rightX, top);
-    this.ctx.lineTo(rightX, bottom);
-    this.ctx.moveTo(stemX - footOverhang, bottom);
-    this.ctx.lineTo(rightX + footOverhang, bottom);
-    // The bowl. Canvas angles run with y pointing down, so sweeping forwards
-    // from PI/2 to -PI/2 passes through PI — bulging left, away from the stems.
-    this.ctx.moveTo(stemX, top + 2 * bowlR);
-    this.ctx.arc(stemX, top + bowlR, bowlR, Math.PI / 2, -Math.PI / 2, false);
-    this.ctx.stroke();
+    rect(stemX - capLead, top - half, rightX + overhang, top + half);
+    rect(stemX - half, top - half, stemX + half, bottom);
+    rect(rightX - half, top - half, rightX + half, bottom);
+    // The foot is off for now.
+    // rect(stemX - overhang, bottom - lineWidth, rightX + overhang, bottom);
+
+    // The bowl, its flat side on the stem's left edge and its top on the cap's.
+    // Canvas angles run with y pointing down, so sweeping forwards from PI/2 to
+    // -PI/2 passes through PI — bulging left, away from the stems, and winding
+    // with the rectangles; the close then runs back up the flat side.
+    const bowlCx = stemX - half;
+    const bowlCy = top - half + bowlR;
+    this.ctx.moveTo(bowlCx, bowlCy + bowlR);
+    this.ctx.arc(bowlCx, bowlCy, bowlR, Math.PI / 2, -Math.PI / 2, false);
+    this.ctx.closePath();
+
+    this.ctx.fill();
     this.ctx.restore();
   }
 

--- a/packages/annotator/src/lib/Cursor.ts
+++ b/packages/annotator/src/lib/Cursor.ts
@@ -346,7 +346,8 @@ export default class Cursor
     charWidth: number,
     scrollOffsetY: number = 0,
     viewportLineStart: number = 0,
-    pixelXToColumn?: (absLine: number, deviceX: number) => number
+    pixelXToColumn?: (absLine: number, deviceX: number) => number,
+    lineXOrigin?: (absLine: number) => number
   ) {
     this.setPositionFromCanvasOffsets(
       evt.offsetX,
@@ -355,7 +356,8 @@ export default class Cursor
       charWidth,
       scrollOffsetY,
       viewportLineStart,
-      pixelXToColumn
+      pixelXToColumn,
+      lineXOrigin
     );
   }
 
@@ -366,6 +368,10 @@ export default class Cursor
    * resolved from the prefix table of the clicked line via measured widths, so
    * `yLine` is computed first and `offsetX` is scaled CSS→device px (× ratio) to
    * match the device-px prefix table. Without it, the legacy `xToCharI` is used.
+   *
+   * `lineXOrigin` gives the line's horizontal origin in device px (the paragraph
+   * indent, #2076); column 0 sits there rather than at x=0, so the pointer is
+   * un-shifted by it before a column is resolved.
    */
   setPositionFromCanvasOffsets(
     offsetX: number,
@@ -374,16 +380,19 @@ export default class Cursor
     charWidth: number,
     scrollOffsetY: number = 0,
     viewportLineStart: number = 0,
-    pixelXToColumn?: (absLine: number, deviceX: number) => number
+    pixelXToColumn?: (absLine: number, deviceX: number) => number,
+    lineXOrigin?: (absLine: number) => number
   ) {
     const relY = Math.max(
       0,
       Math.floor((offsetY * this.ratio + scrollOffsetY) / lineHeight)
     );
     this.yLine = viewportLineStart + relY;
+    const originPx = lineXOrigin ? lineXOrigin(this.yLine) : 0;
+    const deviceX = Math.max(0, offsetX * this.ratio - originPx);
     this.xLine = pixelXToColumn
-      ? pixelXToColumn(this.yLine, Math.max(offsetX, 0) * this.ratio)
-      : this.xToCharI(offsetX, charWidth);
+      ? pixelXToColumn(this.yLine, deviceX)
+      : this.xToCharI(deviceX / this.ratio, charWidth);
     this.goalColumn = null;
   }
 

--- a/packages/annotator/src/lib/Highlighter.ts
+++ b/packages/annotator/src/lib/Highlighter.ts
@@ -114,8 +114,14 @@ export default class Highlighter {
       columnToPixelX && absLine !== undefined
         ? (col: number) => columnToPixelX(absLine, col)
         : (col: number) => col * charWidth;
-    const xStartPx = toPx(xStart);
-    const width = toPx(xEnd) - xStartPx;
+    // Column 0 of an indented paragraph line sits at the indent, not at x=0
+    // (#2076). A shift, so the span's width is unaffected.
+    const originPx =
+      options.lineXOrigin && absLine !== undefined
+        ? options.lineXOrigin(absLine)
+        : 0;
+    const xStartPx = toPx(xStart) + originPx;
+    const width = toPx(xEnd) - toPx(xStart);
     // const height = this.hlMode === HighlightMode.UNDERLINE ? 3 : lineHeight;
 
     const isNarrowHighlight =

--- a/packages/annotator/src/lib/Highlighter.ts
+++ b/packages/annotator/src/lib/Highlighter.ts
@@ -169,7 +169,16 @@ export default class Highlighter {
         ctx.globalCompositeOperation = "color";
       }
       // width === 0 means a collapsed caret; honor the configured caret width.
-      ctx.fillRect(xStartPx, y, width || options.caretWidth || 1, height);
+      if (width === 0) {
+        // A caret parked in a line's trailing wrap margin — pushed further by
+        // the paragraph indent (#2076) — can land past the canvas edge; pin it
+        // to the edge so it stays visible (mirrors drawParagraphMark).
+        const caretW = options.caretWidth || 1;
+        const caretX = Math.min(xStartPx, ctx.canvas.width - caretW);
+        ctx.fillRect(caretX, y, caretW, height);
+      } else {
+        ctx.fillRect(xStartPx, y, width, height);
+      }
     }
   }
 

--- a/packages/annotator/src/lib/Text.ts
+++ b/packages/annotator/src/lib/Text.ts
@@ -470,6 +470,36 @@ class Text {
   }
 
   /**
+   * Index of the segment holding absolute visual line `absLine`, or -1 when the
+   * line is outside `[0, noLines)`. Binary search: {@link calculateLines} lays
+   * segments out contiguously and ordered by `lineStart`, and these lookups run
+   * per visible line per frame, where a linear scan of a many-thousand-paragraph
+   * document is measurable.
+   */
+  private segmentIndexForLine(absLine: number): number {
+    let lo = 0;
+    let hi = this.segments.length - 1;
+    while (lo <= hi) {
+      const mid = (lo + hi) >> 1;
+      const s = this.segments[mid];
+      if (s.lineEndExclusive <= absLine) {
+        lo = mid + 1;
+      } else if (s.lineStart > absLine) {
+        hi = mid - 1;
+      } else {
+        return mid;
+      }
+    }
+    return -1;
+  }
+
+  /** The segment holding absolute visual line `absLine`, or undefined. */
+  private segmentForLine(absLine: number): Segment | undefined {
+    const i = this.segmentIndexForLine(absLine);
+    return i === -1 ? undefined : this.segments[i];
+  }
+
+  /**
    * Horizontal origin of an absolute visual line, in wrap-budget units: the
    * paragraph indent on a paragraph's first line, 0 on its soft-wrapped
    * continuations. Everything drawn on the line — the text, the caret, selection
@@ -481,9 +511,7 @@ class Text {
     if (!this.paragraphIndent) {
       return 0;
     }
-    const segment = this.segments.find(
-      (s) => s.lineStart <= absLine && s.lineEndExclusive > absLine
-    );
+    const segment = this.segmentForLine(absLine);
     return segment && absLine === segment.lineStart ? segment.indent : 0;
   }
 
@@ -493,9 +521,7 @@ class Text {
    * document's final paragraph ends there even without a trailing newline.
    */
   isParagraphEnd(absLine: number): boolean {
-    const segment = this.segments.find(
-      (s) => s.lineStart <= absLine && s.lineEndExclusive > absLine
-    );
+    const segment = this.segmentForLine(absLine);
     return !!segment && absLine === segment.lineEndExclusive - 1;
   }
 
@@ -516,9 +542,7 @@ class Text {
    */
   private prefixForLine(absLine: number): number[] | undefined {
     const clamped = Math.max(0, Math.min(absLine, Math.max(0, this.noLines - 1)));
-    const segment = this.segments.find(
-      (s) => s.lineStart <= clamped && s.lineEndExclusive > clamped
-    );
+    const segment = this.segmentForLine(clamped);
     return segment?.linePrefixes[clamped - segment.lineStart];
   }
 
@@ -566,16 +590,13 @@ class Text {
    */
   getLine(lineIndex: number): string {
     // Find the segment that contains the line
-    const segmentIndex = this.segments.findIndex(
-      (s) => s.lineStart <= lineIndex && s.lineEndExclusive > lineIndex
-    );
+    const segment = this.segmentForLine(lineIndex);
 
-    if (segmentIndex === -1) {
+    if (!segment) {
       return "";
     }
 
     // Calculate the relative line index within the segment
-    const segment = this.segments[segmentIndex];
     const relativeLineIndex = lineIndex - segment.lineStart;
 
     // Return the line from the segment
@@ -1361,9 +1382,7 @@ class Text {
       }
     }
 
-    const segmentIndex = this.segments.findLastIndex(
-      (s) => s.lineStart <= absLineIndex && s.lineEndExclusive > absLineIndex
-    );
+    const segmentIndex = this.segmentIndexForLine(absLineIndex);
 
     if (segmentIndex === -1) {
       return null;

--- a/packages/annotator/src/lib/Text.ts
+++ b/packages/annotator/src/lib/Text.ts
@@ -1,6 +1,6 @@
 import Viewport from "./Viewport";
 import { IAbsCoordinates, IRelativeCoordinates } from "./Highlighter";
-import { EditMode } from "./constants";
+import { EditMode, PARAGRAPH_INDENT_MAX_RATIO } from "./constants";
 import {
   closingTagRegex,
   createOpeningTagRegex,
@@ -356,6 +356,15 @@ class Text {
    * when a {@link measurer} is active. Undefined means "no width limit".
    */
   maxPixelWidth?: number;
+  /**
+   * First-line indent of a paragraph (#2076), in the same unit as the wrap
+   * budget: device px while a {@link measurer} is active, character columns on
+   * the monospace grid. 0 disables the indent. The caller converts to that unit
+   * (see `Annotator.paragraphIndentUnits`), which keeps this one number valid
+   * both for shortening the first line's wrap budget and — via
+   * {@link lineXOrigin} — for placing everything drawn on that line.
+   */
+  paragraphIndent: number = 0;
 
   /**
    * Creates a new Text instance from raw text content.
@@ -397,6 +406,85 @@ class Text {
       this.maxPixelWidth = maxPixelWidth;
     }
     this.calculateLines();
+  }
+
+  /**
+   * Set the paragraph first-line indent (#2076) in wrap-budget units and
+   * re-wrap — the indent shortens that line, so the break positions move with it.
+   */
+  setParagraphIndent(indent: number) {
+    this.paragraphIndent = indent;
+    this.calculateLines();
+  }
+
+  /**
+   * Display text of a segment: the text {@link calculateLines} wraps and
+   * {@link getLine} returns — raw in RAW mode, tag-free in HIGHLIGHT/SEMI.
+   */
+  private displayTextOf(segment: Segment): string {
+    return this.mode === EditMode.RAW ? segment.raw : segment.parsed;
+  }
+
+  /**
+   * Indent applied to a paragraph's first line. Two paragraphs get none:
+   * - the document's first, which has nothing above it to be confused with (the
+   *   same reason typesetting leaves an opening paragraph flush);
+   * - one whose text already begins with whitespace, since some documents were
+   *   written with the indent typed in as spaces and would otherwise double it.
+   */
+  private indentForSegment(segmentIndex: number, displayText: string): number {
+    if (!this.paragraphIndent || segmentIndex === 0 || /^\s/.test(displayText)) {
+      return 0;
+    }
+    return Math.min(
+      this.paragraphIndent,
+      Math.floor(this.wrapBudget() * PARAGRAPH_INDENT_MAX_RATIO)
+    );
+  }
+
+  /**
+   * Full width available to a visual line, in the unit the active mode wraps in
+   * — device px under a {@link measurer}, character columns otherwise. Mirrors
+   * the `maxWidth` {@link calculateLines} wraps against.
+   */
+  private wrapBudget(): number {
+    return this.measurer
+      ? Math.max(1, this.maxPixelWidth ?? Infinity)
+      : Math.max(1, this.charsAtLine);
+  }
+
+  /**
+   * Horizontal origin of an absolute visual line, in wrap-budget units: the
+   * paragraph indent on a paragraph's first line, 0 on its soft-wrapped
+   * continuations. Everything drawn on the line — the text, the caret, selection
+   * and anchor rects — is shifted by it, and mouse x is un-shifted by it.
+   */
+  lineXOrigin(absLine: number): number {
+    if (!this.paragraphIndent) {
+      return 0;
+    }
+    const segment = this.segments.find(
+      (s) => s.lineStart <= absLine && s.lineEndExclusive > absLine
+    );
+    if (!segment || absLine !== segment.lineStart) {
+      return 0;
+    }
+    return this.indentForSegment(
+      segment.segmentIndex,
+      this.displayTextOf(segment)
+    );
+  }
+
+  /**
+   * Does `absLine` hold the end of a paragraph, i.e. is it the last visual line
+   * of its segment? True for the last line of the document as well — the
+   * document's final paragraph ends there even without a trailing newline.
+   */
+  isParagraphEnd(absLine: number): boolean {
+    const segment = this.segments.find(
+      (s) => s.lineStart <= absLine && s.lineEndExclusive > absLine
+    );
+    return !!segment && absLine === segment.lineEndExclusive - 1;
   }
 
   /**
@@ -643,6 +731,13 @@ class Text {
           cells.push({ text: t.text, space: t.space, parts: [t] });
         }
       }
+      // The paragraph's first visual line starts at the indent, so it has that
+      // much less room; the wrapped continuations get the full width. Read as a
+      // function of how many lines are already pushed so it follows pushLine.
+      const indent = this.indentForSegment(segmentIndex, text);
+      const lineBudget = () =>
+        maxWidth - (segment.lines.length === 0 ? indent : 0);
+
       let currentLine: string[] = [];
       let currentLineLength = 0;
       const pushLine = () => {
@@ -658,7 +753,7 @@ class Text {
       for (let ci = 0; ci < cells.length; ci++) {
         const cell = cells[ci];
 
-        if (currentLineLength + widthOf(cell.text) <= maxWidth) {
+        if (currentLineLength + widthOf(cell.text) <= lineBudget()) {
           appendStr(cell.text);
           continue;
         }
@@ -673,7 +768,10 @@ class Text {
           continue;
         }
 
-        if (widthOf(cell.text) <= maxWidth) {
+        // Budget of the line this unit would land on: a push leaves line 0
+        // behind, so the fresh line is a full-width continuation.
+        const targetBudget = currentLineLength > 0 ? maxWidth : lineBudget();
+        if (widthOf(cell.text) <= targetBudget) {
           // Move the whole unit down to a fresh line.
           if (currentLineLength > 0) pushLine();
           appendStr(cell.text);
@@ -687,16 +785,16 @@ class Text {
           if (part.atomic && widthOf(part.text) <= maxWidth) {
             if (
               currentLineLength > 0 &&
-              currentLineLength + widthOf(part.text) > maxWidth
+              currentLineLength + widthOf(part.text) > lineBudget()
             )
               pushLine();
             appendStr(part.text);
           } else {
             let s = part.text;
-            while (currentLineLength + widthOf(s) > maxWidth) {
+            while (currentLineLength + widthOf(s) > lineBudget()) {
               // Chars that still fit the remaining budget; force at least one on
               // an empty line so an over-wide glyph can't loop forever (#narrow).
-              const fit = charsThatFit(s, maxWidth - currentLineLength);
+              const fit = charsThatFit(s, lineBudget() - currentLineLength);
               const take = currentLineLength === 0 ? Math.max(1, fit) : fit;
               if (take > 0) {
                 appendStr(s.slice(0, take));

--- a/packages/annotator/src/lib/Text.ts
+++ b/packages/annotator/src/lib/Text.ts
@@ -418,22 +418,27 @@ class Text {
   }
 
   /**
-   * Display text of a segment: the text {@link calculateLines} wraps and
-   * {@link getLine} returns — raw in RAW mode, tag-free in HIGHLIGHT/SEMI.
-   */
-  private displayTextOf(segment: Segment): string {
-    return this.mode === EditMode.RAW ? segment.raw : segment.parsed;
-  }
-
-  /**
-   * Indent applied to a paragraph's first line. Two paragraphs get none:
+   * Indent applied to a paragraph's first line. Three paragraphs get none:
    * - the document's first, which has nothing above it to be confused with (the
    *   same reason typesetting leaves an opening paragraph flush);
    * - one whose text already begins with whitespace, since some documents were
-   *   written with the indent typed in as spaces and would otherwise double it.
+   *   written with the indent typed in as spaces and would otherwise double it;
+   * - one with no text at all, which has no start to mark. A blank line, or a
+   *   line holding only an anchor tag, would otherwise show its caret, selection
+   *   sliver and anchor markers nudged off the text column.
+   *
+   * The decision reads the segment's PARSED text in every mode, so a paragraph
+   * sits at the same x whichever mode the document is viewed in: markup is
+   * structure, not the prose the indent marks the start of.
    */
-  private indentForSegment(segmentIndex: number, displayText: string): number {
-    if (!this.paragraphIndent || segmentIndex === 0 || /^\s/.test(displayText)) {
+  private indentForSegment(segment: Segment): number {
+    const text = segment.parsed;
+    if (
+      !this.paragraphIndent ||
+      segment.segmentIndex === 0 ||
+      text === "" ||
+      /^\s/.test(text)
+    ) {
       return 0;
     }
     return Math.min(
@@ -469,10 +474,7 @@ class Text {
     if (!segment || absLine !== segment.lineStart) {
       return 0;
     }
-    return this.indentForSegment(
-      segment.segmentIndex,
-      this.displayTextOf(segment)
-    );
+    return this.indentForSegment(segment);
   }
 
   /**
@@ -734,7 +736,7 @@ class Text {
       // The paragraph's first visual line starts at the indent, so it has that
       // much less room; the wrapped continuations get the full width. Read as a
       // function of how many lines are already pushed so it follows pushLine.
-      const indent = this.indentForSegment(segmentIndex, text);
+      const indent = this.indentForSegment(segment);
       const lineBudget = () =>
         maxWidth - (segment.lines.length === 0 ? indent : 0);
 
@@ -782,7 +784,14 @@ class Text {
         // fits on a line, but a tag longer than the line is still broken — with
         // no horizontal scroll, an unsplit over-long tag would run off the edge.
         for (const part of cell.parts) {
-          if (part.atomic && widthOf(part.text) <= maxWidth) {
+          // "Fits on a line" is judged against the line the part would land on:
+          // the indented first line of a paragraph holds less than the
+          // full-width continuation a pushLine would open. A tag measured
+          // against the full width and then appended to the indented line would
+          // run past the right edge before any break — visible in XML mode,
+          // where a tag carrying a UUID is long enough to sit in that gap.
+          const partBudget = currentLineLength > 0 ? maxWidth : lineBudget();
+          if (part.atomic && widthOf(part.text) <= partBudget) {
             if (
               currentLineLength > 0 &&
               currentLineLength + widthOf(part.text) > lineBudget()

--- a/packages/annotator/src/lib/Text.ts
+++ b/packages/annotator/src/lib/Text.ts
@@ -234,6 +234,12 @@ export class Segment {
    * Empty unless a proportional measurer is active (monospace path is untouched).
    */
   linePrefixes: number[][] = [];
+  /**
+   * First-line indent (#2076) in wrap-budget units, as applied by the last
+   * wrap. Kept here so draw-time reads see the exact value (including the
+   * width cap) the segment's lines were wrapped against.
+   */
+  indent: number = 0;
   segmentIndex: number = -1; // index of this segment in the text
 
   /**
@@ -421,11 +427,13 @@ class Text {
    * Indent applied to a paragraph's first line. Three paragraphs get none:
    * - the document's first, which has nothing above it to be confused with (the
    *   same reason typesetting leaves an opening paragraph flush);
-   * - one whose text already begins with whitespace, since some documents were
-   *   written with the indent typed in as spaces and would otherwise double it;
-   * - one with no text at all, which has no start to mark. A blank line, or a
-   *   line holding only an anchor tag, would otherwise show its caret, selection
-   *   sliver and anchor markers nudged off the text column.
+   * - one whose text already begins with hand-typed indentation — a tab, or a
+   *   run of two or more whitespace chars — since some documents were written
+   *   with the indent typed in and would otherwise double it. A single leading
+   *   space is incidental typing, not layout, and still gets the indent;
+   * - one with no text beyond whitespace, which has no start to mark. A blank
+   *   line, or a line holding only an anchor tag, would otherwise show its
+   *   caret, selection sliver and anchor markers nudged off the text column.
    *
    * The decision reads the segment's PARSED text in every mode, so a paragraph
    * sits at the same x whichever mode the document is viewed in: markup is
@@ -433,11 +441,13 @@ class Text {
    */
   private indentForSegment(segment: Segment): number {
     const text = segment.parsed;
+    const leadingWs = /^\s+/.exec(text)?.[0];
+    const handIndented = leadingWs !== undefined && leadingWs !== " ";
     if (
       !this.paragraphIndent ||
       segment.segmentIndex === 0 ||
-      text === "" ||
-      /^\s/.test(text)
+      !text.trim() ||
+      handIndented
     ) {
       return 0;
     }
@@ -449,8 +459,9 @@ class Text {
 
   /**
    * Full width available to a visual line, in the unit the active mode wraps in
-   * — device px under a {@link measurer}, character columns otherwise. Mirrors
-   * the `maxWidth` {@link calculateLines} wraps against.
+   * — device px under a {@link measurer}, character columns otherwise. The
+   * `maxWidth` {@link calculateLines} wraps against, and the base the paragraph
+   * indent cap is taken from.
    */
   private wrapBudget(): number {
     return this.measurer
@@ -463,6 +474,8 @@ class Text {
    * paragraph indent on a paragraph's first line, 0 on its soft-wrapped
    * continuations. Everything drawn on the line — the text, the caret, selection
    * and anchor rects — is shifted by it, and mouse x is un-shifted by it.
+   * Reads the indent stored on the segment by {@link calculateLines}, so it is
+   * always the value the lines were actually wrapped against.
    */
   lineXOrigin(absLine: number): number {
     if (!this.paragraphIndent) {
@@ -471,10 +484,7 @@ class Text {
     const segment = this.segments.find(
       (s) => s.lineStart <= absLine && s.lineEndExclusive > absLine
     );
-    if (!segment || absLine !== segment.lineStart) {
-      return 0;
-    }
-    return this.indentForSegment(segment);
+    return segment && absLine === segment.lineStart ? segment.indent : 0;
   }
 
   /**
@@ -646,9 +656,7 @@ class Text {
     const widthOf = measurer
       ? (s: string) => additiveWidth(s, measurer)
       : (s: string) => s.length;
-    const maxWidth = measurer
-      ? Math.max(1, this.maxPixelWidth ?? Infinity)
-      : Math.max(1, this.charsAtLine);
+    const maxWidth = this.wrapBudget();
     // Largest code-unit count of `s` whose measured width fits `budget`.
     // Monospace reduces to min(len, budget) — i.e. the legacy `maxLen - used`.
     // Iterates code units (s[n]) like the prefix table; grapheme-aware splitting
@@ -736,12 +744,18 @@ class Text {
       // The paragraph's first visual line starts at the indent, so it has that
       // much less room; the wrapped continuations get the full width. Read as a
       // function of how many lines are already pushed so it follows pushLine.
-      const indent = this.indentForSegment(segment);
+      // Stored on the segment so draw-time lineXOrigin reads the same value.
+      const indent = (segment.indent = this.indentForSegment(segment));
       const lineBudget = () =>
         maxWidth - (segment.lines.length === 0 ? indent : 0);
 
       let currentLine: string[] = [];
       let currentLineLength = 0;
+      // Budget of the line a unit lands on after an optional pushLine: a push
+      // leaves the indented first line behind, so anything moved down gets the
+      // full width.
+      const budgetAfterPush = () =>
+        currentLineLength > 0 ? maxWidth : lineBudget();
       const pushLine = () => {
         segment.lines.push(currentLine.join(""));
         currentLine = [];
@@ -770,10 +784,7 @@ class Text {
           continue;
         }
 
-        // Budget of the line this unit would land on: a push leaves line 0
-        // behind, so the fresh line is a full-width continuation.
-        const targetBudget = currentLineLength > 0 ? maxWidth : lineBudget();
-        if (widthOf(cell.text) <= targetBudget) {
+        if (widthOf(cell.text) <= budgetAfterPush()) {
           // Move the whole unit down to a fresh line.
           if (currentLineLength > 0) pushLine();
           appendStr(cell.text);
@@ -790,8 +801,7 @@ class Text {
           // against the full width and then appended to the indented line would
           // run past the right edge before any break — visible in XML mode,
           // where a tag carrying a UUID is long enough to sit in that gap.
-          const partBudget = currentLineLength > 0 ? maxWidth : lineBudget();
-          if (part.atomic && widthOf(part.text) <= partBudget) {
+          if (part.atomic && widthOf(part.text) <= budgetAfterPush()) {
             if (
               currentLineLength > 0 &&
               currentLineLength + widthOf(part.text) > lineBudget()

--- a/packages/annotator/src/lib/constants.ts
+++ b/packages/annotator/src/lib/constants.ts
@@ -105,9 +105,9 @@ export const PARAGRAPH_INDENT_EM = 2;
 export const PARAGRAPH_INDENT_MAX_RATIO = 0.25;
 /**
  * Whether paragraphs are indented. On: the indent answers a question the reader
- * would otherwise have no way to answer, so it is not a matter of taste and
- * carries no user-facing toggle — `Annotator.setParagraphIndent` is there for a
- * host that needs it off.
+ * would otherwise have no way to answer — which line breaks are paragraph
+ * boundaries — so it starts enabled; the settings overlay carries the opt-out,
+ * and `Annotator.setParagraphIndent` is the same switch for a host.
  */
 export const PARAGRAPH_INDENT_DEFAULT = true;
 /**

--- a/packages/annotator/src/lib/constants.ts
+++ b/packages/annotator/src/lib/constants.ts
@@ -110,12 +110,28 @@ export const PARAGRAPH_INDENT_MAX_RATIO = 0.25;
  * host that needs it off.
  */
 export const PARAGRAPH_INDENT_DEFAULT = true;
-/** Glyph drawn at the end of a paragraph while paragraph marks are shown. */
-export const PARAGRAPH_MARK_GLYPH = "¶";
+/**
+ * The end-of-paragraph mark is stroked as a path rather than set as the "¶"
+ * character: a text glyph arrives at the weight of whatever font is active
+ * (the monospace face draws a heavy, slab-sided one) and shifts with every
+ * font setting, where a path keeps one thin, quiet shape everywhere.
+ */
 /** Opacity of the paragraph mark, so it reads as chrome rather than as text. */
 export const PARAGRAPH_MARK_ALPHA = 0.35;
 /** Gap between the last character of a paragraph and its mark, in char widths. */
 export const PARAGRAPH_MARK_GAP_RATIO = 0.5;
+/** Total height of the mark as a fraction of one line height. */
+export const PARAGRAPH_MARK_HEIGHT_RATIO = 0.62;
+/** Radius of the mark's bowl as a fraction of its height: a bowl half as deep as the stems. */
+export const PARAGRAPH_MARK_BOWL_RATIO = 0.25;
+/** Distance between the mark's two stems as a fraction of its height. */
+export const PARAGRAPH_MARK_STEM_GAP_RATIO = 0.16;
+/** How far the foot runs past each stem, as a fraction of the gap between them. */
+export const PARAGRAPH_MARK_FOOT_OVERHANG_RATIO = 0.3;
+/** How far the top bar runs past the trailing stem, as a fraction of that same gap. */
+export const PARAGRAPH_MARK_CAP_OVERHANG_RATIO = 0.5;
+/** Stroke width of the mark, in CSS px (scaled by ratio at draw time). */
+export const PARAGRAPH_MARK_LINE_WIDTH_PX = 1;
 
 /** Height of selection/background highlight as a fraction of line height (0–1). Smaller = narrower band, centered in the line. */
 export const HIGHLIGHT_HEIGHT_RATIO = 0.75;

--- a/packages/annotator/src/lib/constants.ts
+++ b/packages/annotator/src/lib/constants.ts
@@ -121,16 +121,16 @@ export const PARAGRAPH_MARK_ALPHA = 0.35;
 /** Gap between the last character of a paragraph and its mark, in char widths. */
 export const PARAGRAPH_MARK_GAP_RATIO = 0.5;
 /** Total height of the mark as a fraction of one line height. */
-export const PARAGRAPH_MARK_HEIGHT_RATIO = 0.62;
+export const PARAGRAPH_MARK_HEIGHT_RATIO = 0.5;
 /** Radius of the mark's bowl as a fraction of its height: a bowl half as deep as the stems. */
 export const PARAGRAPH_MARK_BOWL_RATIO = 0.25;
 /** Distance between the mark's two stems as a fraction of its height. */
-export const PARAGRAPH_MARK_STEM_GAP_RATIO = 0.16;
-/** How far the foot runs past each stem, as a fraction of the gap between them. */
-export const PARAGRAPH_MARK_FOOT_OVERHANG_RATIO = 0.3;
-/** How far the top bar runs past the trailing stem, as a fraction of that same gap. */
-export const PARAGRAPH_MARK_CAP_OVERHANG_RATIO = 0.5;
-/** Stroke width of the mark, in CSS px (scaled by ratio at draw time). */
+export const PARAGRAPH_MARK_STEM_GAP_RATIO = 0.2;
+/** How far the top bar runs past the trailing stem, as a fraction of the gap between them. */
+export const PARAGRAPH_MARK_OVERHANG_RATIO = 0.6;
+/** How far the top bar reaches past the bowl's leading edge, in CSS px (scaled by ratio at draw time). */
+export const PARAGRAPH_MARK_CAP_LEAD_PX = 1;
+/** Thickness of the mark's stems and cap, in CSS px (scaled by ratio at draw time). */
 export const PARAGRAPH_MARK_LINE_WIDTH_PX = 1;
 
 /** Height of selection/background highlight as a fraction of line height (0–1). Smaller = narrower band, centered in the line. */

--- a/packages/annotator/src/lib/constants.ts
+++ b/packages/annotator/src/lib/constants.ts
@@ -85,6 +85,33 @@ export const DARK_MENU_COLORS: MenuColors = {
   buttonBg: "#2d3748",
 };
 
+/**
+ * Paragraph rendering (#2076). A paragraph is one segment of {@link Text} — the
+ * span between two hard newlines — and every other visual line inside it is a
+ * soft wrap. Left-aligned text gives no signal which of the two a line break is,
+ * so the first visual line of each paragraph is indented; the wrapped
+ * continuations stay flush left and the contrast marks the boundary. The
+ * renderer draws on a fixed line grid (one {@link LINE_HEIGHT} per visual line,
+ * relied on by scrolling, hit-testing and the gutter), so the horizontal axis is
+ * where a paragraph can be marked without paying for variable line boxes.
+ */
+/** First-line indent of a paragraph, in ems of the current font size. */
+export const PARAGRAPH_INDENT_EM = 2;
+/**
+ * Ceiling on the indent as a fraction of the wrap budget. A narrow panel or a
+ * large font can make the nominal indent most of a line, leaving a first line
+ * with room for a word or two; the cap keeps the paragraph readable there.
+ */
+export const PARAGRAPH_INDENT_MAX_RATIO = 0.25;
+/** Whether the first-line indent is on for a user who has never chosen. */
+export const PARAGRAPH_INDENT_DEFAULT = true;
+/** Glyph drawn at the end of a paragraph while paragraph marks are shown. */
+export const PARAGRAPH_MARK_GLYPH = "¶";
+/** Opacity of the paragraph mark, so it reads as chrome rather than as text. */
+export const PARAGRAPH_MARK_ALPHA = 0.35;
+/** Gap between the last character of a paragraph and its mark, in char widths. */
+export const PARAGRAPH_MARK_GAP_RATIO = 0.5;
+
 /** Height of selection/background highlight as a fraction of line height (0–1). Smaller = narrower band, centered in the line. */
 export const HIGHLIGHT_HEIGHT_RATIO = 0.75;
 

--- a/packages/annotator/src/lib/constants.ts
+++ b/packages/annotator/src/lib/constants.ts
@@ -103,7 +103,12 @@ export const PARAGRAPH_INDENT_EM = 2;
  * with room for a word or two; the cap keeps the paragraph readable there.
  */
 export const PARAGRAPH_INDENT_MAX_RATIO = 0.25;
-/** Whether the first-line indent is on for a user who has never chosen. */
+/**
+ * Whether paragraphs are indented. On: the indent answers a question the reader
+ * would otherwise have no way to answer, so it is not a matter of taste and
+ * carries no user-facing toggle — `Annotator.setParagraphIndent` is there for a
+ * host that needs it off.
+ */
 export const PARAGRAPH_INDENT_DEFAULT = true;
 /** Glyph drawn at the end of a paragraph while paragraph marks are shown. */
 export const PARAGRAPH_MARK_GLYPH = "¶";

--- a/packages/annotator/src/paragraphIndent.test.ts
+++ b/packages/annotator/src/paragraphIndent.test.ts
@@ -1,0 +1,187 @@
+/**
+ * Paragraph first-line indent (#2076).
+ *
+ * A paragraph is one segment — the span between two hard newlines — and every
+ * other visual line inside it is a soft wrap. Left-aligned text shows no
+ * difference between the two, so the first line of each paragraph is indented
+ * and its wrapped continuations stay flush left.
+ */
+import { Annotator } from "./lib/Annotator";
+import Text from "./lib/Text";
+import { EditMode, PARAGRAPH_INDENT_MAX_RATIO } from "./lib/constants";
+
+const MAXLEN = 20;
+
+/** A Text on the monospace grid, where the indent unit is a character column. */
+const mkText = (value: string, indent: number, mode = EditMode.RAW): Text => {
+  const t = new Text(value, MAXLEN);
+  t.mode = mode;
+  t.setParagraphIndent(indent);
+  return t;
+};
+
+const mkAnnotator = (value: string): Annotator => {
+  const c = document.createElement("canvas");
+  c.style.width = "800px";
+  c.style.height = "600px";
+  document.body.appendChild(c);
+  const a = new Annotator(c, value);
+  a.setMode(EditMode.RAW);
+  return a;
+};
+
+describe("which lines carry the indent", () => {
+  test("a paragraph's first line is indented, its wrapped lines are not", () => {
+    const t = mkText("first para\nsecond paragraph that wraps over lines", 4);
+    // segment 1 starts at line 1 (segment 0 is the single-line first paragraph)
+    const start = t.segments[1].lineStart;
+    expect(t.lineXOrigin(start)).toBe(4);
+    expect(t.lineXOrigin(start + 1)).toBe(0);
+    expect(t.lineXOrigin(start + 2)).toBe(0);
+  });
+
+  test("the document's first paragraph stays flush", () => {
+    const t = mkText("first paragraph here\nsecond", 4);
+    expect(t.lineXOrigin(0)).toBe(0);
+  });
+
+  test("a paragraph already starting with typed spaces is not indented again", () => {
+    const t = mkText("first\n    typed in as spaces\nrendered indent", 4);
+    expect(t.lineXOrigin(t.segments[1].lineStart)).toBe(0);
+    expect(t.lineXOrigin(t.segments[2].lineStart)).toBe(4);
+  });
+
+  test("the suppression follows the mode's display text, not the raw markup", () => {
+    // The paragraph's raw text starts with a tag, its parsed text with a space.
+    const value = "first\n<x>    tagged then spaces</x>";
+    expect(mkText(value, 4, EditMode.RAW).lineXOrigin(1)).toBe(4);
+    expect(mkText(value, 4, EditMode.HIGHLIGHT).lineXOrigin(1)).toBe(0);
+  });
+
+  test("no indent reported while the setting is off", () => {
+    const t = mkText("first\nsecond paragraph", 0);
+    expect(t.lineXOrigin(t.segments[1].lineStart)).toBe(0);
+  });
+});
+
+describe("wrapping around the indent", () => {
+  test("the indented line holds fewer characters than the ones below it", () => {
+    const value = "first\n" + "ab ".repeat(20).trim();
+    const plain = mkText(value, 0);
+    const indented = mkText(value, 6);
+    // Trailing wrap whitespace is collapsed in the margin past the visible
+    // edge, so a line's visible length is what the budget bounds.
+    const firstLineOf = (t: Text) => t.segments[1].lines[0].trimEnd();
+
+    expect(firstLineOf(plain).length).toBe(MAXLEN);
+    expect(firstLineOf(indented).length).toBeLessThanOrEqual(MAXLEN - 6);
+    // The continuation lines keep the full width.
+    expect(indented.segments[1].lines[1].trimEnd().length).toBeGreaterThan(
+      firstLineOf(indented).length
+    );
+  });
+
+  test("nothing on an indented line overflows the panel", () => {
+    const t = mkText("first\n" + "ab ".repeat(20).trim(), 6);
+    for (const segment of t.segments) {
+      segment.lines.forEach((line, i) => {
+        const origin = t.lineXOrigin(segment.lineStart + i);
+        expect(origin + line.trimEnd().length).toBeLessThanOrEqual(MAXLEN);
+      });
+    }
+  });
+
+  test("a word too wide for the indented line moves down whole", () => {
+    // "wordthatisfifteen" (17) fits a full 20-wide line but not the 14 left
+    // after the indent, so it starts the next line instead of being broken.
+    const t = mkText("first\nab wordthatisfifteen", 6);
+    expect(t.segments[1].lines[0].trimEnd()).toBe("ab");
+    expect(t.segments[1].lines[1]).toBe("wordthatisfifteen");
+  });
+
+  test("an indent wider than a quarter of the line is capped", () => {
+    const t = mkText("first\nsecond paragraph that wraps", MAXLEN - 1);
+    expect(t.lineXOrigin(t.segments[1].lineStart)).toBe(
+      Math.floor(MAXLEN * PARAGRAPH_INDENT_MAX_RATIO)
+    );
+  });
+});
+
+describe("positions on an indented line", () => {
+  test("a click resolves the column the indent shifted it to", () => {
+    const a = mkAnnotator("first paragraph\nsecond paragraph");
+    const indentPx = a.text.lineXOrigin(1) * a.charWidth;
+    expect(indentPx).toBeGreaterThan(0);
+
+    // Column 3 of the second paragraph sits three characters past the indent.
+    a.onMouseDoubleClick({
+      offsetX: (indentPx + 3 * a.charWidth) / a.ratio,
+      offsetY: 1.5 * (a.lineHeight / a.ratio),
+      preventDefault: () => {},
+    } as unknown as MouseEvent);
+    // Double-click selects the word under that column — "second" (cols 0..6).
+    expect(a.cursor.selectStart).toEqual({ xLine: 0, yLine: 1 });
+    expect(a.cursor.selectEnd).toEqual({ xLine: 6, yLine: 1 });
+  });
+
+  test("a click left of the indent lands on column 0, not off the line", () => {
+    const a = mkAnnotator("first paragraph\nsecond paragraph");
+    const indentPx = a.text.lineXOrigin(1) * a.charWidth;
+    a.cursor.setPositionFromCanvasOffsets(
+      0,
+      1.5 * (a.lineHeight / a.ratio),
+      a.lineHeight,
+      a.charWidth,
+      0,
+      0,
+      undefined,
+      () => indentPx
+    );
+    expect({ xLine: a.cursor.xLine, yLine: a.cursor.yLine }).toEqual({
+      xLine: 0,
+      yLine: 1,
+    });
+  });
+});
+
+describe("toggling", () => {
+  test("turning the indent off re-wraps and restores the flush layout", () => {
+    const a = mkAnnotator("first\nsecond paragraph");
+    a.text.updateCharsAtLine(MAXLEN);
+    const indentedLines = a.text.segments[1].lines.slice();
+
+    a.setParagraphIndent(false);
+    expect(a.text.lineXOrigin(1)).toBe(0);
+    expect(a.getParagraphIndent()).toBe(false);
+
+    a.setParagraphIndent(true);
+    expect(a.text.segments[1].lines).toEqual(indentedLines);
+  });
+
+  test("the caret keeps its document offset across the re-wrap", () => {
+    const a = mkAnnotator("first\n" + "ab ".repeat(20).trim());
+    a.text.updateCharsAtLine(MAXLEN);
+    a.cursor.moveToOffset(a.text, 30);
+
+    a.setParagraphIndent(false);
+    expect(a.cursor.head).toBe(30);
+    expect(a.text.offsetFromVisual(a.cursor.xLine, a.cursor.yLine)).toBe(30);
+  });
+});
+
+describe("paragraph marks", () => {
+  test("the end of every paragraph is a paragraph end, wrapped lines are not", () => {
+    const t = mkText("first\nsecond paragraph that wraps over lines", 4);
+    expect(t.isParagraphEnd(0)).toBe(true); // single-line first paragraph
+    const last = t.segments[1].lineEndExclusive - 1;
+    expect(t.isParagraphEnd(last)).toBe(true);
+    expect(t.isParagraphEnd(last - 1)).toBe(false);
+  });
+
+  test("the toggle is off by default and persists through a redraw", () => {
+    const a = mkAnnotator("first\nsecond");
+    expect(a.getShowParagraphMarks()).toBe(false);
+    a.setShowParagraphMarks(true);
+    expect(a.getShowParagraphMarks()).toBe(true);
+  });
+});

--- a/packages/annotator/src/paragraphIndent.test.ts
+++ b/packages/annotator/src/paragraphIndent.test.ts
@@ -51,11 +51,29 @@ describe("which lines carry the indent", () => {
     expect(t.lineXOrigin(t.segments[2].lineStart)).toBe(4);
   });
 
-  test("the suppression follows the mode's display text, not the raw markup", () => {
+  test("markup does not change where a paragraph sits", () => {
     // The paragraph's raw text starts with a tag, its parsed text with a space.
+    // Both modes read the parsed text, so switching mode never shifts the line.
     const value = "first\n<x>    tagged then spaces</x>";
-    expect(mkText(value, 4, EditMode.RAW).lineXOrigin(1)).toBe(4);
+    expect(mkText(value, 4, EditMode.RAW).lineXOrigin(1)).toBe(0);
     expect(mkText(value, 4, EditMode.HIGHLIGHT).lineXOrigin(1)).toBe(0);
+  });
+
+  test("a paragraph holding only an anchor tag is flush in every mode", () => {
+    // What line 3177 of a real document looks like: one anchor tag, no prose.
+    const value = "first\n</f4fc7fb6-c0b4-4caa-997a-0d0d7754494a>\nthird";
+    for (const mode of [EditMode.RAW, EditMode.HIGHLIGHT, EditMode.SEMI]) {
+      const t = mkText(value, 4, mode);
+      expect(t.lineXOrigin(t.segments[1].lineStart)).toBe(0);
+      expect(t.lineXOrigin(t.segments[2].lineStart)).toBe(4);
+    }
+  });
+
+  test("an empty paragraph is not indented", () => {
+    const t = mkText("first\n\n\nfourth paragraph", 4);
+    expect(t.lineXOrigin(1)).toBe(0);
+    expect(t.lineXOrigin(2)).toBe(0);
+    expect(t.lineXOrigin(3)).toBe(4);
   });
 
   test("no indent reported while the setting is off", () => {
@@ -97,6 +115,22 @@ describe("wrapping around the indent", () => {
     const t = mkText("first\nab wordthatisfifteen", 6);
     expect(t.segments[1].lines[0].trimEnd()).toBe("ab");
     expect(t.segments[1].lines[1]).toBe("wordthatisfifteen");
+  });
+
+  test("a tag too wide for the indented line is broken, not run off the edge", () => {
+    // 16 chars: fits a full 20-wide line but not the 15 left after the indent —
+    // the window where a tag measured against the full width would be appended
+    // to the indented line and overhang it. In XML mode, where every anchor is
+    // a tag carrying an id, that window is where the long ones land.
+    const tag = '<person id="12">';
+    const t = mkText(`first\n${tag}name`, 5);
+    const seg = t.segments[1];
+    seg.lines.forEach((line, i) => {
+      const origin = t.lineXOrigin(seg.lineStart + i);
+      expect(origin + line.trimEnd().length).toBeLessThanOrEqual(MAXLEN);
+    });
+    // The pieces still reconstruct the paragraph exactly.
+    expect(seg.lines.join("")).toBe(`${tag}name`);
   });
 
   test("an indent wider than a quarter of the line is capped", () => {

--- a/packages/annotator/src/paragraphIndent.test.ts
+++ b/packages/annotator/src/paragraphIndent.test.ts
@@ -51,6 +51,20 @@ describe("which lines carry the indent", () => {
     expect(t.lineXOrigin(t.segments[2].lineStart)).toBe(4);
   });
 
+  test("a single leading space is incidental and the paragraph still indents", () => {
+    // One space is a typo, not hand-typed indentation; two spaces or a tab are.
+    const t = mkText("first\n one space lead\n  two spaces\n\ttab lead", 4);
+    expect(t.lineXOrigin(t.segments[1].lineStart)).toBe(4);
+    expect(t.lineXOrigin(t.segments[2].lineStart)).toBe(0);
+    expect(t.lineXOrigin(t.segments[3].lineStart)).toBe(0);
+  });
+
+  test("a whitespace-only paragraph is empty, not single-space-led", () => {
+    const t = mkText("first\n \nthird", 4);
+    expect(t.lineXOrigin(t.segments[1].lineStart)).toBe(0);
+    expect(t.lineXOrigin(t.segments[2].lineStart)).toBe(4);
+  });
+
   test("markup does not change where a paragraph sits", () => {
     // The paragraph's raw text starts with a tag, its parsed text with a space.
     // Both modes read the parsed text, so switching mode never shifts the line.

--- a/packages/annotator/src/paragraphIndent.test.ts
+++ b/packages/annotator/src/paragraphIndent.test.ts
@@ -7,6 +7,7 @@
  * and its wrapped continuations stay flush left.
  */
 import { Annotator } from "./lib/Annotator";
+import Cursor from "./lib/Cursor";
 import Text from "./lib/Text";
 import { EditMode, PARAGRAPH_INDENT_MAX_RATIO } from "./lib/constants";
 
@@ -231,5 +232,46 @@ describe("paragraph marks", () => {
     expect(a.getShowParagraphMarks()).toBe(false);
     a.setShowParagraphMarks(true);
     expect(a.getShowParagraphMarks()).toBe(true);
+  });
+});
+
+describe("caret at the canvas edge", () => {
+  /** drawLine with a recording ctx; returns the fillRect calls. */
+  const paintCaret = (
+    col: number,
+    lineXOrigin?: (absLine: number) => number
+  ): number[][] => {
+    const calls: number[][] = [];
+    const ctx = {
+      canvas: { width: 200 },
+      fillRect: (...args: number[]) => calls.push(args),
+      globalAlpha: 1,
+      globalCompositeOperation: "source-over",
+    } as unknown as CanvasRenderingContext2D;
+    const cursor = new Cursor(1);
+    // Collapsed caret: xStart === xEnd on the SELECT highlighter.
+    cursor.drawLine(
+      ctx,
+      0,
+      col,
+      col,
+      { charWidth: 10, lineHeight: 20, charsAtLine: 20, caretWidth: 2, lineXOrigin },
+      0
+    );
+    return calls;
+  };
+
+  test("a margin caret pushed past the edge by the indent is pinned inside", () => {
+    // Column 19 of a 20-col canvas at charWidth 10, shifted 50px by the
+    // indent: 240px on a 200px canvas — drawn pinned at width - caretWidth.
+    const calls = paintCaret(19, () => 50);
+    expect(calls).toHaveLength(1);
+    expect(calls[0][0]).toBe(200 - 2);
+    expect(calls[0][2]).toBe(2);
+  });
+
+  test("a caret inside the canvas is not moved by the pin", () => {
+    const calls = paintCaret(3, () => 50);
+    expect(calls[0][0]).toBe(3 * 10 + 50);
   });
 });

--- a/packages/annotator/src/paragraphMarkDodge.test.ts
+++ b/packages/annotator/src/paragraphMarkDodge.test.ts
@@ -1,0 +1,127 @@
+/**
+ * #2076 — paragraph-mark placement against Territory anchor markers, end-to-end
+ * through Annotator.draw().
+ *
+ * The ¶ marks are held over from the text pass and drawn last, each nudged
+ * right until it clears any END anchor marker (┘) occupying its spot; start
+ * markers (┌) open toward the text, so the mark sits inside their corner
+ * without moving. A mark pinned at the canvas' right edge cannot move at all,
+ * so its dodge search ends immediately.
+ *
+ * The drawn output is observed by spying on the private drawParagraphMark —
+ * its third argument is the final dodge shift — and positions are derived
+ * through the same private paragraphMarkGeometry the dodge loop uses.
+ */
+import { Annotator } from "./lib/Annotator";
+import { EditMode, HighlightMode } from "./lib/constants";
+
+jest.mock("./lib/AnchorMarker", () => ({
+  // Box keyed off the draw coords, mirroring the real fn's return shape.
+  drawAnchorMarker: jest.fn((_ctx: unknown, xPx: number, yMid: number) => ({
+    x: xPx,
+    y: yMid - 5,
+    w: 4,
+    h: 10,
+  })),
+}));
+
+const anchorSchema = {
+  mode: HighlightMode.ANCHOR,
+  style: { color: "#2079DF", opacity: 1 },
+};
+
+const mk = (text: string): Annotator => {
+  const c = document.createElement("canvas");
+  c.style.width = "800px";
+  c.style.height = "600px";
+  document.body.appendChild(c);
+  return new Annotator(c, text);
+};
+
+/** Spy capturing every drawParagraphMark(x, y, shiftX) of a draw pass. */
+const spyMarks = () =>
+  jest.spyOn(Annotator.prototype as any, "drawParagraphMark").mockImplementation(() => {});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+  // setShowParagraphMarks persists; keep it out of the next test's Annotator.
+  localStorage.clear();
+});
+
+describe("paragraph mark dodges anchor markers (#2076)", () => {
+  test("mark lands clear of an end marker at the paragraph end", () => {
+    // The anchor ends where paragraph one ends, so its ┘ marker is drawn at
+    // the very spot the ¶ mark wants: right after the line's last character.
+    const a = mk("foo <T1>bar</T1>\nnext");
+    a.setShowParagraphMarks(true);
+    a.setMode(EditMode.HIGHLIGHT);
+    a.onHighlight(() => anchorSchema);
+
+    const spy = spyMarks();
+    a.draw();
+
+    const inst = a as any;
+    const endBoxes = inst.anchorMarkerHitboxes.filter((hb: any) => hb.kind === "end");
+    expect(endBoxes).toHaveLength(1);
+    const clearOf = endBoxes[0].x + endBoxes[0].w;
+
+    // The first paragraph's mark shares the marker's line: the hitbox is
+    // padded symmetrically around the marker, so its vertical centre is the
+    // line's midline — the y both glyphs are drawn at.
+    const yMid = endBoxes[0].y + endBoxes[0].h / 2;
+    const call = spy.mock.calls.find(([, y]) => y === yMid) as number[];
+    expect(call).toBeDefined();
+    const [x, y, shiftX] = call;
+    expect(shiftX).toBeGreaterThan(0);
+    expect(inst.paragraphMarkGeometry(x, y, shiftX).left).toBeGreaterThanOrEqual(clearOf);
+  });
+
+  test("a start marker at the paragraph end does not move the mark", () => {
+    // The anchor opens at the end of paragraph one (its text begins on the next
+    // line), so a ┌ marker sits where the ¶ mark goes — and is ignored.
+    const a = mk("foo <T1>\nnext</T1>");
+    a.setShowParagraphMarks(true);
+    a.setMode(EditMode.HIGHLIGHT);
+    a.onHighlight(() => anchorSchema);
+
+    const spy = spyMarks();
+    a.draw();
+
+    const inst = a as any;
+    const startHb = inst.anchorMarkerHitboxes.find((hb: any) => hb.kind === "start");
+    expect(startHb).toBeDefined();
+
+    // The anchor's own end marker (on the last line) still dodges its ¶, so
+    // only the mark on the start marker's line is asserted still.
+    const yMid = startHb.y + startHb.h / 2;
+    const call = spy.mock.calls.find(([, y]) => y === yMid) as number[];
+    expect(call).toBeDefined();
+    const [x, y, shiftX] = call;
+    expect(shiftX).toBe(0);
+
+    // Not vacuous: unmoved, the mark does overlap the start marker's hitbox.
+    const g = inst.paragraphMarkGeometry(x, y, 0);
+    expect(g.left < startHb.x + startHb.w && g.left + g.markW > startHb.x).toBe(true);
+  });
+
+  test("a mark pinned at the right edge stays put and stays inside", () => {
+    const a = mk("word");
+    const inst = a as any;
+    const spy = jest.spyOn(inst, "drawParagraphMark").mockImplementation(() => {});
+
+    // A mark anchored at the canvas edge pins at width - markW; the marker
+    // covering that spot cannot be cleared by any shift.
+    const y = inst.lineHeight / 2;
+    inst.pendingParagraphMarks = [{ x: inst.width, y }];
+    inst.anchorMarkerHitboxes = [
+      { x: inst.width - 50, y: y - 10, w: 60, h: 20, kind: "end", tag: {} },
+    ];
+    inst.drawPendingParagraphMarks();
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    const [x, yArg, shiftX] = spy.mock.calls[0] as number[];
+    expect(shiftX).toBe(0);
+    const geom = inst.paragraphMarkGeometry(x, yArg, shiftX);
+    expect(geom.left).toBe(inst.width - geom.markW);
+  });
+});

--- a/packages/client/src/components/advanced/Annotator/Annotator.tsx
+++ b/packages/client/src/components/advanced/Annotator/Annotator.tsx
@@ -47,7 +47,7 @@ import {
 } from "@inkvisitor/shared/types";
 import { AxiosResponse } from "axios";
 import { CancelButton, Loader, Modal, ModalContent, ModalFooter, ModalHeader } from "components";
-import { EntityTagById } from "components/advanced";
+import { EntityTagById } from "../EntityTag/EntityTagById";
 import { Button } from "components/basic/Button/Button";
 import { ButtonGroup } from "components/basic/ButtonGroup/ButtonGroup";
 import { CStatement } from "constructors";

--- a/packages/client/src/components/advanced/Annotator/AnnotatorMenu/AnnotatorMenu.tsx
+++ b/packages/client/src/components/advanced/Annotator/AnnotatorMenu/AnnotatorMenu.tsx
@@ -66,7 +66,10 @@ import {
 } from "../styles";
 import { AnnotatorPositionTNode, TerritoryCreateModalType } from "../types";
 import { useAnnotatorTargetPicker } from "../hooks/useAnnotatorTargetPicker";
-import { EntitySuggester, EntityTag, EntityTagById, ElvlButtonGroup } from "components/advanced";
+import { EntitySuggester } from "../../EntitySuggester/EntitySuggester";
+import { EntityTag } from "../../EntityTag/EntityTag";
+import { EntityTagById } from "../../EntityTag/EntityTagById";
+import { ElvlButtonGroup } from "../../IconButtonGroups/ElvlButtonGroup";
 
 interface TextAnnotatorMenuProps {
   text: string;

--- a/packages/client/src/components/advanced/Annotator/AnnotatorMenu/AnnotatorMenu.tsx
+++ b/packages/client/src/components/advanced/Annotator/AnnotatorMenu/AnnotatorMenu.tsx
@@ -30,10 +30,6 @@ import { setSecondPanelExpanded } from "redux/features/layout/mainPage/secondPan
 import { useAppDispatch } from "redux/hooks";
 import { IcoPlus, IcoTrash } from "Theme/icons";
 import { ButtonSize, classesAnnotator } from "types";
-import { EntitySuggester } from "../../EntitySuggester/EntitySuggester";
-import { EntityTag } from "../../EntityTag/EntityTag";
-import { EntityTagById } from "../../EntityTag/EntityTagById";
-import { ElvlButtonGroup } from "../../IconButtonGroups/ElvlButtonGroup";
 import { TerritoryChildIcon, TerritorySiblingIcon } from "./AnnotatorIcons";
 import {
   ANCHOR_GRID_COLUMNS,
@@ -70,6 +66,7 @@ import {
 } from "../styles";
 import { AnnotatorPositionTNode, TerritoryCreateModalType } from "../types";
 import { useAnnotatorTargetPicker } from "../hooks/useAnnotatorTargetPicker";
+import { EntitySuggester, EntityTag, EntityTagById, ElvlButtonGroup } from "components/advanced";
 
 interface TextAnnotatorMenuProps {
   text: string;
@@ -367,10 +364,7 @@ export const TextAnnotatorMenu = ({
 
   const someAnchorsWithoutElvl = useMemo(() => hasAnchorsWithoutElvl(anchors), [anchors]);
 
-  const resolvedAnchors = useMemo(
-    () => resolveAnchors(anchors, entities),
-    [anchors, entities],
-  );
+  const resolvedAnchors = useMemo(() => resolveAnchors(anchors, entities), [anchors, entities]);
 
   // Anchor controls mode: view (kebab menu + static elvl) or edit (inline
   // resize / elvl / unlink). Always starts in view mode and resets to view on

--- a/packages/client/src/components/advanced/Annotator/AnnotatorMenu/AnnotatorStatementTargetPicker.tsx
+++ b/packages/client/src/components/advanced/Annotator/AnnotatorMenu/AnnotatorStatementTargetPicker.tsx
@@ -7,7 +7,7 @@ import {
   StyledStatementTargetTitle,
 } from "../styles";
 import { AnnotatorPositionTNode } from "../types";
-import { EntityTag } from "components/advanced";
+import { EntityTag } from "../../EntityTag/EntityTag";
 
 interface AnnotatorStatementTargetPicker {
   /** The in-document subT hierarchy, outermost first with nesting depth. */

--- a/packages/client/src/components/advanced/Annotator/AnnotatorSearchLine/AnnotatorSequentialAnchorPanel.tsx
+++ b/packages/client/src/components/advanced/Annotator/AnnotatorSearchLine/AnnotatorSequentialAnchorPanel.tsx
@@ -1,7 +1,8 @@
 import { Annotator, Occurrence } from "@inkvisitor/annotator/src/lib";
 import { IDocument, IEntity } from "@inkvisitor/shared/types";
 import { Button } from "components";
-import { EntitySuggester, EntityTag } from "components/advanced";
+import { EntitySuggester } from "../../EntitySuggester/EntitySuggester";
+import { EntityTag } from "../../EntityTag/EntityTag";
 import React from "react";
 import { useTheme } from "styled-components";
 import { IcoAnchor, IcoAnchorCheck, IcoChevronLeft } from "Theme/icons";


### PR DESCRIPTION
The annotator draws every visual line flush left on a fixed line grid, so a line break gives the reader no clue whether it is a paragraph boundary or a soft wrap. This PR marks the difference on the horizontal axis, where it costs nothing on the fixed grid. Also adding possibility to show paragraph marks for confirmation.

<img width="531" height="425" alt="Screenshot 2026-08-03 at 17 40 16" src="https://github.com/user-attachments/assets/43ca4a5f-d73e-4a58-aa0e-4a04a3e2c3ed" />

## First-line indent

The first visual line of each paragraph is indented by 2 em; its wrapped continuations stay flush left, and the contrast marks the boundary. On by default, toggleable in the settings overlay and persisted with the other annotator settings.

The indent is real layout, not a draw-time offset: it shortens the first line's wrap budget, so break positions move with it. `Text` takes it in whatever unit the active mode wraps in (device px under a proportional measurer, character columns on the monospace grid) and exposes `lineXOrigin(absLine)` — the horizontal origin of a visual line. Everything drawn on a line is shifted by it (text, caret, selection, background washes, anchor markers, selection handles) and mouse x is un-shifted by it before a column is resolved.

Three kinds of paragraph stay flush:

- the document's first, which has nothing above it to be confused with;
- one whose text already begins with hand-typed indentation (a tab, or two or more whitespace characters), so documents written with the indent typed in do not get it twice — a single leading space is incidental typing and still gets the indent;
- one with no text beyond whitespace, including a line holding only an anchor tag, which has no start to mark and would otherwise show its caret, selection sliver and anchor markers nudged off the text column.

That decision reads the segment's parsed text in every mode, so switching RAW/SEMI/HIGHLIGHT never shifts a paragraph sideways. The indent is also capped at a quarter of the line width, so a narrow panel or a large font cannot leave a first line with room for one word.

Wrapping had to learn the difference between the two budgets: a word or tag is measured against the line it will actually land on, since the indented first line holds less than the full-width continuation a wrap would open. Without that, a long tag (an anchor carrying a UUID in XML mode) measured against the full width would be appended to the indented line and overhang the right edge before any break.

## Paragraph marks

Optional pilcrow at the end of each paragraph, in Word's "formatting marks" spirit — a way to double-check where the breaks are. Off by default, toggled from the canvas context menu, persisted.

Drawn as a filled path rather than the "¶" character: a glyph arrives at the weight of whatever font is active (the monospace face draws a heavy, slab-sided one) and shifts with every font setting, where a path keeps one thin, quiet shape everywhere. It is filled as a single union path so the parts may overlap without compounding into dark spots at their junctions, and painted in the text colour at reduced opacity so it reads as chrome.

Marks are collected during the text pass and drawn last, once the Territory anchor markers are down, so each can be nudged right past an end marker it would otherwise land on top of — the marker carries a hover target and is the meaningful glyph, so the mark gives way. A mark pinned at the canvas edge stays put.

## Also in here

- `Text.segmentIndexForLine` — binary search over the segment list, replacing three linear `find`/`findIndex`/`findLastIndex` scans in `getLine`, `prefixForLine` and `getSegmentFromAbsCoordinates`. These run per visible line per frame, where a linear scan of a many-thousand-paragraph document is measurable. Segments are contiguous, ordered and never empty (`lineEndExclusive = lineStart + (lines.length || 1)`), so first-match and last-match agree.
- A collapsed caret parked in a line's trailing wrap margin is pinned inside the canvas so it stays visible.
- Annotator components import `EntitySuggester` / `EntityTag` / `EntityTagById` / `ElvlButtonGroup` directly instead of through the `components/advanced` barrel — the barrel reaches back into `Annotator` via `DocumentModalEdit`, so those imports formed a module cycle.