### PR TITLE
perf(annotator): memoize segment wrapping and reuse unchanged segments

### DIFF
--- a/packages/annotator/src/annotatorFontSettings.test.ts
+++ b/packages/annotator/src/annotatorFontSettings.test.ts
@@ -85,6 +85,16 @@ describe("Annotator line spacing", () => {
     expect(b.lineHeight).toBeCloseTo(b.fontSize * 1.4 * b.ratio);
   });
 
+  test("line-spacing change reuses every segment's wrap in proportional mode", () => {
+    const a = mk("abc def ghi\n\njkl mno pqr");
+    a.setProportional(true, '"Roboto", sans-serif');
+    // Spacing feeds row height, not wrap: the memoized wrap (keyed on measurer
+    // identity among others) must survive, so each segment keeps its lines array.
+    const linesBefore = a.text.segments.map((s) => s.lines);
+    a.setLineHeightRatio(2);
+    a.text.segments.forEach((s, i) => expect(s.lines).toBe(linesBefore[i]));
+  });
+
   test("resetSettings restores the default spacing", () => {
     const a = mk("abc");
     const defaultLineHeight = a.lineHeight;

--- a/packages/annotator/src/annotatorFontSettings.test.ts
+++ b/packages/annotator/src/annotatorFontSettings.test.ts
@@ -56,6 +56,44 @@ describe("Annotator font family", () => {
   });
 });
 
+describe("Annotator line spacing", () => {
+  test("setLineHeightRatio scales the line height off the font size", () => {
+    const a = mk("abc");
+    a.setLineHeightRatio(1.15);
+    expect(a.lineHeightRatio).toBe(1.15);
+    expect(a.lineHeight).toBeCloseTo(a.fontSize * 1.15 * a.ratio);
+  });
+
+  test("ratios below 1 clamp to 1 (lines never overlap)", () => {
+    const a = mk("abc");
+    a.setLineHeightRatio(0.5);
+    expect(a.lineHeightRatio).toBe(1);
+  });
+
+  test("line spacing and font size compose", () => {
+    const a = mk("abc");
+    a.setLineHeightRatio(2);
+    a.setFontSize(15);
+    expect(a.lineHeight).toBeCloseTo(15 * 2 * a.ratio);
+  });
+
+  test("persists and restores across construction", () => {
+    const a = mk("abc");
+    a.setLineHeightRatio(1.4);
+    const b = mk("abc");
+    expect(b.lineHeightRatio).toBe(1.4);
+    expect(b.lineHeight).toBeCloseTo(b.fontSize * 1.4 * b.ratio);
+  });
+
+  test("resetSettings restores the default spacing", () => {
+    const a = mk("abc");
+    const defaultLineHeight = a.lineHeight;
+    a.setLineHeightRatio(1.15);
+    a.resetSettings();
+    expect(a.lineHeight).toBeCloseTo(defaultLineHeight);
+  });
+});
+
 describe("font family options", () => {
   test("setFontFamilyOptions defaults the family to the first option when untouched", () => {
     const a = mk("abc");

--- a/packages/annotator/src/annotatorFontSettings.test.ts
+++ b/packages/annotator/src/annotatorFontSettings.test.ts
@@ -118,6 +118,15 @@ describe("proportional-by-default for hosted instances", () => {
     expect(localStorage.getItem("inkvisitor.annotator.settings")).toBeNull();
   });
 
+  test("a same-session monospace choice survives the host re-supplying fonts", () => {
+    const a = mk("abc");
+    a.setFontFamilyOptions(HOST_OPTIONS); // adopted proportional
+    a.setProportional(false); // user picks monospace in this session
+    a.setFontFamilyOptions(HOST_OPTIONS); // e.g. theme change re-applies host fonts
+    expect(a.proportional).toBe(false);
+    expect(a.font).toContain("Roboto Mono");
+  });
+
   test("a stored monospace choice survives the host handing over fonts", () => {
     const a = mk("abc");
     a.setProportional(false); // explicit user choice, persisted

--- a/packages/annotator/src/annotatorFontSettings.test.ts
+++ b/packages/annotator/src/annotatorFontSettings.test.ts
@@ -20,11 +20,11 @@ afterEach(() => localStorage.clear());
 describe("Annotator font size", () => {
   test("setFontSize updates the size, the font string, and scales line height", () => {
     const a = mk("abc");
-    const baseLineHeight = a.lineHeight; // 13px default
+    const baseLineHeight = a.lineHeight; // 14px default
     a.setFontSize(15);
     expect(a.fontSize).toBe(15);
     expect(a.font).toContain(`${15 * a.ratio}px`);
-    expect(a.lineHeight).toBeCloseTo(baseLineHeight * (15 / 13));
+    expect(a.lineHeight).toBeCloseTo(baseLineHeight * (15 / 14));
   });
 
   test("font size persists across a proportional toggle (font string keeps the size)", () => {
@@ -91,6 +91,55 @@ describe("Annotator line spacing", () => {
     a.setLineHeightRatio(1.15);
     a.resetSettings();
     expect(a.lineHeight).toBeCloseTo(defaultLineHeight);
+  });
+});
+
+describe("proportional-by-default for hosted instances", () => {
+  const HOST_OPTIONS = [
+    { label: "Roboto", value: '"Roboto", sans-serif' },
+    { label: "Serif", value: "Georgia, serif" },
+  ];
+
+  test("bare instance (no host font) stays monospace", () => {
+    const a = mk("abc");
+    expect(a.proportional).toBe(false);
+  });
+
+  test("supplying host fonts adopts proportional with the first family", () => {
+    const a = mk("abc");
+    a.setFontFamilyOptions(HOST_OPTIONS);
+    expect(a.proportional).toBe(true);
+    expect(a.font).toContain('"Roboto", sans-serif');
+  });
+
+  test("adoption is not persisted as an explicit choice", () => {
+    const a = mk("abc");
+    a.setFontFamilyOptions(HOST_OPTIONS);
+    expect(localStorage.getItem("inkvisitor.annotator.settings")).toBeNull();
+  });
+
+  test("a stored monospace choice survives the host handing over fonts", () => {
+    const a = mk("abc");
+    a.setProportional(false); // explicit user choice, persisted
+    const b = mk("abc");
+    b.setFontFamilyOptions(HOST_OPTIONS);
+    expect(b.proportional).toBe(false);
+    expect(b.font).toContain("Roboto Mono");
+  });
+
+  test("resetSettings on a hosted instance returns to proportional", () => {
+    const a = mk("abc");
+    a.setFontFamilyOptions(HOST_OPTIONS);
+    a.setProportional(false);
+    a.resetSettings();
+    expect(a.proportional).toBe(true);
+  });
+
+  test("resetSettings on a bare instance returns to monospace", () => {
+    const a = mk("abc");
+    a.setProportional(true);
+    a.resetSettings();
+    expect(a.proportional).toBe(false);
   });
 });
 
@@ -167,7 +216,7 @@ describe("font settings persistence", () => {
     a.setFontSize(15);
     a.resetSettings();
     expect(a.proportional).toBe(false);
-    expect(a.fontSize).toBe(13);
+    expect(a.fontSize).toBe(14);
     expect(a.font).toContain("Roboto Mono");
     expect(a.text.segments[0].linePrefixes).toEqual([]);
   });

--- a/packages/annotator/src/lib/Annotator.ts
+++ b/packages/annotator/src/lib/Annotator.ts
@@ -1341,6 +1341,9 @@ export class Annotator {
    */
   setProportional(on: boolean, fontFamily?: string) {
     this.proportional = on;
+    // This IS an explicit stored choice — the adoption in setFontFamilyOptions
+    // must not override it when the host re-supplies its fonts (theme change).
+    this.hasStoredProportionalChoice = true;
     if (fontFamily !== undefined) {
       this.proportionalFontFamily = fontFamily;
     }

--- a/packages/annotator/src/lib/Annotator.ts
+++ b/packages/annotator/src/lib/Annotator.ts
@@ -294,6 +294,21 @@ export class Annotator {
   lastSelectedText?: Selected;
   ratio: number = 1;
 
+  /**
+   * Device px per CSS px the host asked for. The live {@link ratio} is this or
+   * the display's `devicePixelRatio`, whichever is larger, so a host that wants
+   * supersampling on a 1× display keeps it while browser zoom (which raises the
+   * DPR) still gets a backing store at its own resolution.
+   */
+  private readonly baseRatio: number;
+
+  /**
+   * Media query matching exactly the current `devicePixelRatio`. It reports the
+   * move away from that one value, so each change re-arms a query built from
+   * the new DPR.
+   */
+  private dprQuery?: MediaQueryList;
+
   previousRenderViewportLineStart: number;
 
   private lastSelectPointer: { cx: number; cy: number } | null = null;
@@ -480,7 +495,8 @@ export class Annotator {
       throw new Error("Cannot get 2d context");
     }
 
-    this.ratio = ratio;
+    this.baseRatio = ratio;
+    this.ratio = this.effectiveRatio();
     this.font = this.composeFont();
 
     this.lineHeight = this.lineHeightForSize(this.fontSize);
@@ -523,6 +539,8 @@ export class Annotator {
 
     this.bgColor = this.element.style.backgroundColor || "white";
     this.fontColor = this.element.style.color || "black";
+
+    this.watchDevicePixelRatio();
 
     this.element.onwheel = this.onWheel.bind(this);
     this.element.onmousedown = this.onMouseDown.bind(this);
@@ -1053,7 +1071,64 @@ export class Annotator {
     this.onAnchorTagHoverCb(null, null);
   }
 
+  /** Live device px per CSS px: the host's request, floored by the display DPR. */
+  private effectiveRatio(): number {
+    const dpr = typeof window !== "undefined" ? window.devicePixelRatio || 1 : 1;
+    return Math.max(this.baseRatio, dpr);
+  }
+
+  /**
+   * Re-seed everything derived from `ratio`: Cursor and Highlighter hold their
+   * own copies for hit-testing, and the font string and line height are device-px
+   * values. Layout (backing store, re-wrap, redraw) is left to the caller.
+   */
+  private applyRatio(ratio: number): boolean {
+    if (!Number.isFinite(ratio) || ratio <= 0 || ratio === this.ratio) {
+      return false;
+    }
+    this.ratio = ratio;
+    this.cursor.ratio = ratio;
+    this.scratchCursor.ratio = ratio;
+    this.hoverHighlighter.ratio = ratio;
+    this.font = this.composeFont();
+    this.lineHeight = this.lineHeightForSize(this.fontSize);
+    return true;
+  }
+
+  /**
+   * Follow `devicePixelRatio`, which browser zoom changes: a backing store built
+   * for the old value is resampled by the compositor and the text goes soft.
+   * A `resolution` query matches one DPR only, so the handler re-arms itself
+   * against the new value before re-laying out.
+   */
+  private watchDevicePixelRatio(): void {
+    if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
+      return;
+    }
+    const dpr = window.devicePixelRatio || 1;
+    this.dprQuery = window.matchMedia(`(resolution: ${dpr}dppx)`);
+    this.dprQuery.addEventListener?.("change", this.boundOnDevicePixelRatioChange);
+  }
+
+  private unwatchDevicePixelRatio(): void {
+    this.dprQuery?.removeEventListener?.("change", this.boundOnDevicePixelRatioChange);
+    this.dprQuery = undefined;
+  }
+
+  private readonly boundOnDevicePixelRatioChange = (): void => {
+    this.unwatchDevicePixelRatio();
+    if (this.destroyed) {
+      return;
+    }
+    this.watchDevicePixelRatio();
+    this.onCanvasResize();
+  };
+
   onCanvasResize() {
+    // Zoom can move the DPR without any other notice, and every size below is
+    // derived from the ratio.
+    const ratioChanged = this.applyRatio(this.effectiveRatio());
+
     this.width = Number(this.element.style.width.replace("px", "")) * this.ratio;
     this.height = Number(this.element.style.height.replace("px", "")) * this.ratio;
 
@@ -1075,6 +1150,11 @@ export class Annotator {
     // Keep the proportional wrap budget in sync with the new width
     // before the re-wrap (updateCharsAtLine triggers calculateLines once).
     if (this.proportional) {
+      if (ratioChanged) {
+        // Prefix widths are measured in device px off the font string, so they
+        // belong to the ratio they were built at.
+        this.text.setMeasurer(new CanvasMeasurer(this.ctx, this.font), this.width);
+      }
       this.text.maxPixelWidth = this.width;
     }
     this.text.updateCharsAtLine(charsAtLine);
@@ -1958,6 +2038,8 @@ export class Annotator {
     document.removeEventListener("mousemove", this.onDocumentSelectMove);
     document.removeEventListener("mouseup", this.onDocumentSelectUp);
 
+    this.unwatchDevicePixelRatio();
+
     this.element.onwheel = null;
     this.element.onmousedown = null;
     this.element.onkeydown = null;
@@ -2215,6 +2297,12 @@ export class Annotator {
    * @param e
    */
   onWheel(e: WheelEvent) {
+    // A trackpad pinch and ctrl+wheel both arrive as wheel events with ctrlKey
+    // set; the browser turns them into page zoom only if the default runs.
+    if (e.ctrlKey || e.metaKey) {
+      return;
+    }
+
     const deltaBufferPx = e.deltaY * this.ratio;
     this.viewport.addScrollOffset(deltaBufferPx, this.lineHeight, this.scrollExtentLineCount());
 

--- a/packages/annotator/src/lib/Annotator.ts
+++ b/packages/annotator/src/lib/Annotator.ts
@@ -1172,7 +1172,7 @@ export class Annotator {
       if (ratioChanged) {
         // Prefix widths are measured in device px off the font string, so they
         // belong to the ratio they were built at.
-        this.text.setMeasurer(new CanvasMeasurer(this.ctx, this.font), this.width);
+        this.text.setMeasurer(this.measurerForFont(), this.width);
       }
       this.text.maxPixelWidth = this.width;
     }
@@ -1285,6 +1285,24 @@ export class Annotator {
   }
 
   /**
+   * The current font's CanvasMeasurer, one instance per font string. Segment
+   * wrap memoization keys on measurer identity ({@link Text}.wrappedFor), so a
+   * fresh instance forces a full re-wrap even when no wrap input moved — e.g.
+   * a line-spacing change. Reuse also keeps the per-string width cache warm.
+   */
+  private measurerCache?: { font: string; measurer: CanvasMeasurer };
+
+  private measurerForFont(): CanvasMeasurer {
+    if (this.measurerCache?.font !== this.font) {
+      this.measurerCache = {
+        font: this.font,
+        measurer: new CanvasMeasurer(this.ctx, this.font),
+      };
+    }
+    return this.measurerCache.measurer;
+  }
+
+  /**
    * Re-derive everything that depends on the font (string, line height, average
    * char width, char budget, viewport rows, measurer) after a font/mode change,
    * preserving the caret through the re-wrap, then redraw. Shared by
@@ -1312,7 +1330,7 @@ export class Annotator {
     this.text.paragraphIndent = this.paragraphIndentUnits();
     // Rebuild (or clear) the prefix tables for the new font; recalculates lines.
     this.text.setMeasurer(
-      this.proportional ? new CanvasMeasurer(this.ctx, this.font) : undefined,
+      this.proportional ? this.measurerForFont() : undefined,
       this.proportional ? this.width : undefined
     );
 

--- a/packages/annotator/src/lib/Annotator.ts
+++ b/packages/annotator/src/lib/Annotator.ts
@@ -12,6 +12,7 @@ import {
   HighlightMode,
   HOVER_DEBOUNCE_MS,
   LIGHT_MENU_COLORS,
+  DEFAULT_CARET_WIDTH_PX,
   DEFAULT_LINE_HEIGHT_RATIO,
   MenuColors,
   PARAGRAPH_INDENT_DEFAULT,
@@ -151,7 +152,7 @@ export interface DrawingOptions {
   lineHeight: number;
   charsAtLine: number;
   color?: string; // override
-  caretWidth?: number; // collapsed-caret width in device px (defaults to 1)
+  caretWidth?: number; // collapsed-caret width in device px (drawing fallback: 1)
   caretOpacity?: number; // collapsed-caret alpha (defaults to 1); block caret uses 0.5 so the letter under it stays readable
   caretVisible?: boolean; // blink phase: skip painting the collapsed caret when false (#3092)
   /**
@@ -223,17 +224,25 @@ export class Annotator {
 
   charWidth: number = 0;
   /**
-   * Proportional feature flag (default off). When on, the rendered font switches
-   * to a proportional family and text layout, draw (caret/selection rects),
+   * Proportional text flag. When on, the rendered font switches to a
+   * proportional family and text layout, draw (caret/selection rects),
    * wrapping, mouse hit-test, drag handles, and vertical goal-column all use
    * measured glyph widths via a CanvasMeasurer instead of the monospace grid.
    *
-   * Functionally complete, verified by the proportional test suites. Exposed to
-   * users as an OPT-IN (the client's font toggle calls {@link setProportional});
-   * the annotator default stays monospace. Flipping the default ON for everyone
-   * is the one deliberately-not-done step.
+   * The bare library defaults to monospace (tests and the standalone demo
+   * depend on the fixed grid). A HOSTED annotator defaults to proportional:
+   * {@link setFontFamilyOptions} — the host handing over its font — adopts
+   * proportional for users with no stored `proportional` choice. A stored
+   * setting, either value, always wins.
    */
   proportional: boolean = false;
+
+  /**
+   * Whether loadSettings found an explicit stored `proportional` value. Guards
+   * the proportional-by-default adoption in {@link setFontFamilyOptions} so an
+   * explicit monospace choice survives new sessions.
+   */
+  private hasStoredProportionalChoice = false;
 
   /**
    * Line height as a multiple of the font size (a CSS unitless line-height).
@@ -346,7 +355,7 @@ export class Annotator {
   } | null = null;
 
   /** Collapsed-caret width in CSS px (scaled by ratio at draw time). */
-  private caretWidth = 1;
+  private caretWidth = DEFAULT_CARET_WIDTH_PX;
 
   /**
    * Block (full char-cell) caret intent. Monospace-only: the caret spans the
@@ -510,6 +519,8 @@ export class Annotator {
     this.lineHeight = this.lineHeightForSize(this.fontSize);
 
     this.ctx = ctx;
+    // Before the first measureText: measurement and paint must share one shaping mode.
+    this.disableTextShaping();
     this.width = Number(this.element.style.width.replace("px", "")) * this.ratio;
     this.height = Number(this.element.style.height.replace("px", "")) * this.ratio;
 
@@ -1366,16 +1377,31 @@ export class Annotator {
    * Host-supplied font-family options shown in the Options-modal dropdown. When
    * the user hasn't chosen a family yet (still the built-in fallback), default to
    * the first option so the picker shows a valid value matching the host font.
+   *
+   * Handing over a font also opts the instance into proportional-by-default: a
+   * hosted annotator renders prose, and the host font (e.g. Roboto) is the
+   * reading face. Only users with no stored `proportional` choice are switched;
+   * the adoption itself is not persisted, so it keeps applying (or a future
+   * default keeps applying) until the user picks something explicitly.
    */
   setFontFamilyOptions(options: { label: string; value: string }[]) {
     this.fontFamilyOptions = options;
-    if (options.length > 0 && this.proportionalFontFamily === PROPORTIONAL_FONT) {
+    if (options.length === 0) {
+      return;
+    }
+    let rebuild = false;
+    if (!this.hasStoredProportionalChoice && !this.proportional) {
+      this.proportional = true; // hosted default; deliberately not persisted
+      rebuild = true;
+    }
+    if (this.proportionalFontFamily === PROPORTIONAL_FONT) {
       this.proportionalFontFamily = options[0].value;
-      // If proportional is already active, the rendered font + measurer were
-      // built from the old (fallback) family — rebuild them for the new default.
-      if (this.proportional) {
-        this.applyFontChange();
-      }
+      // An already-proportional instance has its rendered font + measurer
+      // built from the fallback family — they must follow the new default.
+      rebuild = rebuild || this.proportional;
+    }
+    if (rebuild) {
+      this.applyFontChange();
     }
   }
 
@@ -1469,6 +1495,29 @@ export class Annotator {
     this.ctx.font = this.font;
     const textW = this.ctx.measureText(txt).width;
     this.charWidth = textW / txt.length;
+  }
+
+  /**
+   * Turn off kerning and ligatures on the canvas. The proportional caret math
+   * is additive — per-code-unit widths summed into prefix tables — while a line
+   * is painted with one whole-run fillText; any cross-glyph shaping makes the
+   * painted line narrower than the table says and the caret drifts into the
+   * following glyph. With shaping off, both sides use plain advance widths and
+   * agree exactly. Browsers without these flags keep the (small) drift.
+   * Re-applied every frame because ctx.reset() restores the defaults.
+   */
+  private disableTextShaping(): void {
+    const ctx = this.ctx as CanvasRenderingContext2D & {
+      fontKerning?: string;
+      textRendering?: string;
+    };
+    if ("fontKerning" in ctx) {
+      ctx.fontKerning = "none";
+    }
+    // optimizeSpeed also disables ligatures (fi/fl), which fontKerning cannot.
+    if ("textRendering" in ctx) {
+      ctx.textRendering = "optimizeSpeed";
+    }
   }
 
   /**
@@ -3025,6 +3074,8 @@ export class Annotator {
     this.syncLineNumbersCanvasToMain();
 
     this.ctx.reset();
+    // reset() clears the shaping flags along with everything else.
+    this.disableTextShaping();
 
     this.ctx.fillStyle = this.bgColor;
     this.ctx.fillRect(0, 0, this.width, this.height);
@@ -3477,6 +3528,7 @@ export class Annotator {
     }
     if (typeof parsed.proportional === "boolean") {
       this.proportional = parsed.proportional;
+      this.hasStoredProportionalChoice = true;
       fontChanged = true;
     }
     if (fontChanged) {
@@ -3486,7 +3538,7 @@ export class Annotator {
 
   /** Reset all persisted settings to their defaults, clear storage, and redraw. */
   resetSettings(): void {
-    this.caretWidth = 1;
+    this.caretWidth = DEFAULT_CARET_WIDTH_PX;
     this.caretBlock = false;
     this.highlightColor = undefined;
     // Revert the highlight color to the host theme color (last setSelectStyle).
@@ -3496,8 +3548,10 @@ export class Annotator {
     this.fps = 0;
     this.showParagraphMarks = false;
     this.paragraphIndent = PARAGRAPH_INDENT_DEFAULT;
-    // Font settings back to defaults (#2487).
-    this.proportional = false;
+    // Font settings back to defaults (#2487): hosted instances (font options
+    // supplied) default to proportional, the bare library to monospace.
+    this.proportional = this.fontFamilyOptions.length > 0;
+    this.hasStoredProportionalChoice = false;
     this.fontSize = DEFAULT_FONT_SIZE;
     this.lineHeightRatio = DEFAULT_LINE_HEIGHT_RATIO;
     // Default to the first host-supplied option (e.g. "Roboto (app sans)") so the
@@ -3513,7 +3567,7 @@ export class Annotator {
       // ignore storage errors
     }
 
-    // Re-derive font/layout to the monospace defaults and redraw.
+    // Re-derive font/layout to the defaults and redraw.
     this.applyFontChange();
   }
 

--- a/packages/annotator/src/lib/Annotator.ts
+++ b/packages/annotator/src/lib/Annotator.ts
@@ -12,7 +12,7 @@ import {
   HighlightMode,
   HOVER_DEBOUNCE_MS,
   LIGHT_MENU_COLORS,
-  LINE_HEIGHT,
+  DEFAULT_LINE_HEIGHT_RATIO,
   MenuColors,
   PARAGRAPH_INDENT_DEFAULT,
   PARAGRAPH_INDENT_EM,
@@ -140,6 +140,7 @@ interface PersistedSettings {
   proportional?: boolean;
   fontFamily?: string;
   fontSize?: number;
+  lineHeightRatio?: number;
   showParagraphMarks?: boolean;
   paragraphIndent?: boolean;
 }
@@ -233,7 +234,14 @@ export class Annotator {
    * is the one deliberately-not-done step.
    */
   proportional: boolean = false;
-  lineHeight: number = LINE_HEIGHT;
+
+  /**
+   * Line height as a multiple of the font size (a CSS unitless line-height).
+   * User-adjustable via the settings overlay; persisted.
+   */
+  lineHeightRatio: number = DEFAULT_LINE_HEIGHT_RATIO;
+  /** Row height in device px; every visual line occupies exactly this much. */
+  lineHeight: number;
 
   inputText: string = "";
 
@@ -1260,9 +1268,9 @@ export class Annotator {
     return `${this.fontSize * this.ratio}px ${family}`;
   }
 
-  /** Line height (device px) scaled with the font size off the LINE_HEIGHT base. */
+  /** Line height (device px): font size × the user-adjustable spacing multiple. */
   private lineHeightForSize(size: number): number {
-    return LINE_HEIGHT * (size / DEFAULT_FONT_SIZE) * this.ratio;
+    return size * this.lineHeightRatio * this.ratio;
   }
 
   /**
@@ -1339,6 +1347,17 @@ export class Annotator {
   /** Set the logical font size in CSS px; scales line height. Persisted. */
   setFontSize(px: number) {
     this.fontSize = Math.max(1, px);
+    this.applyFontChange();
+    this.saveSettings();
+  }
+
+  /**
+   * Set the line spacing as a multiple of the font size (a CSS unitless
+   * line-height). Values below 1 would overlap the fixed line grid, so they
+   * are clamped. Persisted.
+   */
+  setLineHeightRatio(ratio: number) {
+    this.lineHeightRatio = Math.max(1, ratio);
     this.applyFontChange();
     this.saveSettings();
   }
@@ -2233,6 +2252,22 @@ export class Annotator {
         ],
         value: this.fontSize,
         onChange: (px) => this.setFontSize(px),
+      },
+      {
+        type: "segmented",
+        label: "Line spacing",
+        // Multiples of the font size (not of the font's own line box, which is
+        // what word processors scale — their "1.15" is ≈1.4 here). Word labels
+        // sidestep that mismatch. Anchor markers and underlines draw inside the
+        // row box, so nothing tighter than Compact is offered. "Normal" is
+        // 23/13, the historical fixed grid.
+        options: [
+          { label: "Compact", value: 1.4 },
+          { label: "Normal", value: DEFAULT_LINE_HEIGHT_RATIO },
+          { label: "Wide", value: 2.1 },
+        ],
+        value: this.lineHeightRatio,
+        onChange: (v) => this.setLineHeightRatio(v),
       },
       {
         type: "segmented",
@@ -3432,6 +3467,10 @@ export class Annotator {
       this.fontSize = Math.max(1, parsed.fontSize);
       fontChanged = true;
     }
+    if (typeof parsed.lineHeightRatio === "number") {
+      this.lineHeightRatio = Math.max(1, parsed.lineHeightRatio);
+      fontChanged = true;
+    }
     if (typeof parsed.fontFamily === "string") {
       this.proportionalFontFamily = parsed.fontFamily;
       fontChanged = true;
@@ -3460,6 +3499,7 @@ export class Annotator {
     // Font settings back to defaults (#2487).
     this.proportional = false;
     this.fontSize = DEFAULT_FONT_SIZE;
+    this.lineHeightRatio = DEFAULT_LINE_HEIGHT_RATIO;
     // Default to the first host-supplied option (e.g. "Roboto (app sans)") so the
     // picker shows a valid value; fall back to the generic when none supplied.
     this.proportionalFontFamily =
@@ -3491,6 +3531,7 @@ export class Annotator {
         proportional: this.proportional,
         fontFamily: this.proportionalFontFamily,
         fontSize: this.fontSize,
+        lineHeightRatio: this.lineHeightRatio,
         showParagraphMarks: this.showParagraphMarks,
         paragraphIndent: this.paragraphIndent,
       };

--- a/packages/annotator/src/lib/Lines.ts
+++ b/packages/annotator/src/lib/Lines.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_FONT, DEFAULT_FONT_SIZE, LINE_HEIGHT } from "./constants";
+import { DEFAULT_FONT, DEFAULT_FONT_SIZE } from "./constants";
 import Viewport from "./Viewport";
 
 /**
@@ -10,14 +10,15 @@ export class Lines {
   // cached canvas contex
   ctx: CanvasRenderingContext2D;
 
-  // TODO: different font, different sizes
-  font: string = `${DEFAULT_FONT_SIZE}px ${DEFAULT_FONT}`;
+  // font and lineHeight are seeded in the constructor and then re-copied from
+  // the owning Annotator on every draw() — the Annotator's values are the truth.
+  font: string;
   fontColor: string = "black";
 
   bgColor: string = "white";
 
   charWidth: number = 0;
-  lineHeight: number = LINE_HEIGHT;
+  lineHeight: number;
   ratio: number = 1;
 
   // size for virtual area inside the canvas element
@@ -44,7 +45,7 @@ export class Lines {
     this.fontColor = this.element.style.color || "black";
 
     this.charWidth = charWidth;
-    // Buffer-space line height (LINE_HEIGHT * ratio), same as Annotator.
+    // Buffer-space line height (device px), same value the Annotator draws with.
     this.lineHeight = lineHeight;
     this.font = `${DEFAULT_FONT_SIZE * ratio}px ${DEFAULT_FONT}`;
   }

--- a/packages/annotator/src/lib/Text.ts
+++ b/packages/annotator/src/lib/Text.ts
@@ -249,9 +249,10 @@ export class Segment {
    * edit cost one paragraph's wrap instead of the whole document's
    * (see {@link Text.calculateLines}).
    *
-   * String fields compare by identity: an edit replaces the segment's strings,
-   * so an untouched segment still holds the exact objects recorded here, and
-   * the check never scans text.
+   * The string fields make this cheap: an untouched segment still holds the
+   * exact string objects recorded here, which === resolves by reference before
+   * looking at characters. Only the edited segment's strings are actually
+   * walked, and that cost is bounded by the one paragraph.
    */
   wrappedFor?: {
     text: string;
@@ -1834,8 +1835,6 @@ class Text {
       return;
     }
 
-    this.dirtySegment = segmentPos.segmentIndex;
-
     let indexPos = segmentPos.rawTextIndex;
     for (let i = 0; i < segmentPos.segmentIndex; i++) {
       indexPos++; // each segment should receive +1 character no matter what (newline)
@@ -1848,6 +1847,8 @@ class Text {
     if (deleteAt < 0 || deleteAt >= this.value.length) {
       return; // document edge — nothing on that side to delete
     }
+
+    this.dirtySegment = segmentPos.segmentIndex;
     this.value =
       this.value.slice(0, deleteAt) + this.value.slice(deleteAt + 1);
 

--- a/packages/annotator/src/lib/Text.ts
+++ b/packages/annotator/src/lib/Text.ts
@@ -36,7 +36,9 @@ export class Tag {
   readonly position: number; // raw position in segment text
   readonly relativeParsedPosition: number; // relative position in parsed segment text
   readonly closing?: boolean;
-  readonly segmentIndex: number; // index of the segment containing this tag
+  // Index of the segment containing this tag. Written by Text.prepareSegments
+  // when segment reuse shifts the segment (and its tags) to a new position.
+  segmentIndex: number;
 
   private tagContent: string; // div id="12"
   attributes: Record<string, string>;
@@ -240,6 +242,26 @@ export class Segment {
    * width cap) the segment's lines were wrapped against.
    */
   indent: number = 0;
+  /**
+   * The inputs {@link lines} (and {@link linePrefixes}, {@link indent}) were
+   * computed from. While every field still matches, a recalc keeps the wrapped
+   * lines and only renumbers the segment's line range — this is what makes an
+   * edit cost one paragraph's wrap instead of the whole document's
+   * (see {@link Text.calculateLines}).
+   *
+   * String fields compare by identity: an edit replaces the segment's strings,
+   * so an untouched segment still holds the exact objects recorded here, and
+   * the check never scans text.
+   */
+  wrappedFor?: {
+    text: string;
+    parsed: string;
+    isFirst: boolean;
+    mode: EditMode;
+    budget: number;
+    paragraphIndent: number;
+    measurer?: TextMeasurer;
+  };
   segmentIndex: number = -1; // index of this segment in the text
 
   /**
@@ -631,12 +653,54 @@ class Text {
    * This method is called when the text content changes.
    */
   prepareSegments() {
-    const segmentsArray = this.value.split("\n");
-    const segments: Segment[] = [];
+    const parts = this.value.split("\n");
+    const old = this.segments;
 
-    for (let i = 0; i < segmentsArray.length; i++) {
-      const segmentText = segmentsArray[i];
-      segments.push(new Segment(segmentText, i));
+    // An edit leaves every paragraph before and after it untouched, so the old
+    // segment objects are reused for the longest matching head and tail and only
+    // the middle is re-parsed. Reuse carries each segment's raw/parsed string
+    // objects along, which is what lets calculateLines keep its wrapped lines
+    // (see Segment.wrappedFor). The scans compare strings, but unequal ones
+    // diverge within a paragraph, so only the reused text is ever fully read.
+    let head = 0;
+    const shared = Math.min(parts.length, old.length);
+    while (head < shared && old[head].raw === parts[head]) {
+      head++;
+    }
+    let tail = 0;
+    const maxTail = shared - head;
+    while (
+      tail < maxTail &&
+      old[old.length - 1 - tail].raw === parts[parts.length - 1 - tail]
+    ) {
+      tail++;
+    }
+
+    const segments: Segment[] = new Array(parts.length);
+    for (let i = 0; i < head; i++) {
+      segments[i] = old[i];
+    }
+    for (let i = parts.length - tail; i < parts.length; i++) {
+      segments[i] = old[old.length - parts.length + i];
+    }
+    for (let i = head; i < parts.length - tail; i++) {
+      segments[i] = new Segment(parts[i], i);
+    }
+
+    // A reused tail segment may sit at a shifted index. Tags carry their own
+    // copy of it (getAbsoluteTagPosition sums the segments before theirs), so
+    // they are restamped together.
+    for (let i = 0; i < segments.length; i++) {
+      const segment = segments[i];
+      if (segment.segmentIndex !== i) {
+        segment.segmentIndex = i;
+        for (const tag of segment.openingTags) {
+          tag.segmentIndex = i;
+        }
+        for (const tag of segment.closingTags) {
+          tag.segmentIndex = i;
+        }
+      }
     }
 
     this.segments = segments;
@@ -716,12 +780,32 @@ class Text {
         segmentIndex === 0
           ? 0
           : this.segments[segmentIndex - 1].lineEndExclusive;
-      segment.lines = [];
 
       let text = segment.raw;
       if (this.mode === EditMode.HIGHLIGHT || this.mode === EditMode.SEMI) {
         text = segment.parsed;
       }
+
+      // The segment's lines are a pure function of these inputs; while all of
+      // them match the recorded ones, the wrap (and the prefix tables built
+      // from it) is kept and only the line numbering above moves. `parsed` is
+      // an input even in RAW mode — indentForSegment reads it — but it never
+      // changes without `raw` changing alongside.
+      const cached = segment.wrappedFor;
+      if (
+        cached &&
+        cached.text === text &&
+        cached.parsed === segment.parsed &&
+        cached.isFirst === (segment.segmentIndex === 0) &&
+        cached.mode === this.mode &&
+        cached.budget === maxWidth &&
+        cached.paragraphIndent === this.paragraphIndent &&
+        cached.measurer === measurer
+      ) {
+        segment.lineEndExclusive = segment.lineStart + segment.lines.length;
+        continue;
+      }
+      segment.lines = [];
 
       // Word wrapping like a normal text editor (issues #2780 / follow-up).
       //
@@ -860,6 +944,16 @@ class Text {
       segment.linePrefixes = measurer
         ? segment.lines.map((line) => buildPrefixWidths(line, measurer))
         : [];
+
+      segment.wrappedFor = {
+        text,
+        parsed: segment.parsed,
+        isFirst: segment.segmentIndex === 0,
+        mode: this.mode,
+        budget: maxWidth,
+        paragraphIndent: this.paragraphIndent,
+        measurer,
+      };
     }
 
     this.noLines = this.segments.reduce<number>(
@@ -1748,13 +1842,24 @@ class Text {
       indexPos += this.segments[i].raw.length;
     }
 
-    this.value = this.value.slice(0, indexPos - 1) + this.value.slice(indexPos);
+    // The character removed from {@link value}: the one before the cursor going
+    // backward (Backspace), the one under it going forward (Delete).
+    const deleteAt = forwardChar ? indexPos : indexPos - 1;
+    if (deleteAt < 0 || deleteAt >= this.value.length) {
+      return; // document edge — nothing on that side to delete
+    }
+    this.value =
+      this.value.slice(0, deleteAt) + this.value.slice(deleteAt + 1);
 
     const segment = this.segments[segmentPos.segmentIndex];
 
-    if (!segment.raw) {
-      this.prepareSegments();
-    } else if (segmentPos.rawTextIndex) {
+    // A delete landing inside the segment's own text is spliced in place; one
+    // landing on a boundary newline joins two segments, so the segment list is
+    // re-split from the updated value.
+    const inSegment = forwardChar
+      ? segmentPos.rawTextIndex < segment.raw.length
+      : segmentPos.rawTextIndex > 0;
+    if (inSegment) {
       const xAlterPos = segmentPos.rawTextIndex - (forwardChar ? 0 : 1);
       segment.raw =
         segment.raw.slice(0, xAlterPos) + segment.raw.slice(xAlterPos + 1);

--- a/packages/annotator/src/lib/constants.ts
+++ b/packages/annotator/src/lib/constants.ts
@@ -24,10 +24,17 @@ export enum HighlightMode {
 }
 /**
  * Line height as a multiple of the font size (a CSS unitless line-height; for
- * scale: Google Docs defaults to 1.15, CSS `normal` is ~1.2). 23/13 keeps the
- * historical fixed 23px grid at the default 13px font.
+ * scale: Google Docs defaults to 1.15, CSS `normal` is ~1.2). 23/13 is the
+ * ratio of the historical fixed grid (23px lines, 13px font).
  */
 export const DEFAULT_LINE_HEIGHT_RATIO = 23 / 13;
+
+/**
+ * Collapsed-caret width in CSS px. 2px (the Docs/VS Code convention) rather
+ * than the native 1px: the caret must stay findable over the colored anchor
+ * highlights and hover fades this canvas paints behind the text.
+ */
+export const DEFAULT_CARET_WIDTH_PX = 2;
 
 /** Extra empty rows after the last text line; scrollable, no line numbers in the gutter. */
 export const VIEWPORT_END_BUFFER_ROWS = 3;
@@ -45,7 +52,8 @@ export const VIEWPORT_END_BUFFER_ROWS = 3;
  * a hit has to be scrolled clear of, so one distance serves both.
  */
 export const VIEWPORT_START_BUFFER_ROWS = 2;
-export const DEFAULT_FONT_SIZE = 13;
+/** Logical font size in CSS px (one of the sizes the settings overlay offers). */
+export const DEFAULT_FONT_SIZE = 14;
 export const DEFAULT_FONT = '"Roboto Mono", monospace';
 /**
  * Fallback font family used when proportional mode is enabled without

--- a/packages/annotator/src/lib/constants.ts
+++ b/packages/annotator/src/lib/constants.ts
@@ -22,7 +22,12 @@ export enum HighlightMode {
    */
   ANCHOR = "anchor",
 }
-export const LINE_HEIGHT = 23;
+/**
+ * Line height as a multiple of the font size (a CSS unitless line-height; for
+ * scale: Google Docs defaults to 1.15, CSS `normal` is ~1.2). 23/13 keeps the
+ * historical fixed 23px grid at the default 13px font.
+ */
+export const DEFAULT_LINE_HEIGHT_RATIO = 23 / 13;
 
 /** Extra empty rows after the last text line; scrollable, no line numbers in the gutter. */
 export const VIEWPORT_END_BUFFER_ROWS = 3;
@@ -91,7 +96,7 @@ export const DARK_MENU_COLORS: MenuColors = {
  * soft wrap. Left-aligned text gives no signal which of the two a line break is,
  * so the first visual line of each paragraph is indented; the wrapped
  * continuations stay flush left and the contrast marks the boundary. The
- * renderer draws on a fixed line grid (one {@link LINE_HEIGHT} per visual line,
+ * renderer draws on a fixed line grid (one line height per visual line,
  * relied on by scrolling, hit-testing and the gutter), so the horizontal axis is
  * where a paragraph can be marked without paying for variable line boxes.
  */

--- a/packages/annotator/src/wrapMemoization.test.ts
+++ b/packages/annotator/src/wrapMemoization.test.ts
@@ -1,0 +1,285 @@
+/**
+ * Segment-level wrap memoization in Text.calculateLines.
+ *
+ * Every edit funnels into calculateLines, which used to re-tokenize and re-wrap
+ * every paragraph of the document; on a large document that made each keystroke
+ * pay for thousands of untouched paragraphs. A segment now keeps its wrapped
+ * lines as long as none of the inputs that shaped them changed, and a recalc
+ * only renumbers its line range. These tests pin down both halves: clean
+ * segments are reused (by array identity), and every input that must invalidate
+ * the cache does.
+ */
+import Text from "./lib/Text";
+import Viewport from "./lib/Viewport";
+import { TextMeasurer } from "./lib/TextMeasurer";
+import { EditMode } from "./lib/constants";
+
+const VP = new Viewport(0, 40);
+const at = (xLine: number, yLine: number) => ({ xLine, yLine });
+
+const mkText = (value: string, charsAtLine = 20, mode = EditMode.RAW): Text => {
+  const t = new Text(value, charsAtLine);
+  t.mode = mode;
+  return t;
+};
+
+/** Every per-segment output a rebuild-from-scratch must agree on. */
+const layoutOf = (t: Text) =>
+  t.segments.map((s) => ({
+    lines: s.lines,
+    lineStart: s.lineStart,
+    lineEndExclusive: s.lineEndExclusive,
+    indent: s.indent,
+    // Absolute tag positions exercise Tag.segmentIndex, which segment reuse
+    // must restamp when a segment's position shifts.
+    tags: [...s.openingTags, ...s.closingTags].map((tag) =>
+      tag.getAbsoluteTagPosition(t.segments)
+    ),
+  }));
+
+/** A fresh Text wrapped from the same document under the same settings. */
+const rebuilt = (t: Text): Text => {
+  const fresh = new Text(t.value, t.charsAtLine);
+  fresh.mode = t.mode;
+  fresh.setParagraphIndent(t.paragraphIndent);
+  return fresh;
+};
+
+const expectSameLayout = (t: Text) => {
+  const fresh = rebuilt(t);
+  expect(t.noLines).toBe(fresh.noLines);
+  expect(layoutOf(t)).toEqual(layoutOf(fresh));
+};
+
+describe("reuse of untouched segments", () => {
+  test("an edit re-wraps only the edited paragraph", () => {
+    const t = mkText("first paragraph\nsecond one\nthird paragraph here");
+    const [before0, before1, before2] = t.segments.map((s) => s.lines);
+
+    t.insertText(VP, at(0, 0), "x");
+
+    expect(t.segments[0].lines).not.toBe(before0);
+    expect(t.segments[1].lines).toBe(before1);
+    expect(t.segments[2].lines).toBe(before2);
+    expectSameLayout(t);
+  });
+
+  test("a recalc with nothing changed reuses every segment", () => {
+    const t = mkText("first paragraph\nsecond one");
+    const before = t.segments.map((s) => s.lines);
+
+    t.calculateLines();
+
+    t.segments.forEach((s, i) => expect(s.lines).toBe(before[i]));
+  });
+
+  test("segments after a growing edit are renumbered, not re-wrapped", () => {
+    const t = mkText("aa\n" + "word ".repeat(6).trim() + "\nlast");
+    const lastLines = t.segments[2].lines;
+    const lastStartBefore = t.segments[2].lineStart;
+
+    // Enough text to wrap the middle paragraph onto more visual lines.
+    t.insertText(VP, at(0, t.segments[1].lineStart), "growing ".repeat(4));
+
+    expect(t.segments[2].lines).toBe(lastLines);
+    expect(t.segments[2].lineStart).toBeGreaterThan(lastStartBefore);
+    expectSameLayout(t);
+  });
+
+  test("deleting a character re-wraps only its paragraph", () => {
+    const t = mkText("first paragraph\nsecond one\nthird");
+    const before2 = t.segments[2].lines;
+
+    t.deleteTextChar(VP, at(3, t.segments[1].lineStart));
+
+    expect(t.segments[2].lines).toBe(before2);
+    expectSameLayout(t);
+  });
+
+  test("a range delete keeps the paragraphs around it", () => {
+    // Backspace and Delete both route through deleteRangeText, which re-splits
+    // the whole segment list; the untouched head and tail must survive it.
+    const t = mkText("first paragraph\nsecond one\nthird paragraph");
+    const [before0, , before2] = t.segments.map((s) => s.lines);
+
+    const y = t.segments[1].lineStart;
+    t.deleteRangeText(at(3, y), at(4, y));
+
+    expect(t.segments[0].lines).toBe(before0);
+    expect(t.segments[2].lines).toBe(before2);
+    expectSameLayout(t);
+  });
+
+  test("removing a whole paragraph reuses and renumbers the ones below", () => {
+    const t = mkText("first\n<t1>tagged</t1>\nthird\nfourth");
+    const thirdLines = t.segments[2].lines;
+
+    // Delete "first\n" — every later segment shifts up one position.
+    t.deleteRangeText(at(0, 0), at(0, 1));
+
+    // The paragraph that landed on position 0 changes indent eligibility, so it
+    // alone re-wraps; the ones below shift index but keep their wrapped lines.
+    expect(t.segments[1].lines).toBe(thirdLines);
+    expect(t.segments[0].segmentIndex).toBe(0);
+    expect(t.segments[0].openingTags[0].getAbsoluteTagPosition(t.segments)).toBe(0);
+    expectSameLayout(t);
+  });
+});
+
+describe("invalidation", () => {
+  test("a width change re-wraps every segment", () => {
+    const t = mkText("one two three four five\nsix seven eight");
+    t.updateCharsAtLine(10);
+    expectSameLayout(t);
+    // And the content actually moved: narrower budget, more lines.
+    expect(t.segments[0].lines.length).toBeGreaterThan(1);
+  });
+
+  test("a mode change re-wraps tagged segments", () => {
+    const t = mkText("<t1>tagged prose</t1> more words here", 12);
+    const rawLines = t.segments[0].lines;
+
+    t.mode = EditMode.HIGHLIGHT;
+    t.calculateLines();
+
+    // Tags are stripped from the wrap text in HIGHLIGHT, so the layout differs.
+    expect(t.segments[0].lines).not.toEqual(rawLines);
+    expectSameLayout(t);
+  });
+
+  test("a paragraph-indent change re-wraps and re-indents", () => {
+    const t = mkText("first\n" + "ab ".repeat(10).trim());
+    t.setParagraphIndent(6);
+    expect(t.segments[1].indent).toBe(5); // capped at a quarter of 20
+    expectSameLayout(t);
+
+    t.setParagraphIndent(0);
+    expect(t.segments[1].indent).toBe(0);
+    expectSameLayout(t);
+  });
+
+  test("a measurer change re-wraps and rebuilds prefix tables", () => {
+    const t = mkText("some words to wrap around\nsecond paragraph");
+    const wide: TextMeasurer = { measure: (s) => s.length * 10 };
+    const narrow: TextMeasurer = { measure: (s) => s.length * 20 };
+
+    t.setMeasurer(wide, 100);
+    const linesWide = t.segments[0].lines.slice();
+    expect(t.segments[0].linePrefixes.length).toBe(t.segments[0].lines.length);
+
+    t.setMeasurer(narrow, 100);
+    expect(t.segments[0].lines).not.toEqual(linesWide);
+
+    t.setMeasurer(undefined);
+    expect(t.segments[0].linePrefixes).toEqual([]);
+    expectSameLayout(t);
+  });
+
+  test("an unrelated edit keeps another segment's prefix tables", () => {
+    const t = mkText("first words\nsecond paragraph");
+    t.setMeasurer({ measure: (s) => s.length * 10 }, 80);
+    const prefixes1 = t.segments[1].linePrefixes;
+
+    t.insertText(VP, at(0, 0), "x");
+
+    expect(t.segments[1].linePrefixes).toBe(prefixes1);
+  });
+});
+
+describe("deleteTextChar keeps value and segments in sync", () => {
+  // The layout comparison against a rebuild from t.value only proves anything
+  // if every edit keeps value and segments telling the same story.
+  test("forward delete removes the character under the cursor", () => {
+    const t = mkText("abcdef");
+    t.deleteTextChar(VP, at(2, 0), true);
+    expect(t.segments[0].raw).toBe("abdef");
+    expect(t.value).toBe("abdef");
+  });
+
+  test("forward delete at the start of a line", () => {
+    const t = mkText("abc");
+    t.deleteTextChar(VP, at(0, 0), true);
+    expect(t.segments[0].raw).toBe("bc");
+    expect(t.value).toBe("bc");
+  });
+
+  test("forward delete at the end of a line joins the next paragraph", () => {
+    const t = mkText("ab\ncd");
+    t.deleteTextChar(VP, at(2, 0), true);
+    expect(t.value).toBe("abcd");
+    expect(t.segments.length).toBe(1);
+    expect(t.segments[0].raw).toBe("abcd");
+  });
+
+  test("deletes at the document edges are no-ops", () => {
+    const t = mkText("ab");
+    t.deleteTextChar(VP, at(0, 0), false); // Backspace at document start
+    t.deleteTextChar(VP, at(2, 0), true); // Delete at document end
+    expect(t.value).toBe("ab");
+    expect(t.segments[0].raw).toBe("ab");
+  });
+});
+
+describe("random edit sequences match a from-scratch rebuild", () => {
+  // Deterministic PRNG so a failure reproduces.
+  let seed = 987654321;
+  const rnd = () => {
+    seed = (seed * 1103515245 + 12345) & 0x7fffffff;
+    return seed / 0x7fffffff;
+  };
+  const pick = <T>(xs: T[]): T => xs[Math.floor(rnd() * xs.length)];
+
+  test("200 mixed operations", () => {
+    const t = mkText(
+      "opening paragraph with some words\n" +
+        "<t1>a tagged paragraph</t1> follows\n" +
+        "third one wraps over the narrow budget for sure\n" +
+        "\n" +
+        "last paragraph"
+    );
+    t.setParagraphIndent(4);
+
+    const randomSpot = () => {
+      const yLine = Math.floor(rnd() * t.noLines);
+      const len = t.getLine(yLine).length;
+      return at(Math.floor(rnd() * (len + 1)), yLine);
+    };
+
+    for (let op = 0; op < 200; op++) {
+      switch (pick(["insert", "insert", "delete", "range", "newline", "width", "mode", "indent"])) {
+        case "insert":
+          t.insertText(
+            VP,
+            randomSpot(),
+            pick(["x", "word and more", " ", "<t9>", "yz", "two\nparagraphs"])
+          );
+          break;
+        case "delete":
+          t.deleteTextChar(VP, randomSpot(), rnd() < 0.5);
+          break;
+        case "range": {
+          // The live deletion path (Backspace/Delete both route through it).
+          const a = randomSpot();
+          const b =
+            rnd() < 0.7 ? at(a.xLine + 1, a.yLine) : randomSpot();
+          t.deleteRangeText(a, t.clampVisual(b.xLine, b.yLine));
+          break;
+        }
+        case "newline":
+          t.insertNewline(VP, randomSpot());
+          break;
+        case "width":
+          t.updateCharsAtLine(pick([12, 20, 33]));
+          break;
+        case "mode":
+          t.mode = pick([EditMode.RAW, EditMode.HIGHLIGHT, EditMode.SEMI]);
+          t.calculateLines();
+          break;
+        case "indent":
+          t.setParagraphIndent(pick([0, 3, 6]));
+          break;
+      }
+      expectSameLayout(t);
+    }
+  });
+});

--- a/packages/annotator/src/wrapPerf.test.ts
+++ b/packages/annotator/src/wrapPerf.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Wrap performance on a large document — skipped unless `RUN_PERF=1` is set.
+ *
+ *   RUN_PERF=1 npx jest wrapPerf
+ *
+ * Timings flake on shared CI runners and this one builds a 1.4 MB document, so
+ * it stays out of the normal suite; it is here to be run by hand against a
+ * change to {@link Text.calculateLines} or {@link Text.prepareSegments}, whose
+ * cost is invisible to the functional tests — those pass just as well when an
+ * edit re-wraps the whole document as when it re-wraps one paragraph.
+ *
+ * Reference numbers (Apple M-series, Node 20), 4000-paragraph document:
+ *
+ *   | operation                         | full re-wrap | memoized |
+ *   | --------------------------------- | -----------: | -------: |
+ *   | type 1 char mid-document          |      27.2 ms |  0.19 ms |
+ *   | backspace (deleteRangeText)       |      30.2 ms |  0.42 ms |
+ *   | paste two paragraphs              |      61.6 ms |  0.82 ms |
+ *   | calculateLines, nothing changed   |      28.1 ms |  0.05 ms |
+ *
+ * Absolute values track the machine; the shape is what matters. An edit costs
+ * one paragraph's wrap, so growing PARAGRAPHS below should leave the per-edit
+ * numbers roughly flat. If they start scaling with document size again, segment
+ * reuse or the wrap cache stopped hitting.
+ */
+import Text from "./lib/Text";
+import Viewport from "./lib/Viewport";
+
+/** Words per paragraph × paragraph count ≈ a 200k-word document. */
+const WORDS_PER_PARAGRAPH = 50;
+const PARAGRAPHS = 4000;
+const CHARS_AT_LINE = 100;
+/** Wrap-budget units of paragraph first-line indent (#2076) to measure with. */
+const INDENT = 2;
+
+const VOCABULARY = [
+  "ds", "quod", "haereticus", "testis", "inquisitio", "de", "anno", "domini",
+  "villa", "dixit", "iuratus", "requisitus", "predicto", "eodem",
+];
+
+/** Deterministic word picker, so two runs measure the identical document. */
+const mkDocument = (): string => {
+  let seed = 12345;
+  const rnd = () => (seed = (seed * 1103515245 + 12345) & 0x7fffffff) / 0x7fffffff;
+  const paragraphs: string[] = [];
+  for (let p = 0; p < PARAGRAPHS; p++) {
+    const words: string[] = [];
+    for (let w = 0; w < WORDS_PER_PARAGRAPH; w++) {
+      words.push(VOCABULARY[Math.floor(rnd() * VOCABULARY.length)]);
+    }
+    paragraphs.push(words.join(" "));
+  }
+  return paragraphs.join("\n");
+};
+
+const median = (xs: number[]): number =>
+  xs.slice().sort((a, b) => a - b)[Math.floor(xs.length / 2)];
+
+const results: { operation: string; ms: number }[] = [];
+
+/** Time `fn` after letting the JIT warm up, and record the median. */
+const measure = (operation: string, iterations: number, fn: () => void) => {
+  for (let i = 0; i < 3; i++) fn();
+  const runs: number[] = [];
+  for (let i = 0; i < iterations; i++) {
+    const started = performance.now();
+    fn();
+    runs.push(performance.now() - started);
+  }
+  results.push({ operation, ms: median(runs) });
+};
+
+// process.env keeps this out of the default suite; describe.skip still type-checks
+// and still reports the tests as skipped rather than hiding them.
+const perfDescribe = process.env.RUN_PERF ? describe : describe.skip;
+
+perfDescribe("wrap performance on a large document", () => {
+  const viewport = new Viewport(0, 40);
+  let text: Text;
+  /** A line in the middle of the document — the worst case for any head scan. */
+  let midLine: number;
+
+  beforeAll(() => {
+    const value = mkDocument();
+    text = new Text(value, CHARS_AT_LINE);
+    text.setParagraphIndent(INDENT);
+    midLine = text.segments[Math.floor(PARAGRAPHS / 2)].lineStart;
+    console.log(
+      `document: ${value.length} chars, ${text.segments.length} paragraphs, ${text.noLines} visual lines`
+    );
+  });
+
+  afterAll(() => {
+    const width = Math.max(...results.map((r) => r.operation.length));
+    console.log(
+      results
+        .map((r) => `  ${r.operation.padEnd(width)}  ${r.ms.toFixed(3)} ms`)
+        .join("\n")
+    );
+  });
+
+  test("typing one character", () => {
+    measure("type 1 char mid-document", 30, () =>
+      text.insertText(viewport, { xLine: 1, yLine: midLine }, "x")
+    );
+  });
+
+  test("deleting one character", () => {
+    // The path both Backspace and Delete take (Keys routes them through it).
+    measure("backspace (deleteRangeText)", 30, () =>
+      text.deleteRangeText(
+        { xLine: 0, yLine: midLine },
+        { xLine: 1, yLine: midLine }
+      )
+    );
+  });
+
+  test("pasting two paragraphs", () => {
+    // Paste then undo the paste, so the document stays the same size across runs.
+    measure("paste two paragraphs", 20, () => {
+      text.insertText(
+        viewport,
+        { xLine: 0, yLine: midLine },
+        "pasted first\npasted second\n"
+      );
+      text.deleteRangeText(
+        { xLine: 0, yLine: midLine },
+        { xLine: 0, yLine: midLine + 2 }
+      );
+    });
+  });
+
+  test("a recalculation with nothing changed", () => {
+    measure("calculateLines, nothing changed", 20, () => text.calculateLines());
+  });
+});

--- a/packages/annotator/src/zoomAndPixelRatio.test.ts
+++ b/packages/annotator/src/zoomAndPixelRatio.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Browser zoom reaches the canvas two ways: as ctrl-modified wheel events (what
+ * a macOS trackpad pinch is delivered as), and as a devicePixelRatio change.
+ */
+import { Annotator } from "./lib/Annotator";
+
+const setDpr = (value: number) => {
+  Object.defineProperty(window, "devicePixelRatio", {
+    value,
+    configurable: true,
+    writable: true,
+  });
+};
+
+const mk = (ratio = 2): Annotator => {
+  const c = document.createElement("canvas");
+  c.style.width = "400px";
+  c.style.height = "600px";
+  document.body.appendChild(c);
+  return new Annotator(c, "foo bar baz qux quux corge grault garply", ratio);
+};
+
+const wheel = (init: Partial<WheelEvent>) => {
+  let defaultPrevented = false;
+  const e = {
+    deltaY: 100,
+    ctrlKey: false,
+    metaKey: false,
+    preventDefault: () => {
+      defaultPrevented = true;
+    },
+    ...init,
+  } as unknown as WheelEvent;
+  return { e, prevented: () => defaultPrevented };
+};
+
+describe("wheel zoom gestures", () => {
+  afterEach(() => setDpr(1));
+
+  test("a plain wheel scrolls and swallows the event", () => {
+    const a = mk();
+    const { e, prevented } = wheel({ deltaY: 120 });
+
+    a.onWheel(e);
+
+    expect(a.viewport.scrollOffsetY).toBeGreaterThan(0);
+    expect(prevented()).toBe(true);
+  });
+
+  test("ctrl+wheel (trackpad pinch) neither scrolls nor blocks page zoom", () => {
+    const a = mk();
+    const { e, prevented } = wheel({ deltaY: 120, ctrlKey: true });
+
+    a.onWheel(e);
+
+    expect(a.viewport.scrollOffsetY).toBe(0);
+    expect(prevented()).toBe(false);
+  });
+
+  test("meta+wheel is left to the browser too", () => {
+    const a = mk();
+    const { e, prevented } = wheel({ deltaY: 120, metaKey: true });
+
+    a.onWheel(e);
+
+    expect(a.viewport.scrollOffsetY).toBe(0);
+    expect(prevented()).toBe(false);
+  });
+});
+
+describe("device pixel ratio", () => {
+  afterEach(() => setDpr(1));
+
+  test("a DPR above the host's ratio raises the backing store on resize", () => {
+    const a = mk(2);
+    expect(a.ratio).toBe(2);
+    const fontAt2x = a.font;
+
+    setDpr(3);
+    a.resize();
+
+    expect(a.ratio).toBe(3);
+    expect(a.element.width).toBe(400 * 3);
+    expect(a.element.height).toBe(600 * 3);
+    expect(a.font).not.toBe(fontAt2x);
+    expect(a.cursor.ratio).toBe(3);
+  });
+
+  test("a DPR below the host's ratio leaves the supersampling alone", () => {
+    setDpr(1);
+    const a = mk(2);
+
+    a.resize();
+
+    expect(a.ratio).toBe(2);
+    expect(a.element.width).toBe(400 * 2);
+  });
+
+  test("the ratio in effect at construction already accounts for zoom", () => {
+    setDpr(4);
+    const a = mk(2);
+
+    expect(a.ratio).toBe(4);
+    expect(a.element.width).toBe(400 * 4);
+  });
+});

--- a/packages/client/src/components/advanced/DocumentTitle/DocumentTitle.tsx
+++ b/packages/client/src/components/advanced/DocumentTitle/DocumentTitle.tsx
@@ -2,23 +2,43 @@ import React, { useState } from "react";
 import { TiDocumentText } from "react-icons/ti";
 import { toast } from "react-toastify";
 import { Tooltip } from "../../basic/Tooltip/Tooltip";
-import { StyledDocumentTag, StyledDocumentTitle } from "./DocumentTitleStyles";
+import {
+  StyledDocumentTag,
+  StyledDocumentTitle,
+  StyledTitleHead,
+  StyledTitleTail,
+} from "./DocumentTitleStyles";
 
 interface DocumentTitle {
   title?: string;
   size?: "sm" | "md" | "lg";
   width?: number | "full";
   noMargin?: boolean;
+  /**
+   * Characters kept visible at the END of a truncated title (middle ellipsis:
+   * `Paolini_Ori…taBon_v2`). Document names often differ only in their suffix
+   * — volume, year, version — which plain end truncation hides. 0 restores end
+   * truncation. The full title stays on the tooltip and the copy click.
+   */
+  tailChars?: number;
 }
 export const DocumentTitle: React.FC<DocumentTitle> = ({
   title = "",
   size = "md",
   width = "full",
   noMargin = false,
+  tailChars = 7,
 }) => {
   const [referenceElement, setReferenceElement] = useState<HTMLDivElement | null>(null);
 
   const [isTooltipOpen, setIsTooltipOpen] = React.useState(false);
+
+  // A title barely longer than the tail would truncate to almost pure tail;
+  // keep such short titles whole (the head span alone end-ellipsizes them).
+  const splitAt = title.length > tailChars + 3 ? title.length - tailChars : title.length;
+  const head = title.slice(0, splitAt);
+  const tail = title.slice(splitAt);
+
   return (
     <React.Fragment>
       <StyledDocumentTag
@@ -35,7 +55,10 @@ export const DocumentTitle: React.FC<DocumentTitle> = ({
       >
         <TiDocumentText size={16} style={{ marginRight: "0.2rem", flexShrink: "0" }} />
 
-        <StyledDocumentTitle>{title}</StyledDocumentTitle>
+        <StyledDocumentTitle>
+          <StyledTitleHead>{head}</StyledTitleHead>
+          {tail && <StyledTitleTail>{tail}</StyledTitleTail>}
+        </StyledDocumentTitle>
       </StyledDocumentTag>
       <Tooltip label={title} visible={isTooltipOpen} referenceElement={referenceElement} />
     </React.Fragment>

--- a/packages/client/src/components/advanced/DocumentTitle/DocumentTitleStyles.tsx
+++ b/packages/client/src/components/advanced/DocumentTitle/DocumentTitleStyles.tsx
@@ -30,12 +30,40 @@ export const StyledDocumentTag = styled.div<{
   overflow: hidden !important;
 `;
 
+/**
+ * Middle ellipsis via two spans: the head carries the ellipsis and absorbs
+ * virtually all shrinkage (flex-shrink 999), so the tail — the distinctive
+ * suffix of a document name — stays effectively whole until the head is
+ * fully collapsed.
+ */
 export const StyledDocumentTitle = styled.div`
-  display: block;
+  display: flex;
   overflow: hidden !important;
-  white-space: nowrap;
-  text-overflow: ellipsis;
   min-width: 0;
 
   flex-shrink: 1;
+`;
+
+export const StyledTitleHead = styled.span`
+  flex: 0 999 auto;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  /* pre, not nowrap: a split can land beside a space, which nowrap would collapse */
+  white-space: pre;
+  /* Room for one character plus the "…" — a fully collapsed head would render
+     nothing and the tail alone would read as the complete title. */
+  min-width: 2ch;
+`;
+
+/*
+ * The tail's shrink share is a sub-pixel fraction (its scaled flex factor is
+ * ~1/10000 of the head's), but any overflow at all makes text-overflow:
+ * ellipsis drop whole characters to fit the "…" — the characters this span
+ * exists to preserve. Clipping instead loses only that invisible sliver.
+ */
+export const StyledTitleTail = styled.span`
+  flex: 0 1 auto;
+  overflow: hidden;
+  white-space: pre;
+  min-width: 0;
 `;

--- a/packages/client/src/components/basic/Box/Box.tsx
+++ b/packages/client/src/components/basic/Box/Box.tsx
@@ -30,6 +30,12 @@ interface Box {
   headerComponent?: ReactNode;
   buttons?: ReactNode[];
   children?: ReactNode;
+  /**
+   * When false, the box label never shrinks — header content and buttons yield
+   * instead. Default true: the label cedes space (some boxes need the header
+   * buttons to win over the caption at narrow widths).
+   */
+  shrinkLabel?: boolean;
   onHeaderClick?: () => void;
   disableHeaderClick?: boolean;
   disableScroll?: boolean;
@@ -46,6 +52,7 @@ export const Box: React.FC<Box> = ({
   headerComponent,
   buttons,
   children,
+  shrinkLabel = true,
   onHeaderClick,
   disableHeaderClick = false,
   disableScroll = false,
@@ -84,7 +91,11 @@ export const Box: React.FC<Box> = ({
         $hasHeaderClick={onHeaderClick !== undefined && !disableHeaderClick && isExpanded}
         onClick={() => !disableHeaderClick && onHeaderClick && onHeaderClick()}
       >
-        {!hideContent && isExpanded && <StyledLabel style={animatedExpand}>{label}</StyledLabel>}
+        {!hideContent && isExpanded && (
+          <StyledLabel $shrinkLabel={shrinkLabel} style={animatedExpand}>
+            {label}
+          </StyledLabel>
+        )}
         {/* Follows the label rather than the buttons: a collapsed box is a
             narrow strip with room for its controls, not for content about what
             it holds. */}

--- a/packages/client/src/components/basic/Box/BoxStyles.tsx
+++ b/packages/client/src/components/basic/Box/BoxStyles.tsx
@@ -64,10 +64,18 @@ export const StyledHead = styled.div<StyledHead>`
     $noFrame || !$isExpanded ? theme.borderWidth[1] : theme.borderWidth[4]};
   cursor: ${({ $hasHeaderClick }) => ($hasHeaderClick ? "pointer" : "")};
 `;
-export const StyledLabel = styled(animated.div)`
+interface StyledLabel {
+  $shrinkLabel: boolean;
+}
+/**
+ * A shrinkable label cedes its space to the header content and buttons (some
+ * boxes need the buttons to win over the caption); a protected one always
+ * shows the full caption and the content yields instead.
+ */
+export const StyledLabel = styled(animated.div)<StyledLabel>`
   display: block;
-  min-width: 0;
-  flex-shrink: 1;
+  min-width: ${({ $shrinkLabel }) => ($shrinkLabel ? "0" : "fit-content")};
+  flex-shrink: ${({ $shrinkLabel }) => ($shrinkLabel ? 1 : 0)};
   white-space: nowrap;
   overflow: hidden !important;
   text-overflow: ellipsis;
@@ -82,6 +90,10 @@ export const StyledHeaderComponentWrap = styled.div<StyledHeaderComponentWrap>`
   align-items: center;
   width: ${({ $isExpanded }) => ($isExpanded ? "auto" : "100%")};
   flex-grow: ${({ $flexGrow }) => ($flexGrow ? 1 : 0)};
+  /* The growing wrap holds ellipsizing content, which needs permission to
+     shrink below its natural width; the buttons wrap keeps min-width: auto so
+     the buttons are never crushed. */
+  min-width: ${({ $flexGrow }) => ($flexGrow ? "0" : "auto")};
 `;
 interface StyledContent {
   $noFrame: boolean;

--- a/packages/client/src/pages/Main/MainPage.tsx
+++ b/packages/client/src/pages/Main/MainPage.tsx
@@ -761,6 +761,9 @@ const MainPage: React.FC<MainPage> = ({}) => {
           heightVarKey="annotator"
           label="Annotator"
           headerComponent={annotatorHeader}
+          // Document identity fills the free header space; the caption and the
+          // panel button stay visible, so the header content yields, not them.
+          shrinkLabel={false}
           isExpanded={thirdPanelExpanded}
           buttons={[thirdPanelButton()]}
         >

--- a/packages/client/src/pages/Main/containers/AnnotatorBox/AnnotatorBoxStyles.tsx
+++ b/packages/client/src/pages/Main/containers/AnnotatorBox/AnnotatorBoxStyles.tsx
@@ -68,23 +68,24 @@ export const StyledInfoText = styled.div`
 `;
 
 /**
- * The resource tag holds a fixed width so the title is the only item that
- * shrinks — StyledLabel in the Box header already ellipsises, and the resource
- * identity matters more than the last characters of the title.
+ * Resource tag and title size to their content when the header has room (no
+ * cap — a wide box shows the full labels) and shrink when it doesn't. The
+ * resource floor is high because resource identity matters more than the last
+ * characters of the title; the Box label is protected separately
+ * (shrinkLabel={false} on the Annotator Box), so neither can cover it.
  */
 export const StyledAnnotatorHeaderResource = styled.div`
   display: flex;
-  flex-shrink: 0;
-  max-width: 11.5rem;
+  flex-shrink: 1;
+  min-width: 11.5rem;
 `;
 
-/** The one item that yields when the header runs out of room. */
+/** The item that yields furthest when the header runs out of room. */
 export const StyledAnnotatorHeaderTitle = styled.div`
   display: flex;
   align-items: center;
   flex-shrink: 1;
   min-width: 2rem;
-  max-width: 16rem;
   overflow: hidden;
 `;
 

--- a/packages/client/src/pages/Main/containers/AnnotatorBox/AnnotatorBoxStyles.tsx
+++ b/packages/client/src/pages/Main/containers/AnnotatorBox/AnnotatorBoxStyles.tsx
@@ -69,18 +69,22 @@ export const StyledInfoText = styled.div`
 
 /**
  * Resource tag and title size to their content when the header has room (no
- * cap — a wide box shows the full labels) and shrink when it doesn't. The
- * resource floor is high because resource identity matters more than the last
- * characters of the title; the Box label is protected separately
- * (shrinkLabel={false} on the Annotator Box), so neither can cover it.
+ * cap — a wide box shows the full labels) and shrink when it doesn't. The Box
+ * label is protected separately (shrinkLabel={false} on the Annotator Box), so
+ * neither can cover it.
+ *
+ * The resource's high flex-shrink makes it yield ahead of the title; flex
+ * would otherwise shrink both proportionally and the min-width would never be
+ * reached. In practice the tag bottoms out at its fixed parts (class chip +
+ * export/unlink buttons + a couple of label chars), above this floor.
  */
 export const StyledAnnotatorHeaderResource = styled.div`
   display: flex;
-  flex-shrink: 1;
-  min-width: 11.5rem;
+  flex-shrink: 3;
+  min-width: 9rem;
 `;
 
-/** The item that yields furthest when the header runs out of room. */
+/** Shrinks last, but yields furthest once the resource has bottomed out. */
 export const StyledAnnotatorHeaderTitle = styled.div`
   display: flex;
   align-items: center;


### PR DESCRIPTION
Goal is to improve (not only) typing performance in large documents.

- prepareSegments reuses old Segment objects for the longest matching head/tail around an edit and only re-parses the changed middle; reused segments and their tags are restamped to the new segmentIndex.
- calculateLines skips rewrapping a segment whose cached inputs (text, parsed, mode, width budget, paragraph indent, measurer) still match, only renumbering its line range.
- fix deleteCharacter to remove the character on the correct side for forward vs backward deletes and guard against document-edge indices.
- add wrapMemoization tests covering segment reuse by identity and every input that must invalidate the cache.

## Benchmark

Synthetic 200k-word document: 1.4 MB of text, 4 000 paragraphs, ~16 000 visual
lines at a monospace wrap budget of 100 chars. Measured on the `Text` layer
directly (no canvas, no draw) with jest — median of 20–30 runs per operation
after 3 warmups. Baseline is `dev` (full re-wrap of every paragraph on each
edit); the memoized column additionally carries the paragraph first-line
indent (#2076) enabled, so the comparison is conservative.

| Operation                        | dev (full re-wrap) | memoized | Speedup |
| -------------------------------- | -----------------: | -------: | ------: |
| Type 1 char mid-document         |            27.2 ms |  0.19 ms |    140× |
| Backspace (`deleteRangeText`)    |            30.2 ms |  0.42 ms |     73× |
| Paste two paragraphs             |            61.6 ms |  0.82 ms |     75× |
| `calculateLines`, nothing changed |           28.1 ms |  0.05 ms |    570× |

A keystroke previously re-tokenized and re-wrapped all 4 000 paragraphs; it
now re-wraps only the edited one. The remaining cost is the document string
splice, the head/tail segment-reuse scan and the line renumbering — all linear
in document size with tiny constants, so the win grows with document size.

Additionally some visual and UX improvements.